### PR TITLE
[REEF-56]: Removed the shaded and test jar creation in reef-tests

### DIFF
--- a/reef-tests/pom.xml
+++ b/reef-tests/pom.xml
@@ -74,17 +74,6 @@ under the License.
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptors>
@@ -99,37 +88,6 @@ under the License.
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-
-                    <outputFile>
-                        ${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar
-                    </outputFile>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>yarn-default.xml</exclude>
-                                <exclude>yarn-version-info.properties</exclude>
-                                <exclude>core-default.xml</exclude>
-                                <exclude>LICENSE</exclude>
-                                <exclude>META-INF/*</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The prior addition of the `-test-jar-with-dependencies` replaces both of them. Hence, their creation has become redundant

JIRA:
   [REEF-56](https://issues.apache.org/jira/browse/REEF-56)
