### PR TITLE
[REEF-1058] Enable StyleCop.CSharp.LayoutRules and fix violations

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client.Tests/JobResourceUploaderTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/JobResourceUploaderTests.cs
@@ -101,7 +101,6 @@ namespace Org.Apache.REEF.Client.Tests
 
         private class TestContext
         {
-
             public readonly IJobSubmissionDirectoryProvider JobSubmissionDirectoryProvider =
                 Substitute.For<IJobSubmissionDirectoryProvider>();
             public readonly IResourceArchiveFileGenerator ResourceArchiveFileGenerator =

--- a/lang/cs/Org.Apache.REEF.Client/API/IJobSubmission.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/IJobSubmission.cs
@@ -67,6 +67,5 @@ namespace Org.Apache.REEF.Client.API
         /// Can be used to redirect assembly versions
         /// </summary>
         string DriverConfigurationFileContents { get; }
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/API/JobSubmission.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/JobSubmission.cs
@@ -95,7 +95,8 @@ namespace Org.Apache.REEF.Client.API
         /// <summary>
         /// The Job's identifier
         /// </summary>
-        string IJobSubmission.JobIdentifier {
+        string IJobSubmission.JobIdentifier 
+        {
             get { return _jobIdentifier; }
         }
 
@@ -107,7 +108,5 @@ namespace Org.Apache.REEF.Client.API
         {
             get { return _driverConfigurationFileContents; }
         }
-
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/API/JobSubmissionBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/JobSubmissionBuilder.cs
@@ -41,7 +41,6 @@ namespace Org.Apache.REEF.Client.API
             _configurationProviders = configurationProviders;
         }
 
-
         /// <summary>
         /// Add a file to be made available in all containers.
         /// </summary>
@@ -152,7 +151,6 @@ namespace Org.Apache.REEF.Client.API
             _driverConfigurationFileContents = driverConfigurationFileContents;
             return this;
         }
-
 
         /// <summary>
         /// Finds the path to the assembly the given Type was loaded from.

--- a/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-
 using System;
 using System.IO;
 using System.Linq;
@@ -172,7 +171,6 @@ namespace Org.Apache.REEF.Client.Common
         /// <param name="filePath"></param>
         /// <returns></returns>
         private static Boolean IsAssemblyToCopy(string filePath)
-
         {
             var fileName = Path.GetFileName(filePath);
             if (string.IsNullOrWhiteSpace(fileName))

--- a/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
@@ -65,7 +65,9 @@ namespace Org.Apache.REEF.Client.Common
         /// <summary>
         /// Returns http end point of the web server running in the driver
         /// </summary>
-        public string DriverUrl { get { return _driverUrl; }
+        public string DriverUrl 
+        {
+            get { return _driverUrl; }
         }
 
         /// <summary>
@@ -307,7 +309,6 @@ namespace Org.Apache.REEF.Client.Common
                     {
                         resultKind = UrlResultKind.GotAppIdUrl;
                     }
-
                 }
             }
 

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Acls.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Acls.cs
@@ -21,7 +21,6 @@ using Newtonsoft.Json.Converters;
 
 // ReSharper disable InconsistentNaming; Name kept in sync with YARN 
 // API documentation
-
 namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ApplicationFinalState.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ApplicationFinalState.cs
@@ -22,7 +22,7 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
     /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
     /// Hadoop RM REST API </see> documentation.
     /// </summary>
-    // valid values are members of the YarnApplicationState enum
+    /// valid values are members of the YarnApplicationState enum
     public enum FinalState
     {
         UNDEFINED,

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ApplicationState.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ApplicationState.cs
@@ -22,7 +22,7 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
     /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
     /// Hadoop RM REST API </see> documentation.
     /// </summary>
-    // valid values are members of the YarnApplicationState enum
+    /// valid values are members of the YarnApplicationState enum
     internal enum State
     {
         NEW,

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Commands.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Commands.cs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-
 using Newtonsoft.Json;
 
 namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/LocalResources.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/LocalResources.cs
@@ -20,7 +20,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 // ReSharper disable InconsistentNaming; Name replicates YARN REST API
-
 namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
@@ -128,7 +128,6 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
             return request;
         }
 
-
         private async Task<T> GenerateUrlAndExecuteRequestAsync<T>(IRestRequest request,
             CancellationToken cancellationToken)
             where T : new()

--- a/lang/cs/Org.Apache.REEF.Client/YARN/WindowsYarnJobCommandProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/WindowsYarnJobCommandProvider.cs
@@ -46,7 +46,6 @@ namespace Org.Apache.REEF.Client.YARN
         private readonly int _driverMaxMemoryAllocationPoolSizeMB;
         private readonly int _driverMaxPermSizeMB;
 
-
         [Inject]
         private WindowsYarnJobCommandProvider(
             [Parameter(typeof(EnableDebugLogging))] bool enableDebugLogging,

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
@@ -125,7 +125,6 @@ namespace Org.Apache.REEF.Client.Yarn
             // TODO: Remove this when we have a generalized way to pass config to java
             var paramInjector = TangFactory.GetTang().NewInjector(jobSubmission.DriverConfigurations.ToArray());
                 
-
             var avroJobSubmissionParameters = new AvroJobSubmissionParameters
             {
                 jobId = jobSubmission.JobIdentifier,

--- a/lang/cs/Org.Apache.REEF.Common/Avro/AvroHttpSerializer.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Avro/AvroHttpSerializer.cs
@@ -28,7 +28,7 @@ namespace Org.Apache.REEF.Common.Avro
     /// <summary>
     /// Class AvroHttpSerializer. Provides methods to serialize and deserialize HttpRequest
     /// </summary>
-    // TODO[REEF-842] Act on the obsoletes
+    //// TODO[REEF-842] Act on the obsoletes
     public class AvroHttpSerializer
     {
         public static AvroHttpRequest FromBytes(byte[] serializedBytes)

--- a/lang/cs/Org.Apache.REEF.Common/Files/REEFFileNames.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Files/REEFFileNames.cs
@@ -278,7 +278,10 @@ namespace Org.Apache.REEF.Common.Files
         /// </summary>
         /// <returns>File name that contains the dfs path for the DriverHttpEndpoint</returns>
         [Unstable("0.13", "Working in progress for what to return after submit")]
-        public string DriverHttpEndpoint { get { return DRIVER_HTTP_ENDPOINT_FILE_NAME; } }
+        public string DriverHttpEndpoint 
+        { 
+            get { return DRIVER_HTTP_ENDPOINT_FILE_NAME; } 
+        }
 
         private static readonly string GLOBAL_FOLDER_PATH = Path.Combine(REEF_BASE_FOLDER, GLOBAL_FOLDER);
         private static readonly string LOCAL_FOLDER_PATH = Path.Combine(REEF_BASE_FOLDER, LOCAL_FOLDER);

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextManager.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextManager.cs
@@ -102,6 +102,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
                 {
                     LOGGER.Log(Level.Info, "AddContext");
                     AddContext(controlMessage.add_context);
+
                     // support submitContextAndTask()
                     if (controlMessage.start_task != null)
                     {
@@ -313,7 +314,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
                 // does not matter if null.
                 _topContext = _topContext.ParentContext.Value;
             }
-            // System.gc(); // TODO: garbage collect?
+            //// System.gc(); // TODO: garbage collect?
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextRuntime.cs
@@ -33,8 +33,10 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
     internal sealed class ContextRuntime
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(ContextRuntime));
+
         // Context-local injector. This contains information that will not be available in child injectors.
         private readonly IInjector _contextInjector;
+
         // Service injector. State in this injector moves to child injectors.
         private readonly IInjector _serviceInjector;
 
@@ -87,6 +89,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
                 
                 Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
             }
+
             // Trigger the context start events on contextInjector.
             _contextLifeCycle.Start();
         }

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
@@ -55,6 +55,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
             catch (Exception e)
             {
                 Utilities.Diagnostics.Exceptions.Caught(e, Level.Warning, "Cannot inject task message source with error: " + e.StackTrace, Logger);
+
                 // do not rethrow since this is benign
             }
             try
@@ -253,13 +254,13 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
         public void OnNext(ICloseEvent value)
         {
             Logger.Log(Level.Info, "TaskRuntime::OnNext(ICloseEvent value)");
-            // TODO: send a heartbeat
+            //// TODO: send a heartbeat
         }
 
         public void OnNext(ISuspendEvent value)
         {
             Logger.Log(Level.Info, "TaskRuntime::OnNext(ISuspendEvent value)");
-            // TODO: send a heartbeat
+            //// TODO: send a heartbeat
         }
 
         public void OnNext(IDriverMessage value)

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStatus.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStatus.cs
@@ -116,6 +116,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                 try
                 {
                     _taskLifeCycle.Start();
+
                     // Need to send an INIT heartbeat to the driver prompting it to create an RunningTask event. 
                     LOGGER.Log(Level.Info, string.Format(CultureInfo.InvariantCulture, "Sending task INIT heartbeat"));
                     Heartbeat();

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Utils/EvaluatorConfigurations.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Utils/EvaluatorConfigurations.cs
@@ -138,6 +138,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Utils
                 return _rootContextConfiguration;
             }
         }
+
         /// <summary>
         /// The ContextConfiguration for the root context.
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/MachineStatus.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/MachineStatus.cs
@@ -124,9 +124,10 @@ namespace Org.Apache.REEF.Common.Runtime
                 }
                 catch (Exception e)
                 {
-                    _checkStatus = false; // It only takes one exception to switch the cheking off for good.
+                    _checkStatus = false; // It only takes one exception to switch the checking off for good.
                     Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Caught(e, Level.Warning, "Cannot obtain machine status due to error", Logger.GetLogger(typeof(MachineStatus)));
-                    // we do not want to crash the evealuator just because we cannot get the information.
+
+                    // we do not want to crash the evaluator just because we cannot get the information.
                     info = "Cannot obtain machine status due to error " + e.Message;
                 }
             }

--- a/lang/cs/Org.Apache.REEF.Common/Services/ServiceConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Services/ServiceConfiguration.cs
@@ -87,4 +87,3 @@ namespace Org.Apache.REEF.Common.Services
     {      
     }
 }
-

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/BridgeConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/BridgeConfigurationProvider.cs
@@ -91,6 +91,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                                           "). Loading only the one found in the legacy location.");
                 return legacyBridgeConfigurationPath;
             }
