### PR TITLE
[REEF-1041] Fix CopyJarFiles in build.props

### DIFF
--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -133,7 +133,7 @@ under the License.
   <Target Name="CopyJarFiles" DependsOnTargets="BuildJarProject">
     <MSBuild Targets="Build" BuildInParallel="$(BuildInParallel)" Properties="Chip=$(Chip);Lang=$(Lang)" Projects="@(ProjectFile)" />
 	<ItemGroup>
-        <MySourceFiles Include="$(Bindir)\**\*.jar"/>
+        <MySourceFiles Include="$(Bindir)\**\Org.Apache.REEF.Bridge.JAR\*.jar"/>
     </ItemGroup>
     <Copy
       SourceFiles="@(MySourceFiles)"


### PR DESCRIPTION
This PR prevents `CopyJarFiles` from redundant copying
by specifying the source directory narrowly.

JIRA:
  [REEF-1041](https://issues.apache.org/jira/browse/REEF-1041)

Pull request:
  This closes #