### PR TITLE
[REEF-1002] Add Vortex examples that cause large serialization cost

### DIFF
--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMul.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMul.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.examples.matmul;
+
+import org.apache.reef.vortex.driver.VortexLauncher;
+
+/**
+ * User's main function.
+ */
+final class MatMul {
+  private MatMul() {
+  }
+
+  /**
+   * Launch the vortex job, passing appropriate arguments.
+   */
+  public static void main(final String[] args) {
+    VortexLauncher.launchLocal("Vortex_Example_MatMul", MatMulStart.class, 2, 1024, 4, 2000);
+  }
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMul.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMul.java
@@ -31,6 +31,6 @@ final class MatMul {
    * Launch the vortex job, passing appropriate arguments.
    */
   public static void main(final String[] args) {
-    VortexLauncher.launchLocal("Vortex_Example_MatMul", MatMulStart.class, 2, 1024, 4, 2000);
+    VortexLauncher.launchLocal("Vortex_Example_MatMul", IdentityMatMulStart.class, 2, 1024, 4, 2000);
   }
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMulException.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMulException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.examples.matmul;
+
+/**
+ * Exception used in the MatMul example.
+ */
+class MatMulException extends Exception {
+  /**
+   * Constructor of MatMulException.
+   * @param message Message to inform users.
+   */
+  MatMulException(final String message) {
+    super(message);
+  }
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMulFunction.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMulFunction.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.examples.matmul;
+
+import org.apache.reef.vortex.api.VortexFunction;
+
+/**
+ * Computes multiplication of two matrices.
+ */
+final class MatMulFunction implements VortexFunction<MatMulInput, MatMulOutput> {
+  /**
+   * Computes multiplication of two matrices.
+   * @param input Input which contains two matrices to multiply,
+   *              and index of the sub-matrix in the entire result.
+   * @return Output which contains the sub-matrix and index of it in the entire result.
+   * @throws Exception If the two matrices cannot be multiplied.
+   */
+  @Override
+  public MatMulOutput call(final MatMulInput input) throws Exception {
+    final int index = input.getIndex();
+    final Matrix<Double> leftMatrix = input.getLeftMatrix();
+    final Matrix<Double> rightMatrix = input.getRightMatrix();
+    final Matrix<Double> result = leftMatrix.multiply(rightMatrix);
+    return new MatMulOutput(index, result);
+  }
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMulInput.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMulInput.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.examples.matmul;
+
+import java.io.Serializable;
+
+/**
+ * Input of {@link MatMulFunction} which contains two matrices to multiply,
+ * and index of the sub-matrix in the entire result.
+ */
+class MatMulInput implements Serializable {
+  private final int index;
+  private final Matrix<Double> leftMatrix;
+  private final Matrix<Double> rightMatrix;
+
+  /**
+   * Constructor of MatMulInput which consists of two matrices.
+   * @param index Index of the resulting sub-matrix in the entire matrix.
+   * @param leftMatrix Matrix to multiply on the left side.
+   * @param rightMatrix Matrix to multiply on the right side.
+   */
+  MatMulInput(final int index, final Matrix<Double> leftMatrix, final Matrix<Double> rightMatrix) {
+    this.index = index;
+    this.leftMatrix = leftMatrix;
+    this.rightMatrix = rightMatrix;
+  }
+
+  /**
+   * @return Index of the resulting sub-matrix in the entire matrix.
+   */
+  int getIndex() {
+    return index;
+  }
+
+  /**
+   * @return Matrix to multiply on the left side.
+   */
+  Matrix<Double> getLeftMatrix() {
+    return leftMatrix;
+  }
+
+  /**
+   * @return Matrix to multiply on the right side.
+   */
+  Matrix<Double> getRightMatrix() {
+    return rightMatrix;
+  }
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMulOutput.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMulOutput.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.examples.matmul;
+
+import java.io.Serializable;
+
+/**
+ * Output of {@link MatMulFunction} which contains the sub-matrix and index of it in the entire result.
+ */
+class MatMulOutput implements Serializable {
+  private final int index;
+  private final Matrix<Double> result;
+
+  /**
+   * Constructor of the output.
+   * @param index Index of the sub-matrix in the entire result.
+   * @param result Result of multiplication (sub-matrix).
+   */
+  MatMulOutput(final int index, final Matrix<Double> result) {
+    this.index = index;
+    this.result = result;
+  }
+
+  /**
+   * @return Index of the sub-matrix in the entire matrix.
+   */
+  int getIndex() {
+    return index;
+  }
+
+  /**
+   * @return Result of multiplication (sub-matrix).
+   */
+  Matrix<Double> getResult() {
+    return result;
+  }
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMulStart.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/MatMulStart.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.examples.matmul;
+
+import org.apache.reef.vortex.api.VortexStart;
+import org.apache.reef.vortex.api.VortexThreadPool;
+import org.apache.reef.wake.EventHandler;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.Vector;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * MatMul User Code Example.
+ * This example multiplies two matrices by distributing computation to multiple Tasklets.
+ * Each Tasklet receives split of the matrix on the left side, and copy of the matrix on the right side.
+ * To check whether the results are correct, Identity matrix is used for the matrix on the right side.
+ */
+final class MatMulStart implements VortexStart {
+  private static final Logger LOG = Logger.getLogger(MatMulStart.class.getName());
+  private static final int DIVIDE_FACTOR = 10000;
+  private static final int NUM_ROWS = 100000;
+  private static final int NUM_COLUMNS = 10;
+
+  @Inject
+  private MatMulStart() {
+  }
+
+  /**
+   * Perform a simple vector multiplication on Vortex.
+   */
+  @Override
+  public void start(final VortexThreadPool vortexThreadPool) {
+
+    final Matrix<Double> left = generateRandomMatrix(NUM_ROWS, NUM_COLUMNS);
+    final List<Matrix<Double>> leftSplits = split(left, DIVIDE_FACTOR);
+    final Matrix<Double> right = generateIdentityMatrix(NUM_COLUMNS);
+
+    // Measure job finish time starting from here..
+    final double start = System.currentTimeMillis();
+
+    // Define callback that is invoked when Tasklets finish.
+    final CountDownLatch latch = new CountDownLatch(DIVIDE_FACTOR);
+    final EventHandler<MatMulOutput> callback = new EventHandler<MatMulOutput>() {
+      @Override
+      public void onNext(final MatMulOutput output) {
+        final int index = output.getIndex();
+        final Matrix<Double> result = output.getResult();
+        // Compare the result from the original matrix.
+        if (result.equals(leftSplits.get(index))) {
+          latch.countDown();
+        } else {
+          throw new RuntimeException(index + " th result is not correct.");
+        }
+      }
+    };
+
+    // Submit Tasklets and register callback.
+    final MatMulFunction matMulFunction = new MatMulFunction();
+    for (int i = 0; i < DIVIDE_FACTOR; i++) {
+      vortexThreadPool.submit(matMulFunction, new MatMulInput(i, leftSplits.get(i), right), callback);
+    }
+
+    try {
+      // Wait until all Tasklets finish.
+      latch.await();
+      LOG.log(Level.INFO, "Job Finish Time: " + (System.currentTimeMillis() - start));
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Generate a matrix with random values.
+   * @param numRows number of matrix's rows.
+   * @param numColumns number of matrix's columns.
+   * @return Matrix that consists of random values.
+   */
+  private Matrix<Double> generateRandomMatrix(final int numRows, final int numColumns) {
+    final List<Vector<Double>> vectors = new ArrayList<>(numRows);
+    final Random random = new Random();
+    for (int i = 0; i < numRows; i++) {
+      final Vector<Double> vector = new Vector<>();
+      for (int j = 0; j < numColumns; j++) {
+        vector.add(random.nextDouble());
+      }
+      vectors.add(vector);
+    }
+    return new RowMatrix(vectors);
+  }
+
+  /**
+   * Generate an identity matrix.
+   * @param numDimension number of rows and columns of the identity matrix.
+   * @return Identity matrix.
+   */
+  private Matrix<Double> generateIdentityMatrix(final int numDimension) {
+    final List<Vector<Double>> vectors = new ArrayList<>(numDimension);
+    for (int i = 0; i < numDimension; i++) {
+      final Vector<Double> vector = new Vector<>();
+      for (int j = 0; j < numDimension; j++) {
+        final double value = i == j ? 1 : 0;
+        vector.add(value);
+      }
+      vectors.add(vector);
+    }
+    return new RowMatrix(vectors);
+  }
+
+  /**
+   * Split a matrix into sub-matrices as many as {@param divideFactor}.
+   * Note that the matrix is split in row-wise, so the number of columns remain same while
+   * the number of rows is divided by {@param divideFactor}.
+   * @param matrix Matrix to Split.
+   * @param divideFactor Number of partitions to split the matrix into.
+   * @return List of matrices divided into multiple sub-matrices.
+   */
+  private List<Matrix<Double>> split(final Matrix<Double> matrix, final int divideFactor) {
+    final List<Matrix<Double>> result = new ArrayList<>(divideFactor);
+    final int totalNumRows = matrix.getNumRows();
+    final int splitNumRows = (totalNumRows + divideFactor - 1) / divideFactor;
+
+    int rowIndex = 0;
+    for (int i = 0; i < divideFactor; i++) {
+      final List<Vector<Double>> vectors = new ArrayList<>(splitNumRows);
+      // Fill each split, but terminate once there is no more data.
+      for (int j = 0; rowIndex < totalNumRows && j < splitNumRows; j++) {
+        vectors.add(matrix.getRows().get(rowIndex));
+        rowIndex++;
+      }
+      result.add(new RowMatrix(vectors));
+    }
+    return result;
+  }
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/Matrix.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/Matrix.java
@@ -20,7 +20,6 @@ package org.apache.reef.vortex.examples.matmul;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Vector;
 
 /**
  * Interface of serializable Matrix.
@@ -51,9 +50,11 @@ interface Matrix<T> extends Serializable {
   Matrix<T> transpose();
 
   /**
+   * Get the rows of the matrix. It is highly recommended to return {@link java.util.Collections.UnmodifiableList}
+   * for making the result immutable.
    * @return Rows of the matrix.
    */
-  List<Vector<T>> getRows();
+  List<List<T>> getRows();
 
   /**
    * @return Number of rows.

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/Matrix.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/Matrix.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.examples.matmul;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Vector;
+
+/**
+ * Interface of serializable Matrix.
+ * @param <T> Type of elements in Matrix.
+ */
+interface Matrix<T> extends Serializable {
+
+  /**
+   * Add another matrix. Note that dimensions of two matrices should be identical.
+   * @param matrix Another matrix to add.
+   * @return Result of adding two matrices.
+   * @throws MatMulException
+   */
+  Matrix<T> add(Matrix<T> matrix) throws MatMulException;
+
+  /**
+   * Multiply another matrix on the right. Note that the number of {@param matrix}'s columns
+   * should be equal to the number of this matrix's rows.
+   * @param matrix Another matrix to multiply.
+   * @return Result of multiplying two matrices.
+   */
+  Matrix<T> multiply(Matrix<T> matrix) throws MatMulException;
+
+  /**
+   * Get the transpose of the matrix.
+   * @return Result of transpose.
+   */
+  Matrix<T> transpose();
+
+  /**
+   * @return Rows of the matrix.
+   */
+  List<Vector<T>> getRows();
+
+  /**
+   * @return Number of rows.
+   */
+  int getNumRows();
+
+  /**
+   * @return Number of columns.
+   */
+  int getNumColumns();
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/RowMatrix.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/RowMatrix.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.examples.matmul;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+
+/**
+ * Row-oriented matrix implementation used in {@link MatMul} example.
+ */
+final class RowMatrix implements Matrix<Double> {
+  private final List<Vector<Double>> values;
+
+  /**
+   * Constructor of matrix which creates an empty matrix of size (numRow x numColumn).
+   * @param values Elements of Matrix.
+   */
+  RowMatrix(final List<Vector<Double>> values) {
+    this.values = values;
+  }
+
+  @Override
+  public Matrix<Double> add(final Matrix<Double> matrix) throws MatMulException {
+    if (this.getNumRows() != matrix.getNumRows() || this.getNumColumns() != matrix.getNumColumns()) {
+      throw new MatMulException("The dimension of two matrices should be same to add.");
+    }
+    final List<Vector<Double>> result = new ArrayList<>(getNumRows());
+    final Matrix<Double> transpose = transpose();
+    for (int i = 0; i < getNumRows(); i++) {
+      final Vector<Double> row1 = getRows().get(i);
+      final Vector<Double> row2 = transpose.getRows().get(i);
+      for (int j = 0; j < getNumColumns(); j++) {
+        result.get(i).add(row1.get(j) + row2.get(j));
+      }
+    }
+    return new RowMatrix(result);
+  }
+
+  @Override
+  public Matrix<Double> multiply(final Matrix<Double> matrix) throws MatMulException {
+    if (this.getNumRows() != matrix.getNumColumns()) {
+      throw new MatMulException("The number of columns of matrix to multiply should be same to the number of rows.");
+    }
+    final List<Vector<Double>> result = new ArrayList<>(getNumRows());
+    for (int i = 0; i < getNumRows(); i++) {
+      result.add(new Vector<Double>(matrix.getNumColumns()));
+    }
+
+    // result(i, j) = leftMatrix.row(i) * rightMatrix.col(j)
+    final Matrix<Double> transpose = matrix.transpose();
+    for (int i = 0; i < getNumRows(); i++) {
+      final Vector<Double> row = getRows().get(i);
+
+      for (int j = 0; j < getNumColumns(); j++) {
+        final Vector<Double> col = transpose.getRows().get(j);
+        result.get(i).add(dot(row, col));
+      }
+    }
+    return new RowMatrix(result);
+  }
+
+  @Override
+  public Matrix<Double> transpose() {
+    // Initialize empty vectors.
+    final ArrayList<Vector<Double>> transpose = new ArrayList<>(getNumColumns());
+    for (int i = 0; i < getNumRows(); i++) {
+      transpose.add(new Vector<Double>(getNumRows()));
+    }
+
+    // Each element in rows is added to corresponding column in transpose matrix.
+    for (final Vector<Double> row : getRows()) {
+      for (int i = 0; i < row.size(); i++) {
+        transpose.get(i).add(row.get(i));
+      }
+    }
+    return new RowMatrix(transpose);
+  }
+
+  @Override
+  public List<Vector<Double>> getRows() {
+    return values;
+  }
+
+  @Override
+  public int getNumRows() {
+    return values.size();
+  }
+
+  @Override
+  public int getNumColumns() {
+    return values.get(0).size();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    RowMatrix rowMatrix = (RowMatrix) o;
+
+    return !(values != null ? !values.equals(rowMatrix.values) : rowMatrix.values != null);
+  }
+
+  @Override
+  public int hashCode() {
+    return values != null ? values.hashCode() : 0;
+  }
+
+  /**
+   * @return Inner product of two vectors.
+   */
+  private double dot(final Vector<Double> vector1, final Vector<Double> vector2) throws MatMulException {
+    if (vector1.size() != vector2.size()) {
+      throw new MatMulException("The dimension of vectors should be equal.");
+    }
+
+    double result = 0.0;
+    for (int i = 0; i < vector1.size(); i++) {
+      result += vector1.get(i) * vector2.get(i);
+    }
+    return result;
+  }
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/package-info.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/matmul/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * A Simple Vortex matrix multiplication example.
+ */
+package org.apache.reef.vortex.examples.matmul;


### PR DESCRIPTION
This addressed the issue by
  * Adding matrix multiplication example based on @johnyangk's code.
  * Defining user-defined Input/output to cause serialization cost.

JIRA:
  [REEF-1002](https://issues.apache.org/jira/browse/REEF-1002)