### PR TITLE
[REEF-75] Removed double quotes from the constructed local runtime Java classpath.

### DIFF
--- a/reef-common/src/main/java/org/apache/reef/runtime/common/launch/JavaLaunchCommandBuilder.java
+++ b/reef-common/src/main/java/org/apache/reef/runtime/common/launch/JavaLaunchCommandBuilder.java
@@ -145,7 +145,7 @@ public final class JavaLaunchCommandBuilder implements LaunchCommandBuilder {
   }
 
   public JavaLaunchCommandBuilder setClassPath(final Collection<String> classPathElements) {
-    this.classPath = "\"" + StringUtils.join(classPathElements, File.pathSeparatorChar) + "\"";
+    this.classPath = StringUtils.join(classPathElements, File.pathSeparatorChar);
     return this;
   }
 


### PR DESCRIPTION
The double quotes caused difficulty when parsing the classpath via LocalClasspathProvider.

JIRA: [REEF-75]: https://issues.apache.org/jira/browse/REEF-75
