### PR TITLE
[REEF-1018] Migrate Org.Apache.REEF.Wake.Tests to xUnit

### DIFF
--- a/lang/cs/Org.Apache.REEF.Wake.Tests/ClockTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/ClockTest.cs
@@ -23,18 +23,17 @@ using System.Linq;
 using System.Reactive;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.Time.Event;
 using Org.Apache.REEF.Wake.Time.Runtime;
+using Xunit;
 
 namespace Org.Apache.REEF.Wake.Tests
 {
-    [TestClass]
     public class ClockTest
     {
-        [TestMethod]
+        [Fact]
         public void TestClock()
         {
             using (RuntimeClock clock = BuildClock())
@@ -45,11 +44,11 @@ namespace Org.Apache.REEF.Wake.Tests
                 heartBeat.OnNext(null);
                 Thread.Sleep(5000);
 
-                Assert.AreEqual(100, heartBeat.EventCount);
+                Assert.Equal(100, heartBeat.EventCount);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestAlarmRegistrationRaceConditions()
         {
             using (RuntimeClock clock = BuildClock())
@@ -72,20 +71,20 @@ namespace Org.Apache.REEF.Wake.Tests
 
                 // The earlier alarm should not have fired after 1 second
                 Thread.Sleep(1000);
-                Assert.AreEqual(0, events1.Count);
+                Assert.Equal(0, events1.Count);
 
                 // The earlier alarm will have fired after another 1.5 seconds, but the later will have not
                 Thread.Sleep(1500);
-                Assert.AreEqual(1, events1.Count);
-                Assert.AreEqual(0, events2.Count);
+                Assert.Equal(1, events1.Count);
+                Assert.Equal(0, events2.Count);
 
                 // The later alarm will have fired after 2 seconds
                 Thread.Sleep(2000);
-                Assert.AreEqual(1, events1.Count);
+                Assert.Equal(1, events1.Count);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSimultaneousAlarms()
         {
             using (RuntimeClock clock = BuildClock())
@@ -100,11 +99,11 @@ namespace Org.Apache.REEF.Wake.Tests
                 clock.ScheduleAlarm(1000, eventRecorder);
 
                 Thread.Sleep(1500);
-                Assert.AreEqual(3, events.Count);
+                Assert.Equal(3, events.Count);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestAlarmOrder()
         {
             using (RuntimeClock clock = BuildLogicalClock())
@@ -121,7 +120,7 @@ namespace Org.Apache.REEF.Wake.Tests
     
                 // Check that the recorded timestamps are in the same order that they were scheduled
                 Thread.Sleep(1500);
-                Assert.IsTrue(expectedTimestamps.SequenceEqual(recordedTimestamps));
+                Assert.True(expectedTimestamps.SequenceEqual(recordedTimestamps));
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/MultiCodecTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/MultiCodecTest.cs
@@ -19,16 +19,15 @@
 
 using System;
 using System.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
+using Xunit;
 
 namespace Org.Apache.REEF.Wake.Tests
 {
-    [TestClass]
     public class MultiCodecTest
     {
-        [TestMethod]
+        [Fact]
         public void TestMultiCodec()
         {
             MultiCodec<BaseEvent> codec = new MultiCodec<BaseEvent>();
@@ -41,8 +40,8 @@ namespace Org.Apache.REEF.Wake.Tests
             Event1 e1 = (Event1)codec.Decode(d1Data);
             Event2 e2 = (Event2)codec.Decode(d2Data);
 
-            Assert.AreEqual(42, e1.Number);
-            Assert.AreEqual("Tony", e2.Name);
+            Assert.Equal(42, e1.Number);
+            Assert.Equal("Tony", e2.Name);
         }
 
         private class BaseEvent

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/PubSubSubjectTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/PubSubSubjectTest.cs
@@ -20,15 +20,14 @@
 using System;
 using System.Reactive;
 using System.Threading;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Wake.RX.Impl;
+using Xunit;
 
 namespace Org.Apache.REEF.Wake.Tests
 {
-    [TestClass]
     public class PubSubSubjectTest
     {
-        [TestMethod]
+        [Fact]
         public void TestPubSubSubjectSingleThread()
         {
             int sum = 0;
@@ -46,10 +45,10 @@ namespace Org.Apache.REEF.Wake.Tests
 
             subject.OnNext(10);
             subject.OnCompleted();
-            Assert.AreEqual(sum, 55);
+            Assert.Equal(sum, 55);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestPubSubSubjectMultipleThreads()
         {
             int sum = 0;
@@ -76,10 +75,10 @@ namespace Org.Apache.REEF.Wake.Tests
                 thread.Join();
             }
 
-            Assert.AreEqual(sum, 100000);
+            Assert.Equal(sum, 100000);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMultipleTypes()
         {
             int sum1 = 0;
@@ -93,11 +92,11 @@ namespace Org.Apache.REEF.Wake.Tests
             subject.OnNext(new SubEvent2());
             subject.OnNext(new SubEvent2());
 
-            Assert.AreEqual(sum1, 100);
-            Assert.AreEqual(sum2, 1000);
+            Assert.Equal(sum1, 100);
+            Assert.Equal(sum2, 1000);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestOnCompleted()
         {
             int sum = 0;
@@ -106,18 +105,18 @@ namespace Org.Apache.REEF.Wake.Tests
             subject.Subscribe(Observer.Create<int>(x => sum += x));
 
             subject.OnNext(10);
-            Assert.AreEqual(10, sum);
+            Assert.Equal(10, sum);
 
             subject.OnNext(10);
-            Assert.AreEqual(20, sum);
+            Assert.Equal(20, sum);
 
             // Check that after calling OnCompleted, OnNext will do nothing
             subject.OnCompleted();
             subject.OnNext(10);
-            Assert.AreEqual(20, sum);
+            Assert.Equal(20, sum);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestOnError()
         {
             int sum = 0;
@@ -126,18 +125,18 @@ namespace Org.Apache.REEF.Wake.Tests
             subject.Subscribe(Observer.Create<int>(x => sum += x));
 
             subject.OnNext(10);
-            Assert.AreEqual(10, sum);
+            Assert.Equal(10, sum);
 
             subject.OnNext(10);
-            Assert.AreEqual(20, sum);
+            Assert.Equal(20, sum);
 
             // Check that after calling OnError, OnNext will do nothing
             subject.OnError(new Exception("error"));
             subject.OnNext(10);
-            Assert.AreEqual(20, sum);
+            Assert.Equal(20, sum);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDisposeSingleSubject()
         {
             int sum = 0;
@@ -148,15 +147,15 @@ namespace Org.Apache.REEF.Wake.Tests
             subject.OnNext(10);
             subject.OnNext(10);
             subject.OnNext(10);
-            Assert.AreEqual(30, sum);
+            Assert.Equal(30, sum);
 
             // Unregister the subject and check that calling OnNext does nothing
             disposable.Dispose();
             subject.OnNext(10);
-            Assert.AreEqual(30, sum);
+            Assert.Equal(30, sum);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDisposeMultipleSubjects()
         {
             int sum1 = 0;
@@ -172,22 +171,22 @@ namespace Org.Apache.REEF.Wake.Tests
             subject.OnNext(event1);
             subject.OnNext(event2);
             subject.OnNext(event2);
-            Assert.AreEqual(sum1, 100);
-            Assert.AreEqual(sum2, 1000);
+            Assert.Equal(sum1, 100);
+            Assert.Equal(sum2, 1000);
 
             // Check that unsubscribing from SubEvent1 does not affect other subscriptions
             disposable1.Dispose();
             subject.OnNext(event1);
             subject.OnNext(event2);
-            Assert.AreEqual(sum1, 100);
-            Assert.AreEqual(sum2, 1500);
+            Assert.Equal(sum1, 100);
+            Assert.Equal(sum2, 1500);
 
             // Unsubscribe from the remaining event types
             disposable2.Dispose();
             subject.OnNext(event1);
             subject.OnNext(event2);
-            Assert.AreEqual(sum1, 100);
-            Assert.AreEqual(sum2, 1500);
+            Assert.Equal(sum1, 100);
+            Assert.Equal(sum2, 1500);
         }
 
         class SuperEvent

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/RemoteManagerTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/RemoteManagerTest.cs
@@ -21,20 +21,19 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
 using System.Reactive;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
 using Org.Apache.REEF.Wake.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Wake.Tests
 {
-    [TestClass]
     public class RemoteManagerTest
     {
         private readonly IRemoteManagerFactory _remoteManagerFactory =
             TangFactory.GetTang().NewInjector().GetInstance<IRemoteManagerFactory>();
-        [TestMethod]
+        [Fact]
         public void TestOneWayCommunication()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -59,10 +58,10 @@ namespace Org.Apache.REEF.Wake.Tests
                 events.Add(queue.Take());
             }
 
-            Assert.AreEqual(3, events.Count);
+            Assert.Equal(3, events.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestOneWayCommunicationClientOnly()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -87,10 +86,10 @@ namespace Org.Apache.REEF.Wake.Tests
                 events.Add(queue.Take());
             }
 
-            Assert.AreEqual(3, events.Count);
+            Assert.Equal(3, events.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTwoWayCommunication()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -133,11 +132,11 @@ namespace Org.Apache.REEF.Wake.Tests
                 events2.Add(queue2.Take());
             }
 
-            Assert.AreEqual(4, events1.Count);
-            Assert.AreEqual(3, events2.Count);
+            Assert.Equal(4, events1.Count);
+            Assert.Equal(3, events2.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCommunicationThreeNodesOneWay()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -168,10 +167,10 @@ namespace Org.Apache.REEF.Wake.Tests
                 }
             }
 
-            Assert.AreEqual(5, events.Count);
+            Assert.Equal(5, events.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCommunicationThreeNodesBothWays()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -230,12 +229,12 @@ namespace Org.Apache.REEF.Wake.Tests
                 events3.Add(queue3.Take());
             }
 
-            Assert.AreEqual(2, events1.Count);
-            Assert.AreEqual(3, events2.Count);
-            Assert.AreEqual(5, events3.Count);
+            Assert.Equal(2, events1.Count);
+            Assert.Equal(3, events2.Count);
+            Assert.Equal(5, events3.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestRemoteSenderCallback()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -270,13 +269,13 @@ namespace Org.Apache.REEF.Wake.Tests
                 events.Add(queue.Take());
             }
 
-            Assert.AreEqual(3, events.Count);
-            Assert.AreEqual("received message: hello", events[0]);
-            Assert.AreEqual("received message: there", events[1]);
-            Assert.AreEqual("received message: buddy", events[2]);
+            Assert.Equal(3, events.Count);
+            Assert.Equal("received message: hello", events[0]);
+            Assert.Equal("received message: there", events[1]);
+            Assert.Equal("received message: buddy", events[2]);
         }
         
-        [TestMethod]
+        [Fact]
         public void TestRegisterObserverByType()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -302,10 +301,10 @@ namespace Org.Apache.REEF.Wake.Tests
                 events.Add(queue.Take());
             }
 
-            Assert.AreEqual(3, events.Count);
+            Assert.Equal(3, events.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCachedConnection()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -334,7 +333,7 @@ namespace Org.Apache.REEF.Wake.Tests
                 events.Add(queue.Take());
             }
 
-            Assert.AreEqual(4, events.Count);
+            Assert.Equal(4, events.Count);
         }
 
         private IRemoteManager<string> GetRemoteManager()

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/StreamingRemoteManagerTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/StreamingRemoteManagerTest.cs
@@ -21,16 +21,15 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
 using System.Reactive;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
 using Org.Apache.REEF.Wake.StreamingCodec;
 using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
+using Xunit;
 
 namespace Org.Apache.REEF.Wake.Tests
 {
-    [TestClass]
     public class StreamingRemoteManagerTest
     {
         private readonly StreamingRemoteManagerFactory _remoteManagerFactory1 =
@@ -40,7 +39,7 @@ namespace Org.Apache.REEF.Wake.Tests
         /// Tests one way communication between Remote Managers 
         /// Remote Manager listens on any available port
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingOneWayCommunication()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -66,13 +65,13 @@ namespace Org.Apache.REEF.Wake.Tests
                 events.Add(queue.Take());
             }
 
-            Assert.AreEqual(3, events.Count);
+            Assert.Equal(3, events.Count);
         }
 
         /// <summary>
         /// Tests two way communications. Checks whether both sides are able to receive messages
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingTwoWayCommunication()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -117,15 +116,15 @@ namespace Org.Apache.REEF.Wake.Tests
                 events2.Add(queue2.Take());
             }
 
-            Assert.AreEqual(4, events1.Count);
-            Assert.AreEqual(3, events2.Count);
+            Assert.Equal(4, events1.Count);
+            Assert.Equal(3, events2.Count);
         }
 
         /// <summary>
         /// Tests one way communication between 3 nodes.
         /// nodes 1 and 2 send messages to node 3
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingCommunicationThreeNodesOneWay()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -157,14 +156,14 @@ namespace Org.Apache.REEF.Wake.Tests
                 }
             }
 
-            Assert.AreEqual(5, events.Count);
+            Assert.Equal(5, events.Count);
         }
 
         /// <summary>
         /// Tests one way communication between 3 nodes.
         /// nodes 1 and 2 send messages to node 3 and node 3 sends message back
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingCommunicationThreeNodesBothWays()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -225,15 +224,15 @@ namespace Org.Apache.REEF.Wake.Tests
                 events3.Add(queue3.Take());
             }
 
-            Assert.AreEqual(2, events1.Count);
-            Assert.AreEqual(3, events2.Count);
-            Assert.AreEqual(5, events3.Count);
+            Assert.Equal(2, events1.Count);
+            Assert.Equal(3, events2.Count);
+            Assert.Equal(5, events3.Count);
         }
 
         /// <summary>
         /// Tests whether remote manager is able to send acknowledgement back
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingRemoteSenderCallback()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -270,16 +269,16 @@ namespace Org.Apache.REEF.Wake.Tests
                 events.Add(queue.Take());
             }
 
-            Assert.AreEqual(3, events.Count);
-            Assert.AreEqual("received message: hello", events[0]);
-            Assert.AreEqual("received message: there", events[1]);
-            Assert.AreEqual("received message: buddy", events[2]);
+            Assert.Equal(3, events.Count);
+            Assert.Equal("received message: hello", events[0]);
+            Assert.Equal("received message: there", events[1]);
+            Assert.Equal("received message: buddy", events[2]);
         }
         
         /// <summary>
         /// Test whether observer can be created with IRemoteMessage interface
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingRegisterObserverByType()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -307,13 +306,13 @@ namespace Org.Apache.REEF.Wake.Tests
                 events.Add(queue.Take());
             }
 
-            Assert.AreEqual(3, events.Count);
+            Assert.Equal(3, events.Count);
         }
 
         /// <summary>
         /// Tests whether we get the cached observer back for sending message without reinstantiating it
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingCachedConnection()
         {
             IPAddress listeningAddress = IPAddress.Parse("127.0.0.1");
@@ -344,7 +343,7 @@ namespace Org.Apache.REEF.Wake.Tests
                 events.Add(queue.Take());
             }
 
-            Assert.AreEqual(4, events.Count);
+            Assert.Equal(4, events.Count);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/StreamingTransportTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/StreamingTransportTest.cs
@@ -22,7 +22,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Reactive;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Wake.Remote;
@@ -30,6 +29,7 @@ using Org.Apache.REEF.Wake.Remote.Impl;
 using Org.Apache.REEF.Wake.Remote.Parameters;
 using Org.Apache.REEF.Wake.StreamingCodec;
 using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
+using Xunit;
 
 namespace Org.Apache.REEF.Wake.Tests
 {
@@ -37,17 +37,16 @@ namespace Org.Apache.REEF.Wake.Tests
     /// Tests the StreamingTransportServer, StreamingTransportClient and StreamingLink.
     /// Basically the Wake transport layer.
     /// </summary>
-    [TestClass]
     public class StreamingTransportTest
     {
-        private readonly ITcpPortProvider _tcpPortProvider = GetTcpProvider(8900, 8940);
+        private readonly ITcpPortProvider _tcpPortProvider = GetTcpProvider(9900, 9940);
         private readonly IInjector _injector = TangFactory.GetTang().NewInjector();
 
         /// <summary>
         /// Tests whether StreamingTransportServer receives 
         /// string messages from StreamingTransportClient
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingTransportServer()
         {
             BlockingCollection<string> queue = new BlockingCollection<string>();
@@ -74,16 +73,16 @@ namespace Org.Apache.REEF.Wake.Tests
                 } 
             }
 
-            Assert.AreEqual(3, events.Count);
-            Assert.AreEqual(events[0], "Hello");
-            Assert.AreEqual(events[1], ", ");
-            Assert.AreEqual(events[2], "World!");
+            Assert.Equal(3, events.Count);
+            Assert.Equal(events[0], "Hello");
+            Assert.Equal(events[1], ", ");
+            Assert.Equal(events[2], "World!");
         }
 
         /// <summary>
         /// Checks whether StreamingTransportClient is able to receive messages from remote host
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingTransportSenderStage()
         {
             
@@ -114,10 +113,10 @@ namespace Org.Apache.REEF.Wake.Tests
                 } 
             }
 