+
             // If we reached this, we weren't able to find the configuration file.
             var message = "Unable to find brigde configuration. Paths checked: ['" +
                           newBridgeConfigurationPath + "', '" +

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrSystemHandlerWrapper.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrSystemHandlerWrapper.cs
@@ -174,7 +174,6 @@ namespace Org.Apache.REEF.Driver.Bridge
                 }
                 catch (Exception ex)
                 {
-                  
                     LOGGER.Log(Level.Info, "Caught exception: " + ex.Message + ex.StackTrace);
                     Exceptions.CaughtAndThrow(ex, Level.Warning,  LOGGER);
                 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridge.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridge.cs
@@ -378,6 +378,9 @@ namespace Org.Apache.REEF.Driver.Bridge
             }
         }
 
-        internal ISet<IConfigurationProvider> ConfigurationProviders { get { return _configurationProviders; } }
+        internal ISet<IConfigurationProvider> ConfigurationProviders 
+        { 
+            get { return _configurationProviders; } 
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/AllocatedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/AllocatedEvaluator.cs
@@ -79,7 +79,6 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
                 ContextConfiguration.ConfigurationModule.Set(ContextConfiguration.Identifier, "RootContext_" + this.Id)
                     .Build();
             SubmitContextAndTask(contextConfiguration, taskConfiguration);
-
         }
         public void SubmitContext(IConfiguration contextConfiguration)
         {

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedEvaluator.cs
@@ -64,6 +64,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
         {
             get { return new List<IFailedContext>(0); }
         }
+
         // TODO[REEF-769]: Implement
         public Optional<IFailedTask> FailedTask
         {

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorDescriptorImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorDescriptorImpl.cs
@@ -159,6 +159,7 @@ namespace Org.Apache.REEF.Driver.Evaluator
             }
 
             return EquivalentMemory(other);
+
             // we don't care about rack now;
             // && string.Equals(_rack, other.Rack, StringComparison.OrdinalIgnoreCase);
         }

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorException.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorException.cs
@@ -23,7 +23,8 @@ using Org.Apache.REEF.Utilities;
 
 namespace Org.Apache.REEF.Driver.Evaluator
 {
-    // Public only such that it can be used in the bridge.
+    //// Public only such that it can be used in the bridge.
+
     /// <summary>
     /// </summary>
     public sealed class EvaluatorException : Exception, IIdentifiable

--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/EvaluatorConfigurationsTests.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/EvaluatorConfigurationsTests.cs
@@ -43,7 +43,6 @@ namespace Org.Apache.REEF.Evaluator.Tests
         private const string RemoteIdPrefix = "socket://";
         private const string AppIdForTest = "REEF_LOCAL_RUNTIME";
 
-
         [TestMethod, Priority(0), TestCategory("Unit")]
         public void TestEvaluatorConfigurations()
         {

--- a/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
@@ -197,7 +197,6 @@ namespace Org.Apache.REEF.Evaluator
                 "Evaluator heartbeat max retry set to be " + heartbeatMaxRetry + " times.");
         }
 
-
         /// <summary>
         /// Instantiates the root injector of the Evaluator.
         /// </summary>
@@ -267,6 +266,7 @@ namespace Org.Apache.REEF.Evaluator
             catch (Exception e)
             {
                 Utilities.Diagnostics.Exceptions.Caught(e, Level.Error, logger);
+
                 // custom trace listener not set properly, use empty set
                 customTraceListeners = new HashSet<TraceListener>();
             }

--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/HelloFailedEvaluatorHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/HelloFailedEvaluatorHandler.cs
@@ -53,7 +53,6 @@ namespace Org.Apache.REEF.Examples.AllHandlers
                 var newRequest =
                     _evaluatorRequestor.NewBuilder().SetNumber(1).SetMegabytes(512).SetRackName("somerack").Build();
                 _evaluatorRequestor.Submit(newRequest);
-
             }
             else
             {

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
@@ -58,6 +58,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
                 .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<HelloDriver>.Class)
                 .Set(DriverConfiguration.OnDriverStarted, GenericType<HelloDriver>.Class)
                 .Build();
+
             // The JobSubmission contains the Driver configuration as well as the files needed on the Driver.
             var helloJobSubmission = _jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
                 .AddDriverConfiguration(helloDriverConfiguration)

--- a/lang/cs/Org.Apache.REEF.Examples/DriverRestart/HelloRestartDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/DriverRestart/HelloRestartDriver.cs
@@ -145,7 +145,6 @@ namespace Org.Apache.REEF.Examples.DriverRestart
                 Logger.Log(Level.Info, "{0} running task with ID [{1}] from evaluator with ID [{2}]",
                     _evaluators[evaluatorId], value.Id, evaluatorId);
 
