### PR TITLE
[REEF-991] Remove deprecated RangeTcpPortProvider.Default and DefaultRemoteManagerImplementation constructor

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultRemoteManagerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultRemoteManagerFactory.java
@@ -16,16 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.wake.remote.impl;
+package org.apache.reef.wake.remote;
 
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.remote.Codec;
-import org.apache.reef.wake.remote.RemoteConfiguration;
-import org.apache.reef.wake.remote.RemoteManager;
-import org.apache.reef.wake.remote.RemoteManagerFactory;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
 import org.apache.reef.wake.remote.ports.TcpPortProvider;
 import org.apache.reef.wake.remote.transport.TransportFactory;
@@ -35,7 +31,7 @@ import javax.inject.Inject;
 /**
  * Default implementation of RemoteManagerFactory.
  */
-public final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
+final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
 
   private final Injector injector;
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultRemoteManagerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultRemoteManagerFactory.java
@@ -55,7 +55,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
       final TransportFactory tpFactory,
       final TcpPortProvider tcpPortProvider,
       final Injector injector) {
-    this.injector = injector;
+    this.injector = injector.forkInjector();
     this.codec = codec;
     this.errorHandler = errorHandler;
     this.orderingGuarantee = orderingGuarantee;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManagerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManagerFactory.java
@@ -21,7 +21,6 @@ package org.apache.reef.wake.remote;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
-import org.apache.reef.wake.remote.impl.DefaultRemoteManagerFactory;
 import org.apache.reef.wake.remote.ports.TcpPortProvider;
 
 /**

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
@@ -24,7 +24,6 @@ import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.impl.StageManager;
 import org.apache.reef.wake.remote.*;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
-import org.apache.reef.wake.remote.ports.RangeTcpPortProvider;
 import org.apache.reef.wake.remote.ports.TcpPortProvider;
 import org.apache.reef.wake.remote.transport.Transport;
 import org.apache.reef.wake.remote.transport.TransportFactory;
@@ -43,7 +42,7 @@ import java.util.logging.Logger;
 /**
  * Default remote manager implementation.
  */
-public class DefaultRemoteManagerImplementation implements RemoteManager {
+public final class DefaultRemoteManagerImplementation implements RemoteManager {
 
   private static final Logger LOG = Logger.getLogger(HandlerContainer.class.getName());
 
@@ -66,28 +65,8 @@ public class DefaultRemoteManagerImplementation implements RemoteManager {
    */
   public static final String UNKNOWN_HOST_NAME = NettyMessagingTransport.UNKNOWN_HOST_NAME;
 
-  /**
-   * @deprecated have an instance injected instead.
-   */
-  @Deprecated
   @Inject
-  public <T> DefaultRemoteManagerImplementation(
-      @Parameter(RemoteConfiguration.ManagerName.class) final String name,
-      @Parameter(RemoteConfiguration.HostAddress.class) final String hostAddress,
-      @Parameter(RemoteConfiguration.Port.class) final int listeningPort,
-      @Parameter(RemoteConfiguration.MessageCodec.class) final Codec<T> codec,
-      @Parameter(RemoteConfiguration.ErrorHandler.class) final EventHandler<Throwable> errorHandler,
-      @Parameter(RemoteConfiguration.OrderingGuarantee.class) final boolean orderingGuarantee,
-      @Parameter(RemoteConfiguration.NumberOfTries.class) final int numberOfTries,
-      @Parameter(RemoteConfiguration.RetryTimeout.class) final int retryTimeout,
-      final LocalAddressProvider localAddressProvider,
-      final TransportFactory tpFactory) {
-      this(name, hostAddress, listeningPort, codec, errorHandler, orderingGuarantee, numberOfTries, retryTimeout,
-              localAddressProvider, tpFactory, RangeTcpPortProvider.Default);
-  }
-
-  @Inject
-    private <T> DefaultRemoteManagerImplementation(
+  private <T> DefaultRemoteManagerImplementation(
             @Parameter(RemoteConfiguration.ManagerName.class) final String name,
             @Parameter(RemoteConfiguration.HostAddress.class) final String hostAddress,
             @Parameter(RemoteConfiguration.Port.class) final int listeningPort,

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RangeTcpPortProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RangeTcpPortProvider.java
@@ -58,16 +58,6 @@ public final class RangeTcpPortProvider implements TcpPortProvider {
     return new RandomRangeIterator(portRangeBegin, portRangeCount, portRangeTryCount);
   }
 
-  /**
-   * @deprecated in 0.12 have an instance injected instead.
-   */
-  @Deprecated
-  @SuppressWarnings("checkstyle:constantname")
-  public static final RangeTcpPortProvider Default = new RangeTcpPortProvider(
-      Integer.parseInt(TcpPortRangeBegin.DEFAULT_VALUE),
-      Integer.parseInt(TcpPortRangeCount.DEFAULT_VALUE),
-      Integer.parseInt(TcpPortRangeTryCount.DEFAULT_VALUE));
-
   @Override
   public String toString() {
     return "RangeTcpPortProvider{" +

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
@@ -81,15 +81,19 @@ public class MessagingTransportFactory implements TransportFactory {
     }
   }
 
-  // TODO[REEF-547]: This method uses deprecated RangeTcpPortProvider.Default. Must remove usages and deprecate.
   @Override
   public Transport newInstance(final String hostAddress, final int port,
                                final EStage<TransportEvent> clientStage,
                                final EStage<TransportEvent> serverStage,
                                final int numberOfTries,
                                final int retryTimeout) {
-    return newInstance(hostAddress, port, clientStage,
-        serverStage, numberOfTries, retryTimeout, RangeTcpPortProvider.Default);
+    try {
+      TcpPortProvider tcpPortProvider = Tang.Factory.getTang().newInjector().getInstance(RangeTcpPortProvider.class);
+      return newInstance(hostAddress, port, clientStage,
+              serverStage, numberOfTries, retryTimeout, tcpPortProvider);
+    } catch (final InjectionException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
@@ -27,7 +27,6 @@ import org.apache.reef.wake.impl.SyncStage;
 import org.apache.reef.wake.remote.RemoteConfiguration;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
 import org.apache.reef.wake.remote.impl.TransportEvent;
-import org.apache.reef.wake.remote.ports.RangeTcpPortProvider;
 import org.apache.reef.wake.remote.ports.TcpPortProvider;
 import org.apache.reef.wake.remote.transport.Transport;
 import org.apache.reef.wake.remote.transport.TransportFactory;
@@ -81,14 +80,25 @@ public class MessagingTransportFactory implements TransportFactory {
     }
   }
 
+  /**
+   * Creates a transport.
+   *
+   * @param hostAddress   a host address
+   * @param port          a listening port
+   * @param clientStage   a client stage
+   * @param serverStage   a server stage
+   * @param numberOfTries a number of tries
+   * @param retryTimeout  a timeout for retry
+   */
   @Override
-  public Transport newInstance(final String hostAddress, final int port,
+  public Transport newInstance(final String hostAddress,
+                               final int port,
                                final EStage<TransportEvent> clientStage,
                                final EStage<TransportEvent> serverStage,
                                final int numberOfTries,
                                final int retryTimeout) {
     try {
-      TcpPortProvider tcpPortProvider = Tang.Factory.getTang().newInjector().getInstance(RangeTcpPortProvider.class);
+      TcpPortProvider tcpPortProvider = Tang.Factory.getTang().newInjector().getInstance(TcpPortProvider.class);
       return newInstance(hostAddress, port, clientStage,
               serverStage, numberOfTries, retryTimeout, tcpPortProvider);
     } catch (final InjectionException e) {
@@ -96,8 +106,20 @@ public class MessagingTransportFactory implements TransportFactory {
     }
   }
 
+  /**
+   * Creates a transport.
+   *
+   * @param hostAddress     a host address
+   * @param port            a listening port
+   * @param clientStage     a client stage
+   * @param serverStage     a server stage
+   * @param numberOfTries   a number of tries
+   * @param retryTimeout    a timeout for retry
+   * @param tcpPortProvider a provider for TCP port
+   */
   @Override
-  public Transport newInstance(final String hostAddress, final int port,
+  public Transport newInstance(final String hostAddress,
+                               final int port,
                                final EStage<TransportEvent> clientStage,
                                final EStage<TransportEvent> serverStage,
                                final int numberOfTries,


### PR DESCRIPTION
JIRA:
  [REEF-991](https://issues.apache.org/jira/browse/REEF-991)

Pull request:
  This closes #