### PR TITLE
[REEF-1042]  JobSubmissionDirectoryPrefixParameter bind at C# is not used at Java client

### DIFF
--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnClusterSubmissionFromCS.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnClusterSubmissionFromCS.java
@@ -180,6 +180,13 @@ final class YarnClusterSubmissionFromCS {
   }
 
   /**
+   * @return job Submission Directory Prefix which is serialized from C#
+   */
+  String getJobSubmissionDirectoryPrefix() {
+    return jobSubmissionDirectoryPrefix;
+  }
+
+  /**
    * Takes the YARN cluster job submission configuration file, deserializes it, and creates submission object.
    */
   static YarnClusterSubmissionFromCS fromJobSubmissionParametersFile(final File yarnClusterJobSubmissionParametersFile)

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
@@ -37,6 +37,7 @@ import org.apache.reef.runtime.yarn.client.SecurityTokenProvider;
 import org.apache.reef.runtime.yarn.client.YarnSubmissionHelper;
 import org.apache.reef.runtime.yarn.client.uploader.JobFolder;
 import org.apache.reef.runtime.yarn.client.uploader.JobUploader;
+import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectoryPrefix;
 import org.apache.reef.runtime.yarn.util.YarnConfigurationConstructor;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Tang;
@@ -246,6 +247,7 @@ public final class YarnJobSubmissionClient {
     final Configuration yarnJobSubmissionClientConfig = Tang.Factory.getTang().newConfigurationBuilder()
         .bindImplementation(RuntimeClasspathProvider.class, YarnClasspathProvider.class)
         .bindConstructor(org.apache.hadoop.yarn.conf.YarnConfiguration.class, YarnConfigurationConstructor.class)
+        .bindNamedParameter(JobSubmissionDirectoryPrefix.class, yarnSubmission.getJobSubmissionDirectoryPrefix())
         .bindList(DriverLaunchCommandPrefix.class, launchCommandPrefix)
         .build();
     final YarnJobSubmissionClient client = Tang.Factory.getTang().newInjector(yarnJobSubmissionClientConfig)


### PR DESCRIPTION
This PR expose jobSubmissionDirectoryPrefix from YarnClusterSubmissionFromCS
Set the value get from C# to the named parameter JobSubmissionDirectoryPrefix before injecting YarnJobSubmissionClient so that it will be used in JobSubmissionDirectoryProviderImpl instead of default

JIRA: [REEF-1042](https://issues.apache.org/jira/browse/REEF-1042)

This closes #