-
                 if (_evaluators[evaluatorId] == EvaluatorState.Expected)
                 {
                     value.Send(Encoding.UTF8.GetBytes("Hello from driver!"));
@@ -156,6 +155,7 @@ namespace Org.Apache.REEF.Examples.DriverRestart
                     _evaluators[evaluatorId] = EvaluatorState.NewRunning;
 
                     var newRunningCount = CountState(EvaluatorState.NewRunning);
+
                     // Kill itself in order for the driver to restart it.
                     if (!_isRestart && newRunningCount == NumberOfTasksToSubmit)
                     {

--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/DataVector.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/DataVector.cs
@@ -92,9 +92,11 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
         public static List<DataVector> ShuffleDataAndGetInitialCentriods(string originalDataFile, int partitionsNum, int clustersNum, string executionDirectory)
         {
             List<DataVector> data = DataPartitionCache.ReadDataFile(originalDataFile);
-            // shuffle, not truely random, but sufficient for our purpose
+
+            // shuffle, not truly random, but sufficient for our purpose
             data = data.OrderBy(a => Guid.NewGuid()).ToList();
             string dataDirectory = Path.Combine(executionDirectory, Constants.DataDirectory);
+
             // clean things up first
             if (Directory.Exists(dataDirectory))
             {

--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansDriverHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansDriverHandlers.cs
@@ -175,6 +175,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
             else
             {
                 string slaveTaskId = Constants.SlaveTaskIdPrefix + activeContext.Id;
+
                 // Configure Slave Task
                 taskConfiguration = TaskConfiguration.ConfigurationModule
                     .Set(TaskConfiguration.Identifier, Constants.SlaveTaskIdPrefix + activeContext.Id)

--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansSlaveTask.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansSlaveTask.cs
@@ -66,6 +66,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
                     break;
                 }
                 Centroids centroids = _dataBroadcastReceiver.Receive();
+
                 // we compute the loss here before data is relabled, this does not reflect the latest clustering result at the end of current iteration, 
                 // but it will save another round of group communications in each iteration
                 _logger.Log(Level.Info, "Received centroids from master: " + centroids);

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
@@ -177,7 +177,6 @@ namespace Org.Apache.REEF.IMRU.Examples
                 default:
                     Logger.Log(Level.Info, "wrong test name");
                     return;
-
             }
         }
     }

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinition.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinition.cs
@@ -187,7 +187,8 @@ namespace Org.Apache.REEF.IMRU.API
         /// TODO: automatically from IPartitionedDataset. However, right now 
         /// TODO: GroupComm. instantiated in IMRUDriver needs this parameter 
         /// TODO: in constructor. This will be removed once we remove it from GroupComm. 
-        internal int NumberOfMappers {
+        internal int NumberOfMappers 
+        {
             get { return _numberOfMappers; }
         }
 
@@ -206,7 +207,6 @@ namespace Org.Apache.REEF.IMRU.API
         {
             get { return _updateTaskMemory; }
         }
-
 
         /// <summary>
         /// Cores for each mapper

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
@@ -271,7 +271,6 @@ namespace Org.Apache.REEF.IMRU.API
             return this;
         }
 
-
         /// <summary>
         /// Instantiate the IMRUJobDefinition.
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/API/PerMapConfigGeneratorSet.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/PerMapConfigGeneratorSet.cs
@@ -1,23 +1,21 @@
-﻿#region LICENSE
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-#endregion
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 using System.Collections.Generic;
 using Org.Apache.REEF.Tang.Annotations;

--- a/lang/cs/Org.Apache.REEF.IMRU/InProcess/MapFunctions.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/InProcess/MapFunctions.cs
@@ -27,7 +27,7 @@ namespace Org.Apache.REEF.IMRU.InProcess
     /// </summary>
     /// <typeparam name="TMapInput"></typeparam>
     /// <typeparam name="TMapOutput"></typeparam>
-    // This is needed as Tang doesn't support BindVolatile into a Set.
+    /// This is needed as Tang doesn't support BindVolatile into a Set.
     internal sealed class MapFunctions<TMapInput, TMapOutput>
     {
         private readonly ISet<IMapFunction<TMapInput, TMapOutput>> _mappers;

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ContextAndServiceConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ContextAndServiceConfiguration.cs
@@ -41,6 +41,5 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             Context = context;
             Service = service;
         }
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -130,7 +130,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         public void OnNext(IDriverStarted value)
         {
             RequestUpdateEvaluator();
-            // TODO[REEF-598]: Set a timeout for this request to be satisfied. If it is not within that time, exit the Driver.
+            //// TODO[REEF-598]: Set a timeout for this request to be satisfied. If it is not within that time, exit the Driver.
         }
 
         /// <summary>
@@ -244,7 +244,10 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         {
             _completedTasks.Add(completedTask);
 
-            if (_completedTasks.Count != _dataSet.Count + 1) return;
+            if (_completedTasks.Count != _dataSet.Count + 1)
+            {
+                return;
+            }
             
             foreach (var task in _completedTasks)
             {

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/CoresForUpdateTask.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/CoresForUpdateTask.cs
@@ -1,23 +1,21 @@
-﻿#region LICENSE
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-#endregion
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 using Org.Apache.REEF.Tang.Annotations;
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/CoresPerMapper.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/CoresPerMapper.cs
@@ -1,23 +1,21 @@
-﻿#region LICENSE
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-#endregion
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 using Org.Apache.REEF.Tang.Annotations;
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/MemoryForUpdateTask.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/MemoryForUpdateTask.cs
@@ -1,23 +1,21 @@
-﻿#region LICENSE
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-#endregion
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 using Org.Apache.REEF.Tang.Annotations;
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/MemoryPerMapper.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/MemoryPerMapper.cs
@@ -1,23 +1,21 @@
-﻿#region LICENSE
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-#endregion
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 using Org.Apache.REEF.Tang.Annotations;
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/SerializedMapInputPipelineDataConverterConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/SerializedMapInputPipelineDataConverterConfiguration.cs
@@ -1,23 +1,21 @@
-﻿#region LICENSE
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-#endregion
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 using Org.Apache.REEF.Tang.Annotations;
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/SerializedMapOutputPipelineDataConverterConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/SerializedMapOutputPipelineDataConverterConfiguration.cs
@@ -1,23 +1,21 @@
-﻿#region LICENSE
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-#endregion
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 using Org.Apache.REEF.Tang.Annotations;
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/SerializedReduceConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/SerializedReduceConfiguration.cs
@@ -1,23 +1,21 @@
-﻿#region LICENSE
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-#endregion
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 using Org.Apache.REEF.Tang.Annotations;
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/SerializedUpdateConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/SerializedUpdateConfiguration.cs
@@ -1,23 +1,21 @@
-﻿#region LICENSE
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-#endregion
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 using Org.Apache.REEF.Tang.Annotations;
 

--- a/lang/cs/Org.Apache.REEF.IMRU/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/Properties/AssemblyInfo.cs
@@ -32,6 +32,7 @@ using System.Runtime.InteropServices;
 [assembly: Guid("138891df-d331-4a5e-8514-775611c06f6c")]
 [assembly: AssemblyVersion("0.14.0.0")]
 [assembly: AssemblyFileVersion("0.14.0.0")]
+
 // Allow the tests project access to `internal` APIs
 [assembly: InternalsVisibleTo("Org.Apache.REEF.IMRU.Tests, publickey=" +
  "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +

--- a/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileInputPartitionTest.cs
+++ b/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileInputPartitionTest.cs
@@ -116,7 +116,9 @@ namespace Org.Apache.REEF.IO.TestClient
             using (var s = File.Create(filePath))
             {
                 foreach (var b in bytes)
+                {
                     s.WriteByte(b);
+                }
             }
         }
 
@@ -139,7 +141,8 @@ namespace Org.Apache.REEF.IO.TestClient
     {
         [Inject]
         private ByteSerializer()
-        { }
+        { 
+        }
 
         /// <summary>
         /// Read bytes from all the files in the file folder and return one by one

--- a/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileSystemTest.cs
+++ b/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileSystemTest.cs
@@ -59,7 +59,6 @@ namespace Org.Apache.REEF.IO.TestClient
             var remoteUri = GetTempUri();
             Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "remoteUri {0}: ", remoteUri.AbsolutePath));
 
-
             _fileSystem.CopyFromLocal(localFile, remoteUri);
             Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "File CopyFromLocal {0}: ", remoteUri));
 

--- a/lang/cs/Org.Apache.REEF.IO.TestClient/Run.cs
+++ b/lang/cs/Org.Apache.REEF.IO.TestClient/Run.cs
@@ -22,7 +22,8 @@ using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.IO.TestClient
 {
-    // TODO[JIRA REEF-815]: once move to Nunit, tose test should be moved to Test project
+    //// TODO[JIRA REEF-815]: once move to Nunit, tose test should be moved to Test project
+
     /// <summary>
     /// This purpose of this test is to run tests in Yarn envionment
     /// 
@@ -68,6 +69,8 @@ namespace Org.Apache.REEF.IO.TestClient
 
     public class AssertFailedException : Exception
     {
-        public AssertFailedException(string message) : base(message) { }
+        public AssertFailedException(string message) : base(message) 
+        { 
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystemE2E.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystemE2E.cs
@@ -156,8 +156,6 @@ namespace Org.Apache.REEF.IO.Tests
             }
         }
 
-        
-
         [TestMethod]
         public void TestDeleteDirectoryAtContainerE2E()
         {

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
@@ -232,7 +232,9 @@ namespace Org.Apache.REEF.IO.Tests
             using (var s = File.Create(filePath))
             {
                 foreach (var b in bytes)
+                {
                     s.WriteByte(b);
+                }
             }
         }
 
@@ -261,7 +263,8 @@ namespace Org.Apache.REEF.IO.Tests
     {
         [Inject]
         public ByteSerializer()
-        { }
+        { 
+        }
 
         /// <summary>
         /// Enumerate all the files in the file foder and return each byte read
@@ -303,7 +306,8 @@ namespace Org.Apache.REEF.IO.Tests
     {
         [Inject]
         private RowSerializer()
-        { }
+        { 
+        }
 
         /// <summary>
         /// read all the files in the fileFolder cand return byte read one by one

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
@@ -104,13 +104,16 @@ namespace Org.Apache.REEF.IO.Tests
             // Make a directory
             var remoteDirectory = GetTempUri();
             _fileSystem.CreateDirectory(remoteDirectory);
+
             // Check that it is empty
             Assert.AreEqual(message: "The directory should be empty.", expected: 0,
                 actual: _fileSystem.GetChildren(remoteDirectory).Count());
+
             // Upload some localfile there
             var localTempFile = FileSystemTestUtilities.MakeLocalTempFile();
             var remoteUri = new Uri(remoteDirectory, Path.GetFileName(localTempFile));
             _fileSystem.CopyFromLocal(localTempFile, remoteUri);
+
             // Check that it is on the listing
             var uriInResult = _fileSystem.GetChildren(remoteUri).First();
             Assert.AreEqual(remoteUri, uriInResult);
@@ -124,9 +127,11 @@ namespace Org.Apache.REEF.IO.Tests
 
             // Delete the file
             _fileSystem.Delete(remoteUri);
+
             // Check that the folder is empty again
             Assert.AreEqual(message: "The directory should be empty.", expected: 0,
                 actual: _fileSystem.GetChildren(remoteDirectory).Count());
+
             // Delete the folder
             _fileSystem.DeleteDirectory(remoteDirectory);
         }

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestLocalFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestLocalFileSystem.cs
@@ -25,7 +25,6 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 
 namespace Org.Apache.REEF.IO.Tests
 {
-
     /// <summary>
     /// Tests for Org.Apache.REEF.IO.FileSystem.Local.LocalFileSystem
     /// </summary>
@@ -39,7 +38,6 @@ namespace Org.Apache.REEF.IO.Tests
         public void TestCreateAndOpenAndDelete()
         {
             var fs = GetFileSystem();
-
 
             // Create a temp file
             var tempFilePath = Path.Combine(Path.GetTempPath(), TempFileName);

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlockBlobFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlockBlobFileSystem.cs
@@ -174,7 +174,8 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
                 }
 
                 blobContinuationToken = listing.ContinuationToken;
-            } while (blobContinuationToken != null);
+            } 
+            while (blobContinuationToken != null);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobClient.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobClient.cs
@@ -32,7 +32,10 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
     {
         private readonly CloudBlobClient _client;
 
-        public StorageCredentials Credentials { get { return _client.Credentials; } }
+        public StorageCredentials Credentials 
+        { 
+            get { return _client.Credentials; } 
+        }
 
         [Inject]
         private AzureCloudBlobClient([Parameter(typeof(AzureStorageConnectionString))] string connectionString,

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HDFSCommandRunner.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HDFSCommandRunner.cs
@@ -221,6 +221,7 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
                     errList.Add(e.Data.Trim());
                 }
             };
+
             // Start it
             process.Start();
             process.BeginErrorReadLine();

--- a/lang/cs/Org.Apache.REEF.IO/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.IO/Properties/AssemblyInfo.cs
@@ -33,6 +33,7 @@ using System.Runtime.InteropServices;
 [assembly: Guid("58c49df4-8dc0-4f58-9a7e-a341d33e40ee")]
 [assembly: AssemblyVersion("0.14.0.0")]
 [assembly: AssemblyFileVersion("0.14.0.0")]
+
 // Allow the tests project access to `internal` APIs
 [assembly: InternalsVisibleTo("Org.Apache.REEF.IO.Tests, publickey=" +
  "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
@@ -44,6 +45,7 @@ using System.Runtime.InteropServices;
  "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
  "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
  "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
+
 // Allow NSubstitute to create proxy implementations
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=002400000480000" +
  "0940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a36" +

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/BroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/BroadcastReduceDriver.cs
@@ -86,7 +86,6 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
                     portRange.ToString(CultureInfo.InvariantCulture))
                 .Build();
 
-
             _codecConfig = StreamingCodecConfiguration<int>.Conf
                 .Set(StreamingCodecConfiguration<int>.Codec, GenericType<IntStreamingCodec>.Class)
                 .Build();

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/MasterTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/MasterTask.cs
@@ -70,11 +70,13 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
                 }
 
                 broadcastTime.Start();
+
                 // Each slave task calculates the nth triangle number
                 _broadcastSender.Send(i);
                 broadcastTime.Stop();
 
                 reduceTime.Start();
+
                 // Sum up all of the calculated triangle numbers
                 int sum = _sumReducer.Reduce();
                 reduceTime.Stop();

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/SlaveTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/SlaveTask.cs
@@ -59,6 +59,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
             for (int i = 0; i < _numIterations; i++)
             {
                 broadcastTime.Start();
+
                 // Receive n from Master Task
                 int n = _broadcastReceiver.Receive();
                 broadcastTime.Stop();

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedSlaveTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedSlaveTask.cs
@@ -75,6 +75,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
                 }
 
                 broadcastTime.Start();
+
                 // Receive n from Master Task
                 int[] intVec = _broadcastReceiver.Receive();
                 broadcastTime.Stop();

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
@@ -181,7 +181,6 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             Assert.Equal(value3, receiver9.Receive());
         }
 
-
         [Fact]
         public void TestBroadcastReduceOperators()
         {

--- a/lang/cs/Org.Apache.REEF.Network.Tests/NetworkService/StreamingNetworkServiceTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/NetworkService/StreamingNetworkServiceTests.cs
@@ -300,6 +300,7 @@ namespace Org.Apache.REEF.Network.Tests.NetworkService
                 await writer.WriteStringAsync(obj.Value2, token);
             }
         } 
+
         /// <summary>
         /// The observer to handle incoming messages for string
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/IGroupCommDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/IGroupCommDriver.cs
@@ -35,7 +35,6 @@ namespace Org.Apache.REEF.Network.Group.Driver
 
         ICommunicationGroupDriver DefaultGroup { get; }
 
-
         /// <summary>
         /// Create a new CommunicationGroup with the given name and number of tasks/operators. 
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
@@ -30,7 +30,6 @@ using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
 
