### PR TITLE
[REEF-1023] Handle Exceptions in Vortex callback

### DIFF
--- a/lang/java/reef-applications/reef-vortex/pom.xml
+++ b/lang/java/reef-applications/reef-vortex/pom.xml
@@ -50,6 +50,11 @@ under the License.
             <artifactId>reef-runtime-local</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/lang/java/reef-applications/reef-vortex/pom.xml
+++ b/lang/java/reef-applications/reef-vortex/pom.xml
@@ -50,11 +50,6 @@ under the License.
             <artifactId>reef-runtime-local</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/FutureCallback.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/FutureCallback.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.api;
+
+/**
+ * A callback for accepting the results of a {@link VortexFuture} computation asynchronously.
+ * Only one of either {@link FutureCallback#onSuccess} or {@link FutureCallback#onFailure(Throwable)}
+ * will be invoked.
+ * Based on Google Guava's FutureCallback.
+ */
+public interface FutureCallback<V> {
+
+  /**
+   * Invoked with the result of the Tasklet computation on success.
+   * @param result the result.
+   */
+  void onSuccess(final V result);
+
+  /**
+   * Invoked with the error of the Tasklet computation on failure.
+   * @param t the error.
+   */
+  void onFailure(final Throwable t);
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexFuture.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexFuture.java
@@ -18,7 +18,6 @@
  */
 package org.apache.reef.vortex.api;
 
-import com.google.common.util.concurrent.FutureCallback;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.util.Optional;
 
@@ -112,7 +111,12 @@ public final class VortexFuture<TOutput> implements Future<TOutput> {
   public void completed(final TOutput result) {
     this.userResult = Optional.ofNullable(result);
     if (callbackHandler != null) {
-      callbackHandler.onSuccess(userResult.get());
+      new Thread() {
+        @Override
+        public void run() {
+          callbackHandler.onSuccess(userResult.get());
+        }
+      }.start();
     }
     this.countDownLatch.countDown();
   }
@@ -123,7 +127,12 @@ public final class VortexFuture<TOutput> implements Future<TOutput> {
   public void threwException(final Exception exception) {
     this.userException = exception;
     if (callbackHandler != null) {
-      callbackHandler.onFailure(exception);
+      new Thread() {
+        @Override
+        public void run() {
+          callbackHandler.onFailure(exception);
+        }
+      }.start();
     }
     this.countDownLatch.countDown();
   }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexThreadPool.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexThreadPool.java
@@ -18,10 +18,10 @@
  */
 package org.apache.reef.vortex.api;
 
+import com.google.common.util.concurrent.FutureCallback;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.driver.VortexMaster;
-import org.apache.reef.wake.EventHandler;
 
 import javax.inject.Inject;
 import java.io.Serializable;
@@ -47,7 +47,7 @@ public final class VortexThreadPool {
    */
   public <TInput extends Serializable, TOutput extends Serializable> VortexFuture<TOutput>
       submit(final VortexFunction<TInput, TOutput> function, final TInput input) {
-    return vortexMaster.enqueueTasklet(function, input, Optional.<EventHandler<TOutput>>empty());
+    return vortexMaster.enqueueTasklet(function, input, Optional.<FutureCallback<TOutput>>empty());
   }
 
   /**
@@ -60,7 +60,7 @@ public final class VortexThreadPool {
    */
   public <TInput extends Serializable, TOutput extends Serializable> VortexFuture<TOutput>
       submit(final VortexFunction<TInput, TOutput> function, final TInput input,
-             final EventHandler<TOutput> callback) {
+             final FutureCallback<TOutput> callback) {
     return vortexMaster.enqueueTasklet(function, input, Optional.of(callback));
   }
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexThreadPool.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexThreadPool.java
@@ -18,7 +18,6 @@
  */
 package org.apache.reef.vortex.api;
 
-import com.google.common.util.concurrent.FutureCallback;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.driver.VortexMaster;

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
@@ -51,7 +51,7 @@ final class DefaultVortexMaster implements VortexMaster {
   @Inject
   DefaultVortexMaster(final RunningWorkers runningWorkers,
                       final PendingTasklets pendingTasklets,
-                      @Parameter(VortexMasterConf.CallbackThreadpoolSize.class) final int threadPoolSize) {
+                      @Parameter(VortexMasterConf.CallbackThreadPoolSize.class) final int threadPoolSize) {
     this.executor = Executors.newFixedThreadPool(threadPoolSize);
     this.runningWorkers = runningWorkers;
     this.pendingTasklets = pendingTasklets;

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
@@ -18,12 +18,12 @@
  */
 package org.apache.reef.vortex.driver;
 
+import com.google.common.util.concurrent.FutureCallback;
 import net.jcip.annotations.ThreadSafe;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.api.VortexFunction;
 import org.apache.reef.vortex.api.VortexFuture;
-import org.apache.reef.wake.EventHandler;
 
 import javax.inject.Inject;
 import java.io.Serializable;
@@ -57,7 +57,7 @@ final class DefaultVortexMaster implements VortexMaster {
   @Override
   public <TInput extends Serializable, TOutput extends Serializable> VortexFuture<TOutput>
       enqueueTasklet(final VortexFunction<TInput, TOutput> function, final TInput input,
-                     final Optional<EventHandler<TOutput>> callback) {
+                     final Optional<FutureCallback<TOutput>> callback) {
     // TODO[REEF-500]: Simple duplicate Vortex Tasklet launch.
     final VortexFuture<TOutput> vortexFuture;
     if (callback.isPresent()) {

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
@@ -18,10 +18,10 @@
  */
 package org.apache.reef.vortex.driver;
 
-import com.google.common.util.concurrent.FutureCallback;
 import net.jcip.annotations.ThreadSafe;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.util.Optional;
+import org.apache.reef.vortex.api.FutureCallback;
 import org.apache.reef.vortex.api.VortexFunction;
 import org.apache.reef.vortex.api.VortexFuture;
 

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexConfHelper.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexConfHelper.java
@@ -63,7 +63,7 @@ public final class VortexConfHelper {
         .set(VortexMasterConf.NUM_OF_VORTEX_START_THREAD, DEFAULT_NUM_OF_VORTEX_START_THREAD) // fixed to 1 for now
         .build();
 
-    // TODO[JIRA REEF-1000]: Consider exposing VortexMasterConf.FUTURE_CALLBACK_THREADPOOL_SIZE.
+    // TODO[JIRA REEF-1000]: Consider exposing VortexMasterConf.FUTURE_CALLBACK_THREAD_POOL_SIZE.
     // For now, use default value defined in the NamedParameter.
 
     return Configurations.merge(vortexDriverConf, vortexMasterConf);

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexConfHelper.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexConfHelper.java
@@ -63,6 +63,9 @@ public final class VortexConfHelper {
         .set(VortexMasterConf.NUM_OF_VORTEX_START_THREAD, DEFAULT_NUM_OF_VORTEX_START_THREAD) // fixed to 1 for now
         .build();
 
+    // TODO[JIRA REEF-1000]: Consider exposing VortexMasterConf.FUTURE_CALLBACK_THREADPOOL_SIZE.
+    // For now, use default value defined in the NamedParameter.
+
     return Configurations.merge(vortexDriverConf, vortexMasterConf);
   }
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMaster.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMaster.java
@@ -18,11 +18,11 @@
  */
 package org.apache.reef.vortex.driver;
 
-import com.google.common.util.concurrent.FutureCallback;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.util.Optional;
+import org.apache.reef.vortex.api.FutureCallback;
 import org.apache.reef.vortex.api.VortexFunction;
 import org.apache.reef.vortex.api.VortexFuture;
 

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMaster.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMaster.java
@@ -18,13 +18,13 @@
  */
 package org.apache.reef.vortex.driver;
 
+import com.google.common.util.concurrent.FutureCallback;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.api.VortexFunction;
 import org.apache.reef.vortex.api.VortexFuture;
-import org.apache.reef.wake.EventHandler;
 
 import java.io.Serializable;
 
@@ -41,7 +41,7 @@ public interface VortexMaster {
    */
   <TInput extends Serializable, TOutput extends Serializable> VortexFuture<TOutput>
       enqueueTasklet(final VortexFunction<TInput, TOutput> vortexFunction, final TInput input,
-                     final Optional<EventHandler<TOutput>> callback);
+                     final Optional<FutureCallback<TOutput>> callback);
 
   /**
    * Call this when a new worker is up and running.

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMasterConf.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMasterConf.java
@@ -67,6 +67,13 @@ public final class VortexMasterConf extends ConfigurationModuleBuilder {
   }
 
   /**
+   * Size of threadpool for callbacks on {@link org.apache.reef.vortex.api.VortexFuture}.
+   */
+  @NamedParameter(doc = "Size of threadpool for callbacks on VortexFuture.", default_value = "10")
+  final class CallbackThreadpoolSize implements Name<Integer> {
+  }
+
+  /**
    * Number of Workers.
    */
   public static final RequiredParameter<Integer> WORKER_NUM = new RequiredParameter<>();
@@ -97,6 +104,11 @@ public final class VortexMasterConf extends ConfigurationModuleBuilder {
   public static final RequiredParameter<Integer> NUM_OF_VORTEX_START_THREAD = new RequiredParameter<>();
 
   /**
+   * Size of threadpool for callbacks on VortexFuture.
+   */
+  public static final OptionalParameter<Integer> FUTURE_CALLBACK_THREADPOOL_SIZE = new OptionalParameter<>();
+
+  /**
    * Vortex Master configuration.
    */
   public static final ConfigurationModule CONF = new VortexMasterConf()
@@ -106,5 +118,6 @@ public final class VortexMasterConf extends ConfigurationModuleBuilder {
       .bindNamedParameter(WorkerCapacity.class, WORKER_CAPACITY)
       .bindImplementation(VortexStart.class, VORTEX_START)
       .bindNamedParameter(NumberOfVortexStartThreads.class, NUM_OF_VORTEX_START_THREAD)
+      .bindNamedParameter(CallbackThreadpoolSize.class, FUTURE_CALLBACK_THREADPOOL_SIZE)
       .build();
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMasterConf.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMasterConf.java
@@ -70,7 +70,7 @@ public final class VortexMasterConf extends ConfigurationModuleBuilder {
    * Size of threadpool for callbacks on {@link org.apache.reef.vortex.api.VortexFuture}.
    */
   @NamedParameter(doc = "Size of threadpool for callbacks on VortexFuture.", default_value = "10")
-  final class CallbackThreadpoolSize implements Name<Integer> {
+  final class CallbackThreadPoolSize implements Name<Integer> {
   }
 
   /**
@@ -106,7 +106,7 @@ public final class VortexMasterConf extends ConfigurationModuleBuilder {
   /**
    * Size of threadpool for callbacks on VortexFuture.
    */
-  public static final OptionalParameter<Integer> FUTURE_CALLBACK_THREADPOOL_SIZE = new OptionalParameter<>();
+  public static final OptionalParameter<Integer> FUTURE_CALLBACK_THREAD_POOL_SIZE = new OptionalParameter<>();
 
   /**
    * Vortex Master configuration.
@@ -118,6 +118,6 @@ public final class VortexMasterConf extends ConfigurationModuleBuilder {
       .bindNamedParameter(WorkerCapacity.class, WORKER_CAPACITY)
       .bindImplementation(VortexStart.class, VORTEX_START)
       .bindNamedParameter(NumberOfVortexStartThreads.class, NUM_OF_VORTEX_START_THREAD)
-      .bindNamedParameter(CallbackThreadpoolSize.class, FUTURE_CALLBACK_THREADPOOL_SIZE)
+      .bindNamedParameter(CallbackThreadPoolSize.class, FUTURE_CALLBACK_THREAD_POOL_SIZE)
       .build();
 }

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.reef.vortex.driver;
 
-import com.google.common.util.concurrent.FutureCallback;
 import org.apache.reef.util.Optional;
+import org.apache.reef.vortex.api.FutureCallback;
 import org.apache.reef.vortex.api.VortexFunction;
 import org.apache.reef.vortex.api.VortexFuture;
 import org.junit.Test;
@@ -162,7 +162,6 @@ public class DefaultVortexMasterTest {
     }
   }
 
-
   /**
    * Test handling of single tasklet execution with a failure.
    */
@@ -203,7 +202,6 @@ public class DefaultVortexMasterTest {
     latch.await();
     assertTrue("Callback should have been received", callbackReceived.get());
   }
-
 
   /**
    * Launch specified number of tasklets as a substitute for PendingTaskletLauncher.

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
@@ -45,7 +45,7 @@ public class DefaultVortexMasterTest {
     final VortexWorkerManager vortexWorkerManager1 = testUtil.newWorker();
     final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
     final PendingTasklets pendingTasklets = new PendingTasklets();
-    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets);
+    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets, 5);
 
     final AtomicBoolean callbackReceived = new AtomicBoolean(false);
     final CountDownLatch latch = new CountDownLatch(1);
@@ -87,7 +87,7 @@ public class DefaultVortexMasterTest {
     final VortexWorkerManager vortexWorkerManager2 = testUtil.newWorker();
     final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
     final PendingTasklets pendingTasklets = new PendingTasklets();
-    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets);
+    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets, 5);
 
     // Allocate worker & tasklet and schedule
     vortexMaster.workerAllocated(vortexWorkerManager1);
@@ -120,7 +120,7 @@ public class DefaultVortexMasterTest {
     final ArrayList<VortexFuture> vortexFutures = new ArrayList<>();
     final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
     final PendingTasklets pendingTasklets = new PendingTasklets();
-    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets);
+    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets, 5);
 
     // Allocate iniital evaluators (will all be preempted later...)
     final List<VortexWorkerManager> initialWorkers = new ArrayList<>();
@@ -171,7 +171,7 @@ public class DefaultVortexMasterTest {
     final VortexWorkerManager vortexWorkerManager1 = testUtil.newWorker();
     final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
     final PendingTasklets pendingTasklets = new PendingTasklets();
-    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets);
+    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets, 5);
 
     final AtomicBoolean callbackReceived = new AtomicBoolean(false);
     final CountDownLatch latch = new CountDownLatch(1);

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.reef.vortex.driver;
 
+import com.google.common.util.concurrent.FutureCallback;
 import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.api.VortexFunction;
 import org.apache.reef.vortex.api.VortexFuture;
-import org.apache.reef.wake.EventHandler;
 import org.junit.Test;
 
 import java.util.*;
@@ -52,12 +52,18 @@ public class DefaultVortexMasterTest {
 
     vortexMaster.workerAllocated(vortexWorkerManager1);
 
-    final EventHandler<Integer> testCallbackHandler = new EventHandler<Integer>() {
+    final FutureCallback<Integer> testCallbackHandler = new FutureCallback<Integer>() {
       @Override
-      public void onNext(final Integer value) {
+      public void onSuccess(final Integer integer) {
         callbackReceived.set(true);
         latch.countDown();
-      }};
+      }
+
+      @Override
+      public void onFailure(final Throwable throwable) {
+        throw new RuntimeException("Did not expect exception in test.", throwable);
+      }
+    };
 
     final VortexFuture future = vortexMaster.enqueueTasklet(vortexFunction, null, Optional.of(testCallbackHandler));
 
@@ -86,7 +92,7 @@ public class DefaultVortexMasterTest {
     // Allocate worker & tasklet and schedule
     vortexMaster.workerAllocated(vortexWorkerManager1);
     final VortexFuture future = vortexMaster.enqueueTasklet(vortexFunction, null,
-        Optional.<EventHandler<Integer>>empty());
+        Optional.<FutureCallback<Integer>>empty());
     final ArrayList<Integer> taskletIds1 = launchTasklets(runningWorkers, pendingTasklets, 1);
 
     // Preemption!
@@ -129,7 +135,7 @@ public class DefaultVortexMasterTest {
     final int numOfTasklets = 100;
     for (int i = 0; i < numOfTasklets; i++) {
       vortexFutures.add(vortexMaster.enqueueTasklet(testUtil.newFunction(), null,
-          Optional.<EventHandler<Integer>>empty()));
+          Optional.<FutureCallback<Integer>>empty()));
     }
     final ArrayList<Integer> taskletIds1 = launchTasklets(runningWorkers, pendingTasklets, numOfTasklets);
 
@@ -155,6 +161,49 @@ public class DefaultVortexMasterTest {
       assertTrue("The VortexFuture should be done", vortexFuture.isDone());
     }
   }
+
+
+  /**
+   * Test handling of single tasklet execution with a failure.
+   */
+  @Test(timeout = 10000)
+  public void testTaskletThrowException() throws Exception {
+    final VortexFunction vortexFunction = testUtil.newIntegerFunction();
+    final VortexWorkerManager vortexWorkerManager1 = testUtil.newWorker();
+    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
+    final PendingTasklets pendingTasklets = new PendingTasklets();
+    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets);
+
+    final AtomicBoolean callbackReceived = new AtomicBoolean(false);
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    vortexMaster.workerAllocated(vortexWorkerManager1);
+
+    final FutureCallback<Integer> testCallbackHandler = new FutureCallback<Integer>() {
+      @Override
+      public void onSuccess(final Integer integer) {
+        throw new RuntimeException("Did not expect success in test.");
+      }
+
+      @Override
+      public void onFailure(final Throwable throwable) {
+        callbackReceived.set(true);
+        latch.countDown();
+      }
+    };
+
+    final VortexFuture future = vortexMaster.enqueueTasklet(vortexFunction, null, Optional.of(testCallbackHandler));
+
+    final ArrayList<Integer> taskletIds = launchTasklets(runningWorkers, pendingTasklets, 1);
+    for (final int taskletId : taskletIds) {
+      vortexMaster.taskletErrored(vortexWorkerManager1.getId(), taskletId, new RuntimeException("Test exception"));
+    }
+
+    assertTrue("The VortexFuture should be done", future.isDone());
+    latch.await();
+    assertTrue("Callback should have been received", callbackReceived.get());
+  }
+
 
   /**
    * Launch specified number of tasklets as a substitute for PendingTaskletLauncher.

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/TestUtil.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/TestUtil.java
@@ -23,6 +23,8 @@ import org.apache.reef.vortex.api.VortexFunction;
 import org.apache.reef.vortex.api.VortexFuture;
 
 import java.io.Serializable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.Mockito.mock;
@@ -31,9 +33,10 @@ import static org.mockito.Mockito.when;
 /**
  * Utility methods for tests.
  */
-public class TestUtil {
+public final class TestUtil {
   private final AtomicInteger taskletId = new AtomicInteger(0);
   private final AtomicInteger workerId = new AtomicInteger(0);
+  private final Executor executor = Executors.newFixedThreadPool(5);
 
   /**
    * @return a new mocked worker.
@@ -49,7 +52,7 @@ public class TestUtil {
    * @return a new dummy tasklet.
    */
   public Tasklet newTasklet() {
-    return new Tasklet(taskletId.getAndIncrement(), null, null, new VortexFuture());
+    return new Tasklet(taskletId.getAndIncrement(), null, null, new VortexFuture(executor));
   }
 
   /**

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/addone/AddOneCallbackTestStart.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/addone/AddOneCallbackTestStart.java
@@ -18,8 +18,8 @@
  */
 package org.apache.reef.tests.applications.vortex.addone;
 
-import com.google.common.util.concurrent.FutureCallback;
 import io.netty.util.internal.ConcurrentSet;
+import org.apache.reef.vortex.api.FutureCallback;
 import org.apache.reef.vortex.api.VortexFuture;
 import org.apache.reef.vortex.api.VortexStart;
 import org.apache.reef.vortex.api.VortexThreadPool;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/addone/AddOneCallbackTestStart.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/addone/AddOneCallbackTestStart.java
@@ -18,11 +18,11 @@
  */
 package org.apache.reef.tests.applications.vortex.addone;
 
+import com.google.common.util.concurrent.FutureCallback;
 import io.netty.util.internal.ConcurrentSet;
 import org.apache.reef.vortex.api.VortexFuture;
 import org.apache.reef.vortex.api.VortexStart;
 import org.apache.reef.vortex.api.VortexThreadPool;
-import org.apache.reef.wake.EventHandler;
 import org.junit.Assert;
 
 import javax.inject.Inject;
@@ -54,11 +54,16 @@ public final class AddOneCallbackTestStart implements VortexStart {
     final AddOneFunction addOneFunction = new AddOneFunction();
 
     for (final int i : inputVector) {
-      futures.add(vortexThreadPool.submit(addOneFunction, i, new EventHandler<Integer>() {
+      futures.add(vortexThreadPool.submit(addOneFunction, i, new FutureCallback<Integer>() {
         @Override
-        public void onNext(final Integer value) {
-          outputSet.add(value - 1);
+        public void onSuccess(final Integer result) {
+          outputSet.add(result - 1);
           latch.countDown();
+        }
+
+        @Override
+        public void onFailure(final Throwable t) {
+          throw new RuntimeException("Did not expect exception in test.", t);
         }
       }));
     }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/exception/ExceptionCallbackTestStart.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/exception/ExceptionCallbackTestStart.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.tests.applications.vortex.exception;
 
-import com.google.common.util.concurrent.FutureCallback;
+import org.apache.reef.vortex.api.FutureCallback;
 import org.apache.reef.vortex.api.VortexFuture;
 import org.apache.reef.vortex.api.VortexStart;
 import org.apache.reef.vortex.api.VortexThreadPool;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/exception/ExceptionCallbackTestStart.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/exception/ExceptionCallbackTestStart.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.applications.vortex.exception;
+
+import com.google.common.util.concurrent.FutureCallback;
+import org.apache.reef.vortex.api.VortexFuture;
+import org.apache.reef.vortex.api.VortexStart;
+import org.apache.reef.vortex.api.VortexThreadPool;
+import org.junit.Assert;
+
+import javax.inject.Inject;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Test that an {@link ExecutionException} is thrown on tasklets that throws an Exception, and
+ * that the callback handler gets invoked on failure.
+ */
+public final class ExceptionCallbackTestStart implements VortexStart {
+
+  @Inject
+  private ExceptionCallbackTestStart() {
+  }
+
+  @Override
+  public void start(final VortexThreadPool vortexThreadPool) {
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    final ExceptionFunction exceptionFunction = new ExceptionFunction();
+
+    final VortexFuture<Integer> future = vortexThreadPool.submit(exceptionFunction, 1, new FutureCallback<Integer>() {
+      @Override
+      public void onSuccess(final Integer result) {
+        throw new RuntimeException("Did not expect success in test.");
+      }
+
+      @Override
+      public void onFailure(final Throwable t) {
+        latch.countDown();
+      }
+    });
+
+    boolean gotFailure = false;
+    try {
+      latch.await();
+      future.get();
+    } catch (final InterruptedException e) {
+      e.printStackTrace();
+      Assert.fail();
+    } catch (final ExecutionException ex) {
+      gotFailure = true;
+    }
+
+    Assert.assertTrue(gotFailure);
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/exception/ExceptionFunction.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/exception/ExceptionFunction.java
@@ -16,17 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.tests.applications.vortex;
+package org.apache.reef.tests.applications.vortex.exception;
 
-import org.apache.reef.tests.applications.vortex.addone.AddOneTest;
-import org.apache.reef.tests.applications.vortex.exception.VortexExceptionTest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.apache.reef.vortex.api.VortexFunction;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-    AddOneTest.class,
-    VortexExceptionTest.class
-    })
-public final class VortexTestSuite {
+/**
+ * A test Vortex function that throws an Exception.
+ */
+public final class ExceptionFunction implements VortexFunction<Integer, Integer> {
+  @Override
+  public Integer call(final Integer integer) throws Exception {
+    throw new RuntimeException("Expected test exception.");
+  }
 }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/exception/VortexExceptionTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/exception/VortexExceptionTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.applications.vortex.exception;
+
+import org.apache.reef.client.LauncherStatus;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tests.TestEnvironment;
+import org.apache.reef.tests.TestEnvironmentFactory;
+import org.apache.reef.vortex.driver.VortexConfHelper;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test(s) for tasklets that throw Exceptions.
+ */
+public final class VortexExceptionTest {
+  private final TestEnvironment testEnvironment = TestEnvironmentFactory.getNewTestEnvironment();
+
+  /**
+   * Set up the test environment.
+   */
+  @Before
+  public void setUp() throws Exception {
+    this.testEnvironment.setUp();
+  }
+
+  /**
+   * Tear down the test environment.
+   */
+  @After
+  public void tearDown() throws Exception {
+    this.testEnvironment.tearDown();
+  }
+
+  /**
+   * Tests that callback is invoked on Vortex Tasklet failure.
+   */
+  @Test
+  public void testVortexExceptionCallback() {
+    final Configuration conf =
+        VortexConfHelper.getVortexConf("TEST_Vortex_ExceptionCallbackTest",
+            ExceptionCallbackTestStart.class, 2, 64, 4, 2000);
+    final LauncherStatus status = this.testEnvironment.run(conf);
+    Assert.assertTrue("Job state after execution: " + status, status.isSuccess());
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/exception/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/exception/package-info.java
@@ -16,17 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.tests.applications.vortex;
 
-import org.apache.reef.tests.applications.vortex.addone.AddOneTest;
-import org.apache.reef.tests.applications.vortex.exception.VortexExceptionTest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-    AddOneTest.class,
-    VortexExceptionTest.class
-    })
-public final class VortexTestSuite {
-}
+/**
+ * Vortex Exception test.
+ */
+package org.apache.reef.tests.applications.vortex.exception;


### PR DESCRIPTION
This addressed the issue by
  * Use ``FutureCallback`` instead of ``EventHandler``.
  * Added tests for tasklet exception scenarios.

JIRA:
  [REEF-1023](https://issues.apache.org/jira/browse/REEF-1023)