### PR TITLE
[REEF-1047] ConstructorDefImpl.hashCode function should consider `className`

### DIFF
--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/ConstructorDefImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/ConstructorDefImpl.java
@@ -161,6 +161,8 @@ public class ConstructorDefImpl<T> implements ConstructorDef<T> {
   public int hashCode() {
     final ConstructorArg[] argsSort = getArgs().clone();
     Arrays.sort(argsSort);
-    return Arrays.hashCode(argsSort);
+    int result = Arrays.hashCode(argsSort);
+    result = 31 * result + (this.className == null ? 0 : this.className.hashCode());
+    return result;
   }
 }


### PR DESCRIPTION
This issue fixes the `hashCode` function of `ConstructorDefImpl` class
to consider `className` and `args` together.

JIRA:
  [REEF-1047](https://issues.apache.org/jira/browse/REEF-1047)

Pull Request:
  This closes #