-
 namespace Org.Apache.REEF.Network.Group.Driver.Impl
 {
     /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommDriver.cs
@@ -59,7 +59,6 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         private readonly Dictionary<string, ICommunicationGroupDriver> _commGroups;
         private readonly AvroConfigurationSerializer _configSerializer;
 
-
         /// <summary>
         /// Create a new GroupCommunicationDriver object.
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/IOperatorSpec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/IOperatorSpec.cs
@@ -25,7 +25,7 @@ namespace Org.Apache.REEF.Network.Group.Operators
     /// <summary>
     /// The specification used to define Broadcast Operators.
     /// </summary>
-    // TODO[REEF-842] Act on the obsoletes
+    //// TODO[REEF-842] Act on the obsoletes
     public interface IOperatorSpec
     {
         [Obsolete("Deprecated in 0.14, please use Configuration instead.")]

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastOperatorSpec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastOperatorSpec.cs
@@ -54,6 +54,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
             get { return Configuration; }
             private set { Configuration = value; }
         }
+
         /// <summary>
         /// Returns the Configuration for Codec, ReduceFunction and DataConverter
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
@@ -109,7 +109,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
                 }
 
                 messageList.Add(message);
-            } while (!message.IsLast);
+            } 
+            while (!message.IsLast);
 
             return PipelineDataConverter.FullMessage(messageList);
         }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceOperatorSpec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceOperatorSpec.cs
@@ -55,7 +55,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// Returns the Configuration for Codec, ReduceFunction and DataConverter
         /// </summary>
         [Obsolete("Deprecated in 0.14, please use Configuration instead.")]
-        public IConfiguration Configiration {
+        public IConfiguration Configiration 
+        {
             get { return Configuration; }
             private set { Configuration = value; }
         }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceReceiver.cs
@@ -116,7 +116,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
             {
                 message = _topology.ReceiveFromChildren(_pipelinedReduceFunc);
                 messageList.Add(message);
-            } while (!message.IsLast);
+            } 
+            while (!message.IsLast);
 
             return PipelineDataConverter.FullMessage(messageList);
         }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/IPipelineDataConverter.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/IPipelineDataConverter.cs
@@ -24,13 +24,12 @@ using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.Network.Group.Pipelining
 {
-
     /// <summary>
     /// User specified class to convert the message to be communicated in to pipelining 
     /// amenable data and vice-versa 
     /// </summary>
     /// <typeparam name="T">The message type</typeparam>
-    // [DefaultImplementation(typeof(DefaultPipelineDataConverter<>))]
+    //// [DefaultImplementation(typeof(DefaultPipelineDataConverter<>))]
     public interface IPipelineDataConverter<T>
     {
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/Impl/DefaultPipelineDataConverter.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/Impl/DefaultPipelineDataConverter.cs
@@ -22,10 +22,8 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Annotations;
 
-
 namespace Org.Apache.REEF.Network.Group.Pipelining.Impl
 {
-
     /// <summary>
     /// Default IPipelineDataConverter implementation
     /// This basically is a non-pipelined implementation that just packs the whole message in one single PipelineMessage

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupNetworkObserver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupNetworkObserver.cs
@@ -100,7 +100,6 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
                 Exceptions.Throw(new ApplicationException("No handler registered yet with the operator name: " + operatorName), LOGGER);
             }
             return handler;
-
         }
 
         public void OnError(Exception error)

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/NodeStruct.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/NodeStruct.cs
@@ -23,7 +23,6 @@ using Org.Apache.REEF.Network.Group.Driver.Impl;
 
 namespace Org.Apache.REEF.Network.Group.Task.Impl
 {
-
     /// <summary>
     /// Stores all incoming messages sent by a particular Task.
     /// Writable version

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
@@ -406,7 +406,6 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
                 }
 
                 return new NodeStruct<T>[] { potentialNode };
-
             }
             catch (OperationCanceledException)
             {

--- a/lang/cs/Org.Apache.REEF.Network/Group/Topology/TaskNode.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Topology/TaskNode.cs
@@ -76,7 +76,8 @@ namespace Org.Apache.REEF.Network.Group.Topology
             _children.Add(child);
         }
 
-        public int GetNumberOfChildren() {
+        public int GetNumberOfChildren() 
+        {
             return _children.Count;
         }
 

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/CheckChild.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/CheckChild.cs
@@ -28,6 +28,8 @@ namespace Org.Apache.REEF.Tang.Examples
     public class CheckChildImpl : CheckChildIface
     {
         [Inject]
-        public CheckChildImpl() { }
+        public CheckChildImpl() 
+        { 
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/ForksInjectorInConstructor.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/ForksInjectorInConstructor.cs
@@ -47,7 +47,7 @@ namespace Org.Apache.REEF.Tang.Examples
         public ForksInjectorInConstructor(IInjector i)
         {
             ICsConfigurationBuilder cb = TangFactory.GetTang().NewConfigurationBuilder(new string[] { @"Org.Apache.REEF.Tang.Examples" });
-            // cb.BindImplementation(Number.class, typeof(Int32));
+            //// cb.BindImplementation(Number.class, typeof(Int32));
             i.ForkInjector(cb.Build());
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/SimpleConstructors.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/SimpleConstructors.cs
@@ -38,6 +38,5 @@ namespace Org.Apache.REEF.Tang.Examples
         public SimpleConstructors(int x, String y) 
         {
         }
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/TestClasses.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/TestClasses.cs
@@ -23,14 +23,15 @@ namespace Org.Apache.REEF.Tang.Examples
 {
     public interface A
     {
-
     }
 
     public class B : A
     {
         public class B1
         {
-            public class B2 { }
+            public class B2 
+            { 
+            }
         }
     }
 

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/Timer.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/Timer.cs
@@ -26,7 +26,9 @@ namespace Org.Apache.REEF.Tang.Examples
     public class Timer
     {
         [NamedParameter("Number of seconds to sleep", "sec", "10")]
-        public class Seconds : Name<Int32> { }
+        public class Seconds : Name<Int32> 
+        { 
+        }
         private readonly int seconds;
 
         [Inject]

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/TweetExample.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/TweetExample.cs
@@ -35,7 +35,8 @@ namespace Org.Apache.REEF.Tang.Examples
     public class MockTweetFactory : ITweetFactory 
     {
         [Inject]
-        public MockTweetFactory() {
+        public MockTweetFactory() 
+        {
         }
 
         public String GetTweet() 
@@ -57,6 +58,7 @@ namespace Org.Apache.REEF.Tang.Examples
             {
                 throw new ArgumentException("Unknown recipient");
             }
+
             // success!
         }
     }
@@ -68,7 +70,9 @@ namespace Org.Apache.REEF.Tang.Examples
         readonly long phoneNumber;
 
         [NamedParameter(Documentation = "Phone number", ShortName = "number", DefaultValue = "1800")]
-        public class PhoneNumber : Name<long> { }
+        public class PhoneNumber : Name<long>
+        { 
+        }
         [Inject]
         public Tweeter(ITweetFactory tw, ISMS sms, [Parameter(typeof(PhoneNumber))] long phoneNumber)
         {

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
@@ -74,7 +74,6 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             }
             catch (NameResolutionException)
             {
-
             }
             Assert.True(msg == null, msg);
         }
@@ -108,7 +107,6 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             }
             catch (NameResolutionException)
             {
-
             }
             Assert.True(msg == null, msg);        
         }
@@ -128,7 +126,6 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             IClassNode timerClassNode = (IClassNode)ns.GetNode(typeof(Timer).AssemblyQualifiedName);
             INode secondNode = ns.GetNode(typeof(Timer.Seconds).AssemblyQualifiedName);
             Assert.Equal(secondNode.GetFullName(), ReflectionUtilities.GetAssemblyQualifiedName(typeof(Timer.Seconds)));
-
         }
 
         [Fact]
@@ -310,7 +307,6 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             "class org.apache.reef.tang.implementation.BadName defines a default class Int32 with a type that does not extend of its target's type string");
         }
 
-
         [Fact]
         public void TestNameCantBindWrongSubclassOfArgumentAsDefault()
         {
@@ -437,7 +433,8 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
     }
 
     [NamedParameter]
-    class GenericTorture1 : Name<ISet<string>> {
+    class GenericTorture1 : Name<ISet<string>> 
+    {
     }
     [NamedParameter]
     class GenericTorture2 : Name<ISet<ISet<string>>>
@@ -454,7 +451,6 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
 
     public interface MyInterface<T>
     {
-
     }
 
     public class RepeatConstructorArg
@@ -513,7 +509,6 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
     }
     public class LeafRepeatedConstructorArgClasses
     {
-
         public static class A
         {
             public class AA
@@ -571,7 +566,8 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         }
     }
 
-    class UnannotatedName : Name<string> {
+    class UnannotatedName : Name<string> 
+    {
     }
 
     interface I1 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestParameterParser.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestParameterParser.cs
@@ -34,7 +34,6 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         {
             var parser = new ParameterParser();
             Int32 o = (Int32)parser.Parse(typeof(Int32), "4");
-
         }
 
         [Fact]
@@ -240,15 +239,22 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         class Foo
         {
             public readonly string s;
-            public Foo(string s) { this.s = s; }
+            public Foo(string s) 
+            { 
+                this.s = s; 
+            }
         }
         class Bar : Foo
         {
-            public Bar(string s) : base(s) { }
+            public Bar(string s) : base(s) 
+            { 
+            }
         }
 
         [NamedParameter]
-        class SomeNamedFoo : Name<Foo> { }
+        class SomeNamedFoo : Name<Foo> 
+        { 
+        }
 
         class ILikeBars
         {
@@ -278,8 +284,14 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             [Inject]
             public TypeParser(String s)
             {
-                if (s.Equals("a")) { instance = new ParseTypeA(); }
-                if (s.Equals("b")) { instance = new ParseTypeB(); }
+                if (s.Equals("a")) 
+                { 
+                    instance = new ParseTypeA(); 
+                }
+                if (s.Equals("b")) 
+                { 
+                    instance = new ParseTypeB(); 
+                }
             }
 
             public ParseableType NewInstance()

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Configuration/TestConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Configuration/TestConfiguration.cs
@@ -241,7 +241,6 @@ namespace Org.Apache.REEF.Tang.Tests.Configuration
             tweeter.sendMessage();
         }
 
-
         [Fact]
         public void TestTweetConfigWithAvroThroughFile()
         {

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/SmokeTest/RootImplementation.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/SmokeTest/RootImplementation.cs
@@ -31,7 +31,7 @@ namespace Org.Apache.REEF.Tang.Tests.SmokeTest
         private readonly InjectableClass injectableClass;
         private readonly SetOfImplementations setOfImplementations;
         private readonly SetOfBaseTypes setOfBaseTypes;
-        // private readonly ListOfBaseTypes listOfBaseTypes;  // TODO: to recover once Avro NuGet support it
+        //// private readonly ListOfBaseTypes listOfBaseTypes;  // TODO: to recover once Avro NuGet support it
         private readonly CyclicDependency cyclicDependency;
 
         [Inject]
@@ -43,7 +43,7 @@ namespace Org.Apache.REEF.Tang.Tests.SmokeTest
                                   InjectableClass injectableClass,
                                   SetOfImplementations setOfImplementations,
                                   SetOfBaseTypes setOfBaseTypes,
-                                  // ListOfBaseTypes listOfBaseTypes, // TODO: to recover once Avro NuGet support it
+                                  //// ListOfBaseTypes listOfBaseTypes, // TODO: to recover once Avro NuGet support it
                                   CyclicDependency cyclicDependency) 
         {
                                 this.requiredString = requiredString;
@@ -54,7 +54,7 @@ namespace Org.Apache.REEF.Tang.Tests.SmokeTest
                                 this.injectableClass = injectableClass;
                                 this.setOfImplementations = setOfImplementations;
                                 this.setOfBaseTypes = setOfBaseTypes;
-                                // this.listOfBaseTypes = listOfBaseTypes;  // TODO: to recover once Avro NuGet support it
+                                //// this.listOfBaseTypes = listOfBaseTypes;  // TODO: to recover once Avro NuGet support it
                                 this.cyclicDependency = cyclicDependency;
         }
 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Tang/TestLegacyConstructors.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Tang/TestLegacyConstructors.cs
@@ -43,7 +43,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             constructorArg.Add(ReflectionUtilities.GetAssemblyQualifiedName(typeof(int)));
             constructorArg.Add(ReflectionUtilities.GetAssemblyQualifiedName(typeof(string)));
             cb.RegisterLegacyConstructor(ReflectionUtilities.GetAssemblyQualifiedName(typeof(LegacyConstructor)), constructorArg);
-            // cb.Bind(typeof(LegacyConstructor), typeof(LegacyConstructor));
+            //// cb.Bind(typeof(LegacyConstructor), typeof(LegacyConstructor));
             cb.BindImplementation(GenericType<LegacyConstructor>.Class, GenericType<LegacyConstructor>.Class);
 
             IInjector i = tang.NewInjector(cb.Build());

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Tang/TestTang.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Tang/TestTang.cs
@@ -81,7 +81,6 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             }
             catch (InjectionException)
             {
-
             }
             Assert.IsNull(obj);
         }