-            Assert.AreEqual(3, events.Count);
-            Assert.AreEqual(events[0], "Hello");
-            Assert.AreEqual(events[1], ", ");
-            Assert.AreEqual(events[2], " World");
+            Assert.Equal(3, events.Count);
+            Assert.Equal(events[0], "Hello");
+            Assert.Equal(events[1], ", ");
+            Assert.Equal(events[2], " World");
         }
 
         /// <summary>
@@ -125,7 +124,7 @@ namespace Org.Apache.REEF.Wake.Tests
         /// in asynchronous condition while sending messages asynchronously from different 
         /// threads
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingRaceCondition()
         {
             BlockingCollection<string> queue = new BlockingCollection<string>();
@@ -160,7 +159,7 @@ namespace Org.Apache.REEF.Wake.Tests
                 }
             }
 
-            Assert.AreEqual(numEventsExpected, events.Count);
+            Assert.Equal(numEventsExpected, events.Count);
 
         }
 

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/TransportTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/TransportTest.cs
@@ -22,21 +22,20 @@ using System.Collections.Generic;
 using System.Net;
 using System.Reactive;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
 using Org.Apache.REEF.Wake.Remote.Parameters;
 using Org.Apache.REEF.Wake.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Wake.Tests
 {
-    [TestClass]
     public class TransportTest
     {
         private readonly IPAddress _localIpAddress = IPAddress.Parse("127.0.0.1");
         private readonly ITcpPortProvider _tcpPortProvider = GetTcpProvider(8900, 8940);
-        [TestMethod]
+        [Fact]
         public void TestTransportServer()
         {
             ICodec<string> codec = new StringCodec();
@@ -65,10 +64,13 @@ namespace Org.Apache.REEF.Wake.Tests
                 } 
             }
 
-            Assert.AreEqual(3, events.Count);
+            Assert.Equal(3, events.Count);
+            Assert.Equal(events[0], "Hello");
+            Assert.Equal(events[1], ", ");
+            Assert.Equal(events[2], "World!");
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTransportServerEvent()
         {
             ICodec<TestEvent> codec = new TestEventCodec();
@@ -96,10 +98,13 @@ namespace Org.Apache.REEF.Wake.Tests
                 } 
             }
 
