### PR TITLE
[REEF-1061] Fix DriverRestartFailedEvaluatorHandler InterOp Signature

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
@@ -642,6 +642,9 @@ static JNINativeMethod methods[] = {
 	{ "clrSystemDriverRestartCompletedHandlerOnNext", "(JLorg/apache/reef/javabridge/generic/DriverRestartCompletedBridge;)V",
 	(void*)&Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartCompletedHandlerOnNext },
 
+    { "clrSystemDriverRestartFailedEvaluatorHandlerOnNext", "(JLorg/apache/reef/javabridge/FailedEvaluatorBridge;Lorg/apache/reef/javabridge/InteropLogger;)V",
+    (void*)&Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartFailedEvaluatorHandlerOnNext },
+
 	{ "clrSystemProgressProviderGetProgress", "(J)F",
 	(void*)&Java_org_apache_reef_javabridge_NativeInterop_clrSystemProgressProviderGetProgress },
 };


### PR DESCRIPTION
This addressed the issue by
  * Add in link for DriverRestartFailedEvaluatorHandler in InterOp.

JIRA:
  [REEF-1061](https://issues.apache.org/jira/browse/REEF-1061)