### PR TITLE
[REEF-818] EvaluatorManager should get job id from evaluator configur…

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/ApplicationIdentifier.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/ApplicationIdentifier.java
@@ -28,7 +28,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
  * <p>
  * In YARN, this is the applicationID assigned by the resource manager.
  */
-@NamedParameter(doc = "The RM application/job identifier.")
+@NamedParameter(doc = "The RM application/job identifier.", default_value = "REEF_LOCAL_RUNTIME")
 public final class ApplicationIdentifier implements Name<String> {
   private ApplicationIdentifier() {
   }

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/restart/DFSEvaluatorPreserver.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/restart/DFSEvaluatorPreserver.java
@@ -28,7 +28,7 @@ import org.apache.reef.driver.parameters.DriverJobSubmissionDirectory;
 import org.apache.reef.driver.parameters.FailDriverOnEvaluatorLogErrors;
 import org.apache.reef.exception.DriverFatalRuntimeException;
 import org.apache.reef.runtime.common.driver.EvaluatorPreserver;
-import org.apache.reef.runtime.common.driver.evaluator.EvaluatorManager;
+import org.apache.reef.runtime.common.evaluator.parameters.ApplicationIdentifier;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
@@ -62,9 +62,11 @@ public final class DFSEvaluatorPreserver implements EvaluatorPreserver, AutoClos
 
   private boolean writerClosed = false;
 
-  @Inject DFSEvaluatorPreserver(@Parameter(FailDriverOnEvaluatorLogErrors.class)
+  @Inject DFSEvaluatorPreserver(@Parameter(ApplicationIdentifier.class)
+                                final String applicationIdentifier,
+                                @Parameter(FailDriverOnEvaluatorLogErrors.class)
                                 final boolean failDriverOnEvaluatorLogErrors) {
-    this(failDriverOnEvaluatorLogErrors, "/ReefApplications/" + EvaluatorManager.getJobIdentifier());
+    this(failDriverOnEvaluatorLogErrors, "/ReefApplications/" + applicationIdentifier);
   }
 
   @Inject


### PR DESCRIPTION
...ation.

This patch:
 * Adds the default value 'REEF_LOCAL_RUNTIME' to the `ApplicationIdentifier` named parameter
 * Injects the `ApplicationIdentifier` parameter into `EvaluatorManager`
   and `DFSEvaluatorPreserver` constructors
 * Removes the static `getJobIdentifier()` from `EvaluatorManager`