-            Assert.AreEqual(3, events.Count);
+            Assert.Equal(3, events.Count);
+            Assert.Equal(events[0].Message, "Hello");
+            Assert.Equal(events[1].Message, ", ");
+            Assert.Equal(events[2].Message, "World!");
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTransportSenderStage()
         {
             ICodec<string> codec = new StringCodec();
@@ -129,10 +134,13 @@ namespace Org.Apache.REEF.Wake.Tests
                 } 
             }
 
-            Assert.AreEqual(3, events.Count);
+            Assert.Equal(3, events.Count);
+            Assert.Equal(events[0], "Hello");
+            Assert.Equal(events[1], ", ");
+            Assert.Equal(events[2], " World");
         }
 
-        [TestMethod]
+        [Fact]
         public void TestRaceCondition()
         {
             ICodec<string> codec = new StringCodec();
@@ -168,7 +176,7 @@ namespace Org.Apache.REEF.Wake.Tests
                 }
             }
 
-            Assert.AreEqual(numEventsExpected, events.Count);
+            Assert.Equal(numEventsExpected, events.Count);
         }
 
         private class TestEvent

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingLink.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingLink.cs
@@ -127,7 +127,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
             }
             if (_disposed)
             {
-                Exceptions.Throw(new IllegalStateException("Link has been closed."), Logger);
+                Exceptions.Throw(new IllegalStateException("StreamingLink has been closed."), Logger);
             }
 
             _streamingCodec.Write(value, _writer);
