### PR TITLE
[REEF-72]: Make DriverIdentifier optional

### DIFF
--- a/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
+++ b/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
@@ -49,7 +49,7 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
   /**
    * Identifies the driver and therefore the JOB. Expect to see this e.g. on YARN's dashboard.
    */
-  public static final RequiredParameter<String> DRIVER_IDENTIFIER = new RequiredParameter<>();
+  public static final OptionalParameter<String> DRIVER_IDENTIFIER = new OptionalParameter<>();
 
   /**
    * The amount of memory to be allocated for the Driver. This is the size of the AM container in YARN.

--- a/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverIdentifier.java
+++ b/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverIdentifier.java
@@ -24,8 +24,12 @@ import org.apache.reef.tang.annotations.NamedParameter;
 /**
  * Driver Identifier
  */
-@NamedParameter(doc = "Driver Identifier", default_value = "Unnamed REEF Job")
+@NamedParameter(doc = "Driver Identifier", default_value = DriverIdentifier.DEFAULT_VALUE)
 public final class DriverIdentifier implements Name<String> {
+
   private DriverIdentifier() {
   }
+
+  public static final String DEFAULT_VALUE = "##NONE##DEFAULT##NEVERUSE##";
+
 }


### PR DESCRIPTION
This makes the DriverIdentifier optional. If it isn't set, we generate a unique one in JobSubmissionHelper.