@@ -140,7 +139,6 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             OneNamedSingletonArgs o = i.GetInstance<OneNamedSingletonArgs>();
             Assert.IsNotNull(o);
         }
-
 
         [TestMethod]
         public void TestRepeatedNamedArgs()
@@ -392,7 +390,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         {
             IInjector i = TangFactory.GetTang().NewInjector();
             var ii = (InjectInjector)i.GetInstance(typeof(InjectInjector));
-            // Assert.IsTrue(ii.i is IInjector);
+            //// Assert.IsTrue(ii.i is IInjector);
             Assert.AreNotSame(i, ii.i);
         }
 
@@ -524,7 +522,8 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             {
                 i.GetInstance<Fail>();
                 Assert.Fail("Injecting Fail should not have worked!");
-            } catch (InjectionException) 
+            } 
+            catch (InjectionException) 
             {
                  i.GetInstance<Pass>();
             }
@@ -876,13 +875,19 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         public float f;
 
         [NamedParameter]
-        public class TCInt : Name<Int32> { }
+        public class TCInt : Name<Int32> 
+        { 
+        }
 
         [NamedParameter]
-        public class TCString : Name<string> { }
+        public class TCString : Name<string> 
+        { 
+        }
 
         [NamedParameter]
-        public class TCFloat : Name<float> { }
+        public class TCFloat : Name<float> 
+        { 
+        }
 
         [Inject]
         public ThreeConstructors([Parameter(typeof(TCInt))] int i, [Parameter(typeof(TCString))] string s) 
@@ -917,11 +922,14 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         public string s;
 
         [NamedParameter]
-        public class TCInt : Name<Int32> { }
+        public class TCInt : Name<Int32> 
+        { 
+        }
 
         [NamedParameter]
-        public class TCString : Name<string> { }
-
+        public class TCString : Name<string> 
+        { 
+        }
 
         [Inject]
         public TwoConstructors([Parameter(typeof(TCInt))] int i, [Parameter(typeof(TCString))] string s)
@@ -938,21 +946,31 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         }
     }
 
-    interface SMC { }
+    interface SMC 
+    { 
+    }
 
     class SingletonMultiConst : SMC 
     {
         [NamedParameter]
-        public class A : Name<string> { }
+        public class A : Name<string> 
+        { 
+        }
   
         [NamedParameter]
-        public class B : Name<string> { }
+        public class B : Name<string> 
+        { 
+        }
   
         [Inject]
-        public SingletonMultiConst([Parameter(typeof(A))] String a) { }
+        public SingletonMultiConst([Parameter(typeof(A))] String a) 
+        { 
+        }
         
         [Inject]
-        public SingletonMultiConst([Parameter(typeof(A))] string a, [Parameter(typeof(B))] string b) { }
+        public SingletonMultiConst([Parameter(typeof(A))] string a, [Parameter(typeof(B))] string b) 
+        { 
+        }
     }
 
     internal class ABCName
@@ -966,25 +984,25 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         {
         }
 
-        // [NamedParameter(DefaultClass = typeof(XAA))]
-        // public class XNameDA : Name<X<BB>>
-        // {
-        // }
+        //// [NamedParameter(DefaultClass = typeof(XAA))]
+        //// public class XNameDA : Name<X<BB>>
+        //// {
+        //// }
 
         [NamedParameter(DefaultClass = typeof(XBB))]
         public class XNameDB : Name<X<BB>>
         {
         }
 
-        // [NamedParameter(DefaultClass = typeof(XCC))]
-        // public class XNameDC : Name<X<BB>>
-        // {
-        // }
+        //// [NamedParameter(DefaultClass = typeof(XCC))]
+        //// public class XNameDC : Name<X<BB>>
+        //// {
+        //// }
 
-        // [NamedParameter(DefaultClass = typeof(XCC))]
-        // public class XNameDAA : Name<XBB>
-        // {
-        // }
+        //// [NamedParameter(DefaultClass = typeof(XCC))]
+        //// public class XNameDAA : Name<XBB>
+        //// {
+        //// }
 
         [NamedParameter(DefaultClass = typeof(XXBB))]
         public class XNameDDAA : Name<XBB>
@@ -1053,8 +1071,8 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         }
     }
 
