### PR TITLE
Remove duplicated binding of ManagerName

### DIFF
--- a/reef-common/src/main/java/org/apache/reef/client/ClientConfiguration.java
+++ b/reef-common/src/main/java/org/apache/reef/client/ClientConfiguration.java
@@ -79,6 +79,5 @@ public final class ClientConfiguration extends ConfigurationModuleBuilder {
       .bind(ResourceManagerErrorHandler.class, ON_RUNTIME_ERROR)
       .bindNamedParameter(ClientPresent.class, ClientPresent.YES)
       .bindNamedParameter(RemoteConfiguration.ErrorHandler.class, ON_WAKE_ERROR)
-      .bindNamedParameter(RemoteConfiguration.ManagerName.class, "REEF_CLIENT")
       .build();
 }

--- a/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
+++ b/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
@@ -28,7 +28,7 @@ import org.apache.reef.wake.remote.impl.ObjectSerializableCodec;
  */
 public final class RemoteConfiguration {
 
-  @NamedParameter(short_name = "rm_name", doc = "The name of the remote manager.")
+  @NamedParameter(short_name = "rm_name", doc = "The name of the remote manager.", default_value = "REEF_CLIENT")
   public static final class ManagerName implements Name<String> {
     // Intentionally empty
   }


### PR DESCRIPTION
[REEF-36](https://issues.apache.org/jira/browse/REEF-36). Currently RemoteConfiguration.ManagerName can be bound in either Client or Launcher, for submission path that generates a static driver.config and then submit job remotely through REST api, it will cause duplicated binding. This removes the bidding in client and add a default value to be safe.