@@ -142,7 +142,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         {
             if (_disposed)
             {
-                Exceptions.Throw(new IllegalStateException("Link has been closed."), Logger);
+                Exceptions.Throw(new IllegalStateException("StreamingLink has been closed."), Logger);
             }
 
             await _streamingCodec.WriteAsync(value, _writer, token);

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportServer.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportServer.cs
@@ -35,7 +35,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
     /// <typeparam name="T">Generic Type of message. It is constrained to have implemented IWritable and IType interface</typeparam>
     internal sealed class StreamingTransportServer<T> : IDisposable
     {
-        private static readonly Logger LOGGER = Logger.GetLogger(typeof(TransportServer<>));
+        private static readonly Logger LOGGER = Logger.GetLogger(typeof(StreamingTransportServer<>));
 
         private TcpListener _listener;
         private readonly CancellationTokenSource _cancellationSource;
@@ -173,11 +173,11 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
             }
             catch (InvalidOperationException)
             {
-                LOGGER.Log(Level.Info, "TransportServer has been closed.");
+                LOGGER.Log(Level.Info, "StreamingTransportServer has been closed.");
             }
             catch (OperationCanceledException)
             {
-                LOGGER.Log(Level.Info, "TransportServer has been closed.");
+                LOGGER.Log(Level.Info, "StreamingTransportServer has been closed.");
             }
         }
 


### PR DESCRIPTION
This change:
 * Migrates Wake.Tests to xUnit
 * Changes port in StreamingTransportTest class to avoid conflicts with TransportTest
 * Improves logging in Streaming* classes
 * Improves TransportTest checks

JIRA:
  [REEF-1018](https://issues.apache.org/jira/browse/REEF-1018)

Pull request:
  This closes #