### PR TITLE
[REEF-38] Updates according to Apache RAT output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,5 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
 REEF
-===== 
+==== 
 
 REEF is the Retainable Evaluator Execution Framework. It makes it easier to write applications on top of resource managers (e.g. YARN). It is released under the Apache 2.0 license. To get started, there is a [Tutorial](https://github.com/Microsoft-CISL/REEF/wiki/How-to-download-and-compile-REEF). We also have a [website](http://www.reef-project.org/)
 

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,9 @@ under the License.
                             <exclude>.git/**</exclude>
                             <exclude>.idea/**</exclude>
                             <exclude>target/**</exclude>
+                            <exclude>README.*</exclude>
+                            <!-- The below are sometimes created during tests -->
+                            <exclude>REEF_LOCAL_RUNTIME/**</exclude>
                         </excludes>
                     </configuration>
                 </plugin>

--- a/reef-bridge-project/reef-bridge-clr/pom.xml
+++ b/reef-bridge-project/reef-bridge-clr/pom.xml
@@ -69,6 +69,24 @@ under the License.
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <!-- Build files are frequently overwritten by Visual Studio -->
+                        <exclude>src/main/Cpp/CppBridge/JavaClrBridge/JavaClrBridge.sln</exclude>
+                        <exclude>src/main/Cpp/CppBridge/JavaClrBridge/JavaClrBridge.vcxproj</exclude>
+                        <exclude>src/main/Cpp/CppBridge/JavaClrBridge/JavaClrBridge.vcxproj.filters</exclude>
+                        <exclude>src/main/CSharp/CSharp/ClrHandler/ClrHandler.csproj</exclude>
+                        <!--End of Visual Studio build files-->
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>Bridge</id>

--- a/reef-tang/pom.xml
+++ b/reef-tang/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/reef-tang/tang/pom.xml
+++ b/reef-tang/tang/pom.xml
@@ -98,6 +98,18 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <!-- The following binary files are generated from the sources and shouldn't be checked -->
+                        <exclude>src/test/resources/Event.bin</exclude>
+                        <exclude>src/test/resources/Task.bin</exclude>
+
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/reef-tang/tang/src/main/proto/class_hierarchy.proto
+++ b/reef-tang/tang/src/main/proto/class_hierarchy.proto
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 option java_package = "org.apache.reef.tang.proto";
 option java_outer_classname = "ClassHierarchyProto";
 //option java_generic_services = true;

--- a/reef-tang/tang/src/main/proto/injection_plan.proto
+++ b/reef-tang/tang/src/main/proto/injection_plan.proto
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 option java_package = "org.apache.reef.tang.proto";
 option java_outer_classname = "InjectionPlanProto";
 //option java_generic_services = true;


### PR DESCRIPTION
This updates the code base such that a `mvn apache-rat` passes as per [REEF-38](https://issues.apache.org/jira/browse/REEF-38) To achieve this, the following files have been updated with license headers:
- Tang protocol buffers schema files.
- Tang POM files

The following files and folders have been marked as exclusions from Apache RAT:
- README.\* (this also removes the now unneeded license headers from them)
- The .bin files in Tang's tests. Those are generated from the C# code base at Microsoft and are given to the ASF as a contribution.  They won't be needed anymore once we have moved the .NET code base to the ASF as well.
- REEF_LOCAL_RUNTIME and its subfolders. This directory is sometimes created during the tests. It is not actually part of a release, but excluding it and the potentially thousands of files inside speeds up Apache RAT quite a bit.
- Visual Studio project files. These are frequently overwritten, making a license header requirement quite cumbersome to support.