-    interface Bottle<Y> {
-  
+    interface Bottle<Y> 
+    {  
     }
     class WaterBottle : Bottle<Water> 
     {  
@@ -1062,77 +1080,116 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
     class GasCan : Bottle<Gas> 
     {  
     }
-    class Water { }
-    class Gas { }
+    class Water 
+    { 
+    }
+    class Gas 
+    { 
+    }
 
     [NamedParameter(DefaultClass = typeof(GasCan))]
-    class WaterBottleName : Name<Bottle<Water>> { }
+    class WaterBottleName : Name<Bottle<Water>> 
+    { 
+    }
 
-    interface IEventHandler<T> { }
+    interface IEventHandler<T> 
+    { 
+    }
     class MyEventHandler<T> : IEventHandler<T> 
     { 
         [Inject]
-        MyEventHandler() { }
+        MyEventHandler() 
+        { 
+        }
     }
 
     [DefaultImplementation(typeof(MyEventHandler<Foo>))]
-    interface MyEventHandlerIface : IEventHandler<Foo> { }
+    interface MyEventHandlerIface : IEventHandler<Foo> 
+    { 
+    }
 
     [NamedParameter(DefaultClass = typeof(MyEventHandler<Foo>))]
-    class FooEventHandler : Name<IEventHandler<Foo>> { }
+    class FooEventHandler : Name<IEventHandler<Foo>> 
+    { 
+    }
 
     internal class Foo : Name<String>
     {
     }
 
-    interface SomeIface { }
+    interface SomeIface 
+    { 
+    }
+
     [NamedParameter(DefaultClass = typeof(MyEventHandler<SomeIface>))]
-    class IfaceEventHandler : Name<IEventHandler<SomeIface>> { }
+    class IfaceEventHandler : Name<IEventHandler<SomeIface>> 
+    { 
+    }
 
     class AH
     {
         [Inject]
-        AH() { }
+        AH() 
+        { 
+        }
     }
     class BH
     {
         [Inject]
-        BH() { }
+        BH() 
+        { 
+        }
     }
 
     [DefaultImplementation(typeof(AHandlerImpl))]
-    interface IAHandler : IEventHandler<AH> { }
+    interface IAHandler : IEventHandler<AH> 
+    { 
+    }
 
     [DefaultImplementation(typeof(BHandlerImpl))]
-    interface IBHandler : IEventHandler<BH> { }
+    interface IBHandler : IEventHandler<BH> 
+    { 
+    }
 
     class AHandlerImpl : IAHandler
     {
         [Inject]
-        public AHandlerImpl() { }
+        public AHandlerImpl() 
+        { 
+        }
     }
     class BHandlerImpl : IBHandler 
     {
         [Inject]
-        public BHandlerImpl() { }
+        public BHandlerImpl() 
+        { 
+        }
     }
 
     class WantSomeHandlers 
     {
         [Inject]
-        WantSomeHandlers(IAHandler a, IBHandler b) { }
+        WantSomeHandlers(IAHandler a, IBHandler b) 
+        { 
+        }
     }
     class WantSomeFutureHandlers 
     {
         [Inject]
-        WantSomeFutureHandlers(IInjectionFuture<IAHandler> a, IInjectionFuture<IBHandler> b) { }
+        WantSomeFutureHandlers(IInjectionFuture<IAHandler> a, IInjectionFuture<IBHandler> b) 
+        { 
+        }
     }
 
     [NamedParameter(DefaultClass = typeof(AHandlerImpl))]
-    class AHandlerName : Name<IEventHandler<AH>> { }
+    class AHandlerName : Name<IEventHandler<AH>> 
+    { 
+    }
     
     [NamedParameter(DefaultClass = typeof(BHandlerImpl))]
-    class BHandlerName : Name<IEventHandler<BH>> { }
+    class BHandlerName : Name<IEventHandler<BH>> 
+    { 
+    }
 
     class WantSomeFutureHandlersName 
     {
@@ -1163,35 +1220,41 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
 
     abstract class MultiLayer
     {
-         
     }
 
     class MiddleLayer : MultiLayer
     {
-       [Inject]
-        public MiddleLayer() { }
+        [Inject]
+        public MiddleLayer() 
+        { 
+        }
     }
 
     class LowerLayer : MiddleLayer 
     {
-       [Inject]
-        public LowerLayer() { }
+        [Inject]
+        public LowerLayer() 
+        { 
+        }
     }
 
     interface IMultiLayer
     {
-
     }
 
     class MiddleLayerImpl : IMultiLayer
     {
         [Inject]
-        public MiddleLayerImpl() { }
+        public MiddleLayerImpl() 
+        { 
+        }
     }
 
     class LowerLayerImpl : MiddleLayerImpl
     {
         [Inject]
-        public LowerLayerImpl() { }
+        public LowerLayerImpl() 
+        { 
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang/Annotations/DefaultImplementation.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Annotations/DefaultImplementation.cs
@@ -35,6 +35,5 @@ namespace Org.Apache.REEF.Tang.Annotations
             Name = n;
             Value = val;
         }
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang/Annotations/Inject.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Annotations/Inject.cs
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-﻿namespace Org.Apache.REEF.Tang.Annotations
+
+namespace Org.Apache.REEF.Tang.Annotations
 {
     /// <summary>
     /// InjectAttribute

--- a/lang/cs/Org.Apache.REEF.Tang/Annotations/Name.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Annotations/Name.cs
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-﻿namespace Org.Apache.REEF.Tang.Annotations
+
+namespace Org.Apache.REEF.Tang.Annotations
 {
     /// <summary>
     /// Base class for named parameters

--- a/lang/cs/Org.Apache.REEF.Tang/Formats/ConfigurationFile.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Formats/ConfigurationFile.cs
@@ -67,7 +67,6 @@ namespace Org.Apache.REEF.Tang.Formats
             return t.FullName;
         }
     
-
         private static string GetFullName(string name)
         {
             try
@@ -79,7 +78,6 @@ namespace Org.Apache.REEF.Tang.Formats
             {
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Caught(e, Level.Warning, LOGGER);
                 return name; // if name is not a type, return as it was
-                
             }
         }
 
@@ -120,7 +118,6 @@ namespace Org.Apache.REEF.Tang.Formats
                 Join(sb, "-", conf.GetLegacyConstructor(cn).GetArgs().ToArray<IConstructorArg>());
                 l.Add(GetFullName(cn) + Escape('=' + ConfigurationBuilderImpl.INIT + '(' + sb.ToString() + ')'));
             }
-
 
             IEnumerator bs = conf.GetBoundSets();
             while (bs.MoveNext())

--- a/lang/cs/Org.Apache.REEF.Tang/Formats/ConfigurationModuleBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Formats/ConfigurationModuleBuilder.cs
@@ -172,7 +172,7 @@ namespace Org.Apache.REEF.Tang.Formats
             c.reqUsed.AddAll(d.Builder.reqUsed);
             c.optUsed.AddAll(d.Builder.optUsed);
             c.SetOpts.AddAll(d.Builder.SetOpts);
-            // c.ListOpts.AddAll(d.Builder.ListOpts);
+            //// c.ListOpts.AddAll(d.Builder.ListOpts);
             c.Map.AddAll(d.Builder.Map);
             c.FreeImpls.AddAll(d.Builder.FreeImpls);
             c.FreeParams.AddAll(d.Builder.FreeParams);

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AbstractNode.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AbstractNode.cs
@@ -94,21 +94,35 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
         public override bool Equals(Object o) 
         {
-            if (o == null) return false;
-            if (o == this) return true;
+            if (o == null)
+            {
+                return false;
+            }
+            if (o == this)
+            {
+                return true;
+            }
     
             AbstractNode n = (AbstractNode)o;
             bool parentsEqual;
-            if (n.parent == this.parent) {
+            if (n.parent == this.parent) 
+            {
                 parentsEqual = true;
-            } else if (n.parent == null) {
+            } 
+            else if (n.parent == null) 
+            {
                 parentsEqual = false;
-            } else if (this.parent == null) {
+            } 
+            else if (this.parent == null) 
+            {
                 parentsEqual = false;
-            } else {
+            } 
+            else 
+            {
                 parentsEqual = n.parent.Equals(this.parent);
             }
-            if (!parentsEqual) {
+            if (!parentsEqual) 
+            {
                 return false;
             }
             return fullName.Equals(n.fullName);

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchy.cs
@@ -154,7 +154,6 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                         var ex = new IllegalStateException("When reading protocol buffer node "
                             + n + " refers to non-existent implementation:" + impl);
                         Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
-
                     }
                     catch (InvalidCastException e)
                     {

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
@@ -47,7 +47,6 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         // alias is indexed by language, for each language, a mapping between alias and corresponding name kept in a Dictionary
         private readonly IDictionary<string, IDictionary<string, string>> _aliasLookupTable = new Dictionary<string, IDictionary<string, string>>();
 
-
         public ParameterParser Parameterparser = new ParameterParser();
 
         public ClassHierarchyImpl(string file) : this(new string[] { file }, new Type[0])
@@ -265,7 +264,8 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             }
             INamedParameterNode np = NodeFactory.CreateNamedParameterNode(parent, type, argType);
 
-            if (Parameterparser.CanParse(ReflectionUtilities.GetAssemblyQualifiedName(argType))) {
+            if (Parameterparser.CanParse(ReflectionUtilities.GetAssemblyQualifiedName(argType))) 
+            {
                 if (type.GetCustomAttribute<NamedParameterAttribute>().DefaultClass != null) 
                 {
                     var e = new ClassHierarchyException("Named parameter " + ReflectionUtilities.GetAssemblyQualifiedName(type) + " defines default implementation for parsable type " + ReflectionUtilities.GetAssemblyQualifiedName(argType));
@@ -312,7 +312,6 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                     Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
                 }
                 shortNames.Add(shortName, np);
-
             }
             return np;            
         }
@@ -340,7 +339,6 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                         }
                     }
                 }
-
             }
             return null;   
         }
@@ -366,9 +364,8 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                         }
                     }
                     return null;
-                    // throw new NameResolutionException(t.FullName, sb.ToString());
+                    //// throw new NameResolutionException(t.FullName, sb.ToString());
                 }
-
             }
             return current; 
         }
@@ -480,7 +477,10 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
         public IClassHierarchy Merge(IClassHierarchy ch)
         {
-            if (this == ch) { return this; }
+            if (this == ch) 
+            { 
+                return this; 
+            }
 
             if (!(ch is ClassHierarchyImpl)) 
             {

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassNodeImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassNodeImpl.cs
@@ -46,7 +46,6 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             String defaultImplementation)
             : base(parent, simpleName, fullName)
         {
-
             this.unit = unit;
             this.injectable = injectable;
             this.externalConstructor = externalConstructor;

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ConstructorArgImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ConstructorArgImpl.cs
@@ -88,7 +88,6 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                 return false;
             }
             return name.Equals(arg.name);
-
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ConstructorDefImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ConstructorDefImpl.cs
@@ -106,10 +106,14 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                         break;
                     }
                 }
+
                 // If not, then argument j from def is not in our list.  Return false.
                 if (found == false)
+                {
                     return false;
+                }
             }
+
             // Everything in def's arg list is in ours.  Do we have at least one extra
             // argument?
             return GetArgs().Count > def.GetArgs().Count;
@@ -142,7 +146,6 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                 {
                     i++;
                 }
-
             }
             return true;
         }
@@ -196,7 +199,6 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                 {
                     return true;
                 }
-
             }
             return false;
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
@@ -45,8 +45,9 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             var unit = null != clazz.GetCustomAttribute<UnitAttribute>();
             string simpleName = ReflectionUtilities.GetName(clazz);
             string fullName = ReflectionUtilities.GetAssemblyQualifiedName(clazz);
-            // bool isStatic = true; // clazz.IsSealed && clazz.IsAbstract; always true in C# for Java static class
-            // bool injectable = true; // always true in C#
+
+            //// bool isStatic = true; // clazz.IsSealed && clazz.IsAbstract; always true in C# for Java static class
+            //// bool injectable = true; // always true in C#
 
             bool isAssignableFromExternalConstructor = ReflectionUtilities.IsAssignableFromIgnoreGeneric(typeof(IExternalConstructor<>), clazz); 
 
@@ -88,7 +89,6 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                     }
                 }
                 allConstructors.Add(constructorDef);
-
             }
 
             string defaultImplementation = null;
