### PR TITLE
[REEF-925] IDataReader and IdataWriter in Wake.Remote should expose t…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Wake/Remote/IDataReader.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/IDataReader.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -143,5 +144,12 @@ namespace Org.Apache.REEF.Wake.Remote
         /// <returns>Task handler that reads bytes and returns that number of bytes read 
         /// if success, otherwise -1</returns>
         Task<int> ReadAsync(byte[] buffer, int index, int bytesToRead, CancellationToken token);
+
+        /// <summary>
+        /// Gets underlying stream. Throws null exception if 
+        /// stream is null or not available
+        /// </summary>
+        /// <returns>The underlying stream</returns>
+        Stream GetStream();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/IDataWriter.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/IDataWriter.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -146,5 +147,12 @@ namespace Org.Apache.REEF.Wake.Remote
         /// <param name="token">Cancellation token</param>
         /// <returns>the handler to the task</returns>
         Task WriteAsync(byte[] buffer, int index, int count, CancellationToken token);
+
+        /// <summary>
+        /// Gets underlying stream. Throws null exception if 
+        /// stream is null or not available
+        /// </summary>
+        /// <returns>The underlying stream</returns>
+        Stream GetStream();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataReader.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataReader.cs
@@ -351,5 +351,19 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
 
             return bytesToRead;
         }
+
+        /// <summary>
+        /// Gets underlying stream. Throws null exception if 
+        /// stream is null or not available
+        /// </summary>
+        /// <returns>The underlying stream</returns>
+        public Stream GetStream()
+        {
+            if (_stream == null)
+            {
+                Exceptions.Throw(new NullReferenceException("Stream is null or not available"), Logger);
+            }
+            return _stream;
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataWriter.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataWriter.cs
@@ -21,11 +21,15 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Org.Apache.REEF.Utilities.Diagnostics;
+using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Wake.Remote.Impl
 {
     public class StreamDataWriter : IDataWriter
     {
+        Logger Logger = Logger.GetLogger(typeof(StreamDataWriter));
+
          /// <summary>
         /// Stream to which to write
         /// </summary>
@@ -215,6 +219,20 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         public async Task WriteAsync(byte[] buffer, int index, int count, CancellationToken token)
         {
             await _stream.WriteAsync(buffer, index, count, token);
+        }
+
+        /// <summary>
+        /// Gets underlying stream. Throws null exception if 
+        /// stream is null or not available
+        /// </summary>
+        /// <returns>The underlying stream</returns>
+        public Stream GetStream()
+        {
+            if (_stream == null)
+            {
+                Exceptions.Throw(new NullReferenceException("Stream is null or not available"), Logger);
+            }
+            return _stream;
         }
     }
 }


### PR DESCRIPTION
…he underlying stream

This addressed the issue by

  * introducing GetStream() function in IDataReader, IDataWriter, StreamDataReader and StreamDataWriter in Wake.Remote

JIRA:

  [REEF-925](https://issues.apache.org/jira/browse/REEF-925)