### PR TITLE
[REEF-45]: Use consistent STDOUT and STDERR file names in the local runtime

### DIFF
--- a/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
+++ b/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
@@ -149,7 +149,11 @@ final class LocalJobSubmissionHandler implements JobSubmissionHandler {
         }
 
         final RunnableProcess process = new RunnableProcess(command,
-            "driver", driverFolder, new LoggingRunnableProcessObserver());
+            "driver",
+            driverFolder,
+            new LoggingRunnableProcessObserver(),
+            this.filenames.getDriverStdoutFileName(),
+            this.filenames.getDriverStderrFileName());
         this.executor.submit(process);
         this.executor.shutdown();
 

--- a/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ProcessContainer.java
+++ b/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ProcessContainer.java
@@ -108,7 +108,7 @@ final class ProcessContainer implements Container {
   }
 
   @Override
-  public void addGlobalFiles(File globalFolder) {
+  public void addGlobalFiles(final File globalFolder) {
     try {
       copy(Arrays.asList(globalFolder.listFiles()), this.globalFolder);
     } catch (final IOException e) {
@@ -118,7 +118,12 @@ final class ProcessContainer implements Container {
 
   @Override
   public void run(final List<String> commandLine) {
-    this.process = new RunnableProcess(commandLine, this.containedID, this.folder, this.processObserver);
+    this.process = new RunnableProcess(commandLine,
+        this.containedID,
+        this.folder,
+        this.processObserver,
+        this.fileNames.getEvaluatorStdoutFileName(),
+        this.fileNames.getEvaluatorStderrFileName());
     this.theThread = new Thread(this.process);
     this.theThread.start();
   }

--- a/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcess.java
+++ b/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcess.java
@@ -47,11 +47,11 @@ public final class RunnableProcess implements Runnable {
   /**
    * Name of the file used for STDERR redirection.
    */
-  private static final String STD_ERROR_FILE_NAME = "STDERR.txt";
+  private final String standardErrorFileName;
   /**
    * Name of the file used for STDOUT redirection.
    */
-  private static final String STD_OUT_FILE_NAME = "STDOUT.txt";
+  private final String standardOutFileName;
 
   /**
    * Command to execute.
@@ -84,21 +84,27 @@ public final class RunnableProcess implements Runnable {
   private State state = State.INIT;   // synchronized on stateLock
 
   /**
-   * @param command         the command to execute.
-   * @param id              The ID of the process. This is used to name files and in the logs created by this process.
-   * @param folder          The folder in which this will store its stdout and stderr output
-   * @param processObserver will be informed of process state changes.
+   * @param command               the command to execute.
+   * @param id                    The ID of the process. This is used to name files and in the logs created by this process.
+   * @param folder                The folder in which this will store its stdout and stderr output
+   * @param processObserver       will be informed of process state changes.
+   * @param standardOutFileName   The name of the file used for redirecting STDOUT
+   * @param standardErrorFileName The name of the file used for redirecting STDERR
    */
   public RunnableProcess(final List<String> command,
                          final String id,
                          final File folder,
-                         final RunnableProcessObserver processObserver) {
+                         final RunnableProcessObserver processObserver,
+                         final String standardOutFileName,
+                         final String standardErrorFileName) {
     this.processObserver = processObserver;
     this.command = new ArrayList<>(command);
     this.id = id;
     this.folder = folder;
     assert (this.folder.isDirectory());
     this.folder.mkdirs();
+    this.standardOutFileName = standardOutFileName;
+    this.standardErrorFileName = standardErrorFileName;
     LOG.log(Level.FINEST, "RunnableProcess ready.");
   }
 
@@ -148,8 +154,8 @@ public final class RunnableProcess implements Runnable {
       }
 
       // Setup the stdout and stderr destinations.
-      final File errFile = new File(folder, STD_ERROR_FILE_NAME);
-      final File outFile = new File(folder, STD_OUT_FILE_NAME);
+      final File errFile = new File(folder, standardErrorFileName);
+      final File outFile = new File(folder, standardOutFileName);
 
       // Launch the process
       try {


### PR DESCRIPTION
This updates the local runtime to use the correct file names for STDOUT and STDERR redirection as provided by the REEFFileNames class.

JIRA:
  [REEF-45] https://issues.apache.org/jira/browse/REEF-45