@@ -175,7 +175,8 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         {
             Type setRawArgType = ReflectionUtilities.GetInterfaceTarget(typeof(ISet<>), argClass);
             bool isSet = setRawArgType != null;
-            if (isSet) {
+            if (isSet) 
+            {
                 argClass = setRawArgType;
             }
 

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/PackageNodeImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/PackageNodeImpl.cs
@@ -39,7 +39,8 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         * children into account.  Therefore, we use the full name as the key when
         * we insert nodes into the root.
         */
-        public override void Add(INode n) {
+        public override void Add(INode n) 
+        {
             children.Add(n.GetFullName(), n);
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ParameterParser.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ParameterParser.cs
@@ -62,7 +62,6 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             parsers.Add(ReflectionUtilities.GetAssemblyQualifiedName(clazz), c);
         }
 
-
         public void MergeIn(ParameterParser p)
         {
             foreach (string s in p.parsers.Keys)

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/ConfigurationBuilderImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/ConfigurationBuilderImpl.cs
@@ -68,7 +68,8 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
         public ConfigurationBuilderImpl(ConfigurationBuilderImpl t) 
         {
             this.ClassHierarchy = t.GetClassHierarchy();
-            try {
+            try 
+            {
                 AddConfiguration(t.GetClassHierarchy(), t);
             } 
             catch (BindException e) 
@@ -146,18 +147,20 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
 
             foreach (KeyValuePair<INamedParameterNode, object> e in builder.BoundSetEntries) 
             {
-              String name = ((INamedParameterNode)e.Key).GetFullName();
-              if (e.Value is INode) 
-              {
+                String name = ((INamedParameterNode)e.Key).GetFullName();
+                if (e.Value is INode) 
+                {
                     BindSetEntry(name, (INode)e.Value);
-              } 
-              else if (e.Value is string) 
-              {
+                } 
+                else if (e.Value is string) 
+                {
                     BindSetEntry(name, (string)e.Value);
-              } else {
-                var ex = new IllegalStateException(string.Format(CultureInfo.CurrentCulture, "The value {0} set to the named parameter {1} is illegel.", e.Value, name));
-                Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
-              }
+                } 
+                else 
+                {
+                    var ex = new IllegalStateException(string.Format(CultureInfo.CurrentCulture, "The value {0} set to the named parameter {1} is illegel.", e.Value, name));
+                    Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
+                }
             }
 
             foreach (var p in builder.BoundLists)

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/CsConfigurationBuilderImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/CsConfigurationBuilderImpl.cs
@@ -184,7 +184,8 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
             return ((ICsInternalConfigurationBuilder)this).BindConstructor(typeof(T), typeof(U));
         }
 
-        // public <T> void bindSetEntry(Class<? extends Name<Set<T>>> iface, String value) throws BindException;
+        //// public <T> void bindSetEntry(Class<? extends Name<Set<T>>> iface, String value) throws BindException;
+
         /// <summary>
         /// Binds a string value to a named parameter of ISet.
         /// </summary>
@@ -199,7 +200,8 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
             return ((ICsInternalConfigurationBuilder)this).BindSetEntry(typeof(U), value);
         }
 
-        // public <T> void bindSetEntry(Class<? extends Name<Set<T>>> iface, Class<? extends T> impl) throws BindException;
+        //// public <T> void bindSetEntry(Class<? extends Name<Set<T>>> iface, Class<? extends T> impl) throws BindException;
+
         /// <summary>
         /// Binds an implementation of T to a named parameter of ISet of T.
         /// </summary>
@@ -310,7 +312,8 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
             return this;
         }
 
-        // public <T> void bindSetEntry(Class<? extends Name<Set<T>>> iface, String value) throws BindException;
+        //// public <T> void bindSetEntry(Class<? extends Name<Set<T>>> iface, String value) throws BindException;
+
         /// <summary>
         /// Binds a string value to to a named parameter of ISet entry
         /// </summary>
@@ -335,12 +338,13 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
                 var ex = new BindException("BindSetEntry got a NamedParameter that takes a " + setType + "; expected Set<...>");
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
             }
-            // Type valType = ReflectionUtilities.getInterfaceTarget(Set.class, setType);
+            //// Type valType = ReflectionUtilities.getInterfaceTarget(Set.class, setType);
             BindSetEntry((INamedParameterNode)n, value);
             return this;
         }
 
-        // public <T> void bindSetEntry(Class<? extends Name<Set<T>>> iface, Class<? extends T> impl) throws BindException;
+        //// public <T> void bindSetEntry(Class<? extends Name<Set<T>>> iface, Class<? extends T> impl) throws BindException;
+
         /// <summary>
         /// Binds an implementation to a named parameter of ISet entry.
         /// </summary>
@@ -370,7 +374,7 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
             Type valType = ReflectionUtilities.GetInterfaceTarget(typeof(ISet<>), setType);
 
             if (!valType.IsAssignableFrom(impl))
-            // if (!ReflectionUtilities.GetRawClass(valType).IsAssignableFrom(impl))
+            //// if (!ReflectionUtilities.GetRawClass(valType).IsAssignableFrom(impl))
             {
                 var ex = new BindException("BindSetEntry got implementation " + impl + " that is incompatible with expected type " + valType);
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
@@ -401,7 +405,8 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
             return this;
         }
 
-        // public <T> void bindConstructor(Class<T> c, Class<? extends ExternalConstructor<? extends T>> v) throws BindException;
+        //// public <T> void bindConstructor(Class<T> c, Class<? extends ExternalConstructor<? extends T>> v) throws BindException;
+
         /// <summary>
         /// Binds an external constructor.
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/Constructor.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/Constructor.cs
@@ -136,7 +136,6 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
 
         public override string ToAmbiguousInjectString() 
         {
-
             if (!isAmbiguous) 
             {
                 var ex = new ArgumentException(GetNode().GetFullName() + " is NOT ambiguous.");
@@ -168,7 +167,8 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                     if (ip.IsInfeasibleLeaf()) 
                     {
                         leaves.Add(ip);
-                    } else 
+                    } 
+                    else 
                     {
                         return ip.ToInfeasibleInjectString();
                     }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectionFuture.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectionFuture.cs
@@ -24,7 +24,6 @@ using Org.Apache.REEF.Tang.Util;
 
 namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
 {
-
     public interface IInjectionFuture<out T>
     {
         T Get();
@@ -74,7 +73,10 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
 
         public T Get() 
         {
-            if (instance != null) return instance;
+            if (instance != null)
+            {
+                return instance;
+            }
             lock (injector) 
             {
                 T t;
@@ -94,6 +96,5 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                 return t;
             }
         }
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectionPlan.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectionPlan.cs
@@ -62,7 +62,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
 
         abstract public bool IsInjectable();
 
-        // abstract public bool HasFutureDependency();
+        //// abstract public bool HasFutureDependency();
 
         protected void pad(StringBuilder sb, int n)
         {
@@ -169,12 +169,10 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
         public abstract bool IsInfeasibleLeaf();
 
         public abstract string ToShallowString();
-
     }
 
     public class BuildingInjectionPlan : InjectionPlan
     {
-
         public BuildingInjectionPlan(INode node)
             : base(node)
         {

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectorImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectorImpl.cs
@@ -46,7 +46,6 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
 
         static readonly InjectionPlan BUILDING = new BuildingInjectionPlan(null); // TODO anonymous class
 
-
         private bool concurrentModificationGuard = false;
 
         private void AssertNotConcurrent()
@@ -223,10 +222,10 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                 }
 
                 Type t = classHierarchy.ClassForName(typeOfSet);
+
                 // MakeGenericType(t = int: MonotonicHashSet<> -> MonotonicHashSet<int>
                 // Get constructor: MonotonicHashSet<int> -> public MonotonicHashSet<int>() { ... }
                 // Invoke: public MonotonicHashSet<int> -> new MonotonicHashSet<int>()
-
                 object ret = typeof(MonotonicHashSet<>).MakeGenericType(t).GetConstructor(new Type[] { }).Invoke(new object[] { }); // (this, classHierarchy.ClassForName(fut.GetNode().GetFullName()));
 
                 MethodInfo mf = ret.GetType().GetMethod("Add");
@@ -279,7 +278,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
         private object GetCachedInstance(IClassNode cn)
         {
             if (cn.GetFullName().Equals(ReflectionUtilities.GetAssemblyQualifiedName(typeof(IInjector))))
-                // if (cn.GetFullName().Equals(ReflectionUtilities.NonGenericFullName(typeof(IInjector))))
+                //// if (cn.GetFullName().Equals(ReflectionUtilities.NonGenericFullName(typeof(IInjector))))
             {
                 return this.ForkInjector(); // TODO: We should be insisting on injection futures here! .forkInjector();
             }
@@ -315,8 +314,9 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
             }
 
             ConstructorInfo cons = clazz.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, parameterTypes, null);
-            // TODO
-            // cons.setAccessible(true);
+
+            //// TODO
+            //// cons.setAccessible(true);
 
             if (cons == null)
             {
@@ -393,7 +393,6 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                 {
                     ip = new CsInstance(np, instance);
                 }
-
             }
             else if (n is IClassNode)
             {
@@ -589,6 +588,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                         liveIndices.Add(i);
                     }
                 }
+
                 // Now, do an all-by-all comparison, removing indices that are dominated
                 // by others.
                 int k = -1;
@@ -621,7 +621,6 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
             #endregion each implementation
             return sub_ips;
         }
-
 
         private InjectionPlan WrapInjectionPlans(IClassNode infeasibleNode,
             List<InjectionPlan> list, bool forceAmbiguous, int selectedIndex)
@@ -982,12 +981,15 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
             {
                 IClassNode cn = (IClassNode)n;
                 object old = GetCachedInstance(cn);
-                if (old != null) {
+                if (old != null) 
+                {
                     Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new BindException("Attempt to re-bind instance.  Old value was "
                     + old + " new value is " + o), LOGGER);
                 }
                 instances.Add(cn, o);
-            } else {
+            } 
+            else 
+            {
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new ArgumentException("Expected Class but got " + c
                     + " (probably a named parameter)."), LOGGER);
             }
@@ -1087,7 +1089,6 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
         public InjectionPlan GetInjectionPlan(string name)
         {
             return GetInjectionPlan(this.classHierarchy.GetNode(name));
-
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/Subplan.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/Subplan.cs
@@ -231,6 +231,5 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
         {
             return false;
         }
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang/Interface/ICsClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Interface/ICsClassHierarchy.cs
@@ -28,7 +28,5 @@ namespace Org.Apache.REEF.Tang.Interface
         Type ClassForName(string name);
         object Parse(INamedParameterNode name, string value);
         object ParseDefaultValue(INamedParameterNode name);
-
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang/Interface/IExternalConstructor.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Interface/IExternalConstructor.cs
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-﻿
+
 namespace Org.Apache.REEF.Tang.Interface
 {
     public interface IExternalConstructor<out T>

--- a/lang/cs/Org.Apache.REEF.Tang/Protobuf/ProtocolBufferClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Protobuf/ProtocolBufferClassHierarchy.cs
@@ -40,7 +40,6 @@ namespace Org.Apache.REEF.Tang.Protobuf
         private readonly IDictionary<string, INode> lookupTable = new Dictionary<string, INode>();
         private readonly IDictionary<string, IDictionary<string, string>> _aliasLookupTable = new Dictionary<string, IDictionary<string, string>>();
 
-
         public static void Serialize(string fileName, IClassHierarchy classHierarchy)
         {
             Org.Apache.REEF.Tang.Protobuf.Node node = Serialize(classHierarchy);
@@ -274,6 +273,7 @@ namespace Org.Apache.REEF.Tang.Protobuf
             {
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new ArgumentException("Expected a package node.  Got: " + root), LOGGER); 
             }
+
             // Register all the classes.
             foreach (Org.Apache.REEF.Tang.Protobuf.Node child in root.children)
             {
@@ -377,7 +377,6 @@ namespace Org.Apache.REEF.Tang.Protobuf
                 {
                     IConstructorDef def = ParseConstructorDef(other, false);
                     allConstructors.Add(def);
-
                 }
 
                 IConstructorDef[] dummy = new ConstructorDefImpl[0];
@@ -436,7 +435,6 @@ namespace Org.Apache.REEF.Tang.Protobuf
                         var ex = new IllegalStateException("When reading protocol buffer node "
                             + n + " refers to non-existent implementation:" + impl);
                         Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER); 
-
                     }
                     catch (InvalidCastException e)
                     {

--- a/lang/cs/Org.Apache.REEF.Tang/Protobuf/ProtocolBufferInjectionPlan.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Protobuf/ProtocolBufferInjectionPlan.cs
@@ -73,7 +73,6 @@ namespace Org.Apache.REEF.Tang.Protobuf
             plan.name = fullName;
             plan.instance = instance;
             return plan;
-
         }
 
         public static void Serialize(string fileName, Org.Apache.REEF.Tang.Implementations.InjectionPlan.InjectionPlan ip)
@@ -109,7 +108,6 @@ namespace Org.Apache.REEF.Tang.Protobuf
                     subPlans[i] = Serialize(args[i]);
                 }
                 return NewSubplan(ip.GetNode().GetFullName(), sp.GetSelectedIndex(), subPlans.ToList<Org.Apache.REEF.Tang.Protobuf.InjectionPlan>());
-
             } 
             if (ip is CsInstance) 
             {

--- a/lang/cs/Org.Apache.REEF.Tang/Types/IConstructorArg.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Types/IConstructorArg.cs
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-﻿
+
 namespace Org.Apache.REEF.Tang.Types
 {
     public interface IConstructorArg

--- a/lang/cs/Org.Apache.REEF.Tang/Types/IPackageNode.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Types/IPackageNode.cs
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-﻿namespace Org.Apache.REEF.Tang.Types
+
+namespace Org.Apache.REEF.Tang.Types
 {
     public interface IPackageNode : INode
     {

--- a/lang/cs/Org.Apache.REEF.Tang/Util/AssemblyLoader.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/AssemblyLoader.cs
@@ -65,7 +65,9 @@ namespace Org.Apache.REEF.Tang.Util
                 {
                     t = a.GetType(name);
                     if (t != null)
+                    {
                         break;
+                    }
                 }
             }
 

--- a/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
@@ -180,7 +180,7 @@ namespace Org.Apache.REEF.Tang.Util
         public static IEnumerable<Type> ClassAndAncestorsExcludeSelf(Type c)
         {
             List<Type> workQueue = new List<Type>();
-            // workQueue.Add(c); // including itself
+            //// workQueue.Add(c); // including itself
 
             foreach (Type t in c.GetInterfaces())
             {
@@ -275,7 +275,7 @@ namespace Org.Apache.REEF.Tang.Util
             ////   && Number.class.isAssignableFrom(from)) {
             ////return sizeof.get(from) <= sizeof.get(to);
             return to.IsAssignableFrom(from);
-            // return IsAssignableFromIgnoreGeneric(to, from);
+            //// return IsAssignableFromIgnoreGeneric(to, from);
         }
 
         /// <summary>
@@ -367,7 +367,9 @@ namespace Org.Apache.REEF.Tang.Util
                 {
                     t = a.GetType(name);
                     if (t != null)
+                    {
                         break;
+                    }
                 }
             }
             if (t == null)
@@ -453,7 +455,6 @@ namespace Org.Apache.REEF.Tang.Util
                     var ex = new ClassHierarchyException("Named parameter " + GetName(type) + " implements "
                                   + "multiple interfaces.  It is only allowed to implement Name<T>");
                     Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
-
                 }
                 else if (intfs.Length == 0 || !IsName(intfs[0]))
                 {
@@ -497,9 +498,13 @@ namespace Org.Apache.REEF.Tang.Util
         public static IEnumerable<Type> GetInterfaces(Type type, bool includeInherited)
         {
             if (includeInherited || type.BaseType == null)
+            {
                 return type.GetInterfaces();
+            }
             else
+            {
                 return type.GetInterfaces().Except(type.BaseType.GetInterfaces());
+            }
         }
 
         // Here is a more elaborate hack to test for anonymous type:

--- a/lang/cs/Org.Apache.REEF.Tang/Util/SetValuedKey.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/SetValuedKey.cs
@@ -49,7 +49,10 @@ namespace Org.Apache.REEF.Tang.Util
         public override bool Equals(Object o)
         {
             SetValuedKey other = (SetValuedKey)o;
-            if (other.key.Count != this.key.Count) { return false; }
+            if (other.key.Count != this.key.Count) 
+            { 
+                return false; 
+            }
             for (int i = 0; i < this.key.Count; i++)
             {
                 if (this.key[i].Equals(other.key[i]))

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/StreamingTransportTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/StreamingTransportTest.cs
@@ -85,7 +85,6 @@ namespace Org.Apache.REEF.Wake.Tests
         [Fact]
         public void TestStreamingTransportSenderStage()
         {
-            
             IPEndPoint endpoint = new IPEndPoint(IPAddress.Any, 0);
 
             List<string> events = new List<string>();
@@ -160,7 +159,6 @@ namespace Org.Apache.REEF.Wake.Tests
             }
 
             Assert.Equal(numEventsExpected, events.Count);
-
         }
 
         private static ITcpPortProvider GetTcpProvider(int portRangeStart, int portRangeEnd)

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/TransportTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/TransportTest.cs
@@ -43,7 +43,6 @@ namespace Org.Apache.REEF.Wake.Tests
             BlockingCollection<string> queue = new BlockingCollection<string>();
             List<string> events = new List<string>();
 
-
             IPEndPoint endpoint = new IPEndPoint(_localIpAddress, 0);
             var remoteHandler = Observer.Create<TransportEvent<string>>(tEvent => queue.Add(tEvent.Data));
 
@@ -207,7 +206,6 @@ namespace Org.Apache.REEF.Wake.Tests
             }
         }
 
-
         private static ITcpPortProvider GetTcpProvider(int portRangeStart, int portRangeEnd)
         {
             var configuration = TangFactory.GetTang().NewConfigurationBuilder()
@@ -217,6 +215,5 @@ namespace Org.Apache.REEF.Wake.Tests
                 .Build();
             return TangFactory.GetTang().NewInjector(configuration).GetInstance<ITcpPortProvider>();
         }
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Examples/P2p/Pull2Push.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Examples/P2p/Pull2Push.cs
@@ -81,6 +81,7 @@ namespace Org.Apache.REEF.Wake.Examples.P2p
                     {
                         // Add the source to the end of the queue again.
                         _sources.Enqueue(nextSource);
+
                         // Send the message. Note that this may block depending on the underlying EventHandler.
                         _output.OnNext(message);
                     }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/IDataReader.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/IDataReader.cs
@@ -132,7 +132,6 @@ namespace Org.Apache.REEF.Wake.Remote
         /// <returns>Task handler that reads string</returns>
         Task<string> ReadStringAsync(CancellationToken token);
 
-
         /// <summary>
         /// Reads data in to the buffer asynchronously
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/IRemoteManagerFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/IRemoteManagerFactory.cs
@@ -46,7 +46,6 @@ namespace Org.Apache.REEF.Wake.Remote
         /// <param name="codec">The codec used for serializing messages</param>
         IRemoteManager<T> GetInstance<T>(IPAddress localAddress, ICodec<T> codec);
 
- 
         /// <summary>
         /// Constructs a DefaultRemoteManager. Does not listen for incoming messages.
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportServer.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportServer.cs
@@ -113,7 +113,6 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
                 String.Format("Listening on {0}", _listener.LocalEndpoint.ToString()));
         }
 
-
         /// <summary>
         /// Close the TransportServer and all open connections
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/TcpPortProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/TcpPortProvider.cs
@@ -107,5 +107,4 @@ namespace Org.Apache.REEF.Wake.Remote
             }
         }
     }
-    
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Util/LimitedConcurrencyLevelTaskScheduler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Util/LimitedConcurrencyLevelTaskScheduler.cs
@@ -168,15 +168,18 @@ namespace Org.Apache.REEF.Wake.Util
                                 --_delegatesQueuedOrRunning;
                                 break;
                             }
+
                             // Get the next item from the queue
                             item = _tasks.First.Value;
                             _tasks.RemoveFirst();
                         }
+
                         // Execute the task we pulled out of the queue
                         base.TryExecuteTask(item);
                     }
                 }
-                    // We're done processing items on the current thread
+
+                // We're done processing items on the current thread
                 finally
                 {
                     _currentThreadIsProcessingItems = false;

--- a/lang/cs/Settings.StyleCop
+++ b/lang/cs/Settings.StyleCop
@@ -237,67 +237,67 @@ under the License.
       <Rules>
         <Rule Name="CurlyBracketsForMultiLineStatementsMustNotShareLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="StatementMustNotBeOnSingleLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ElementMustNotBeOnSingleLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="CurlyBracketsMustNotBeOmitted">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="AllAccessorsMustBeMultiLineOrSingleLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="OpeningCurlyBracketsMustNotBeFollowedByBlankLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ElementDocumentationHeadersMustNotBeFollowedByBlankLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="CodeMustNotContainMultipleBlankLinesInARow">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ClosingCurlyBracketsMustNotBePrecededByBlankLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="OpeningCurlyBracketsMustNotBePrecededByBlankLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ChainedStatementBlocksMustNotBePrecededByBlankLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="WhileDoFooterMustNotBePrecededByBlankLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="SingleLineCommentsMustNotBeFollowedByBlankLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ClosingCurlyBracketMustBeFollowedByBlankLine">
@@ -307,12 +307,12 @@ under the License.
         </Rule>
         <Rule Name="ElementDocumentationHeaderMustBePrecededByBlankLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="SingleLineCommentMustBePrecededByBlankLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ElementsMustBeSeparatedByBlankLine">
@@ -322,12 +322,12 @@ under the License.
         </Rule>
         <Rule Name="CodeMustNotContainBlankLinesAtStartOfFile">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="CodeMustNotContainBlankLinesAtEndOfFile">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
       </Rules>


### PR DESCRIPTION
This enables the following rules:
 * CurlyBracketsForMultiLineStatementsMustNotShareLine
 * StatementMustNotBeOnSingleLine
 * ElementMustNotBeOnSingleLine
 * CurlyBracketsMustNotBeOmitted
 * AllAccessorsMustBeMultiLineOrSingleLine
 * OpeningCurlyBracketsMustNotBeFollowedByBlankLine
 * ElementDocumentationHeadersMustNotBeFollowedByBlankLine
 * CodeMustNotContainMultipleBlankLinesInARow
 * ClosingCurlyBracketsMustNotBePrecededByBlankLine
 * OpeningCurlyBracketsMustNotBePrecededByBlankLine
 * ChainedStatementBlocksMustNotBePrecededByBlankLine
 * WhileDoFooterMustNotBePrecededByBlankLine
 * SingleLineCommentsMustNotBeFollowedByBlankLine
 * ElementDocumentationHeaderMustBePrecededByBlankLine
 * SingleLineCommentMustBePrecededByBlankLine
 * CodeMustNotContainBlankLinesAtStartOfFile
 * CodeMustNotContainBlankLinesAtEndOfFile

JIRA:
  [REEF-1058](https://issues.apache.org/jira/browse/REEF-1058)

Pull request:
  This closes #