### PR TITLE
[REEF-530] Add missing Javadoc comments/triage TODOs in reef-runtime-yarn

### DIFF
--- a/lang/java/reef-runtime-yarn/pom.xml
+++ b/lang/java/reef-runtime-yarn/pom.xml
@@ -76,6 +76,17 @@ under the License.
                 </excludes>
             </resource>
         </resources>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <configuration>
+                        <configLocation>lang/java/reef-common/src/main/resources/checkstyle-strict.xml</configLocation>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
 </project>

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/DefaultRackNameFormatter.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/DefaultRackNameFormatter.java
@@ -26,12 +26,15 @@ import javax.inject.Inject;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Default implementation of rack names formatter.
+ * Extracts rack name from host name, if possible.
+ */
 @Private
 @DriverSide
 public final class DefaultRackNameFormatter implements RackNameFormatter {
 
   private static final Logger LOG = Logger.getLogger(DefaultRackNameFormatter.class.getName());
-
 
   @Inject
   private DefaultRackNameFormatter() {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/JobSubmissionDirectoryProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/JobSubmissionDirectoryProvider.java
@@ -23,7 +23,6 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
  * Provides path to job submission directory.
- *
  */
 @DefaultImplementation(JobSubmissionDirectoryProviderImpl.class)
 public interface JobSubmissionDirectoryProvider {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/JobSubmissionDirectoryProviderImpl.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/JobSubmissionDirectoryProviderImpl.java
@@ -27,6 +27,10 @@ import javax.inject.Inject;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
+/**
+ * Default implementation of JobSubmissionDirectoryProvider.
+ * Constructs path to job submission directory based on current date and time and applicationId.
+ */
 public final class JobSubmissionDirectoryProviderImpl implements JobSubmissionDirectoryProvider {
 
   /**

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -424,7 +424,8 @@ final class YarnContainerManager
         // Therefore it is necessary avoid sending zero-container request, even it means getting extra containers.
         // It is okay to send nonzero m-capacity and n-capacity request together since bigger containers
         // can be matched.
-        // TODO: revisit this when implementing locality-strictness (i.e. a specific rack request can be ignored)
+        // TODO[JIRA REEF-42, REEF-942]: revisit this when implementing locality-strictness
+        // (i.e. a specific rack request can be ignored)
         if (this.requestsAfterSentToRM.size() > 1) {
           try {
             this.resourceManager.removeContainerRequest(matchedRequest);
@@ -488,7 +489,7 @@ final class YarnContainerManager
 
     final AMRMClient.ContainerRequest request = this.requestsAfterSentToRM.peek();
     final boolean resourceCondition = container.getResource().getMemory() >= request.getCapability().getMemory();
-    // TODO: check vcores once YARN-2380 is resolved
+    // TODO[JIRA REEF-35]: check vcores once YARN-2380 is resolved
     final boolean nodeCondition = request.getNodes() == null
         || request.getNodes().contains(container.getNodeId().getHost());
     final boolean rackCondition = request.getRacks() == null

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerRequestHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerRequestHandler.java
@@ -21,12 +21,15 @@ package org.apache.reef.runtime.yarn.driver;
 import org.apache.hadoop.yarn.client.api.AMRMClient;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
+/**
+ * Interface to request containers from YARN using AMRMClient.ContainerRequest requests.
+ */
 @DefaultImplementation(YarnContainerRequestHandlerImpl.class)
 public interface YarnContainerRequestHandler {
   /**
    * Enqueue a set of container requests with YARN.
    *
-   * @param containerRequests
+   * @param containerRequests set of container requests
    */
   void onContainerRequest(final AMRMClient.ContainerRequest... containerRequests);
 }


### PR DESCRIPTION
JIRA:
  [REEF-530](https://issues.apache.org/jira/browse/REEF-530)

Pull request:
  This closes #