### PR TITLE
[REEF-1065] Add Java Reference Cleanup for InterOp code

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/ActiveContextClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/ActiveContextClr2Java.cpp
@@ -46,6 +46,25 @@ namespace Org {
 							ManagedLog::LOGGER->LogStop("ActiveContextClr2Java::ActiveContextClr2Java");
 						}
 
+						ActiveContextClr2Java::~ActiveContextClr2Java() {
+							this->!ActiveContextClr2Java();
+						}
+
+						ActiveContextClr2Java::!ActiveContextClr2Java() {
+							JNIEnv *env = RetrieveEnv(_jvm);
+							if (_jobjectActiveContext != NULL) {
+								env->DeleteGlobalRef(_jobjectActiveContext); 
+							}
+
+							if (_jstringId != NULL) {
+								env->DeleteGlobalRef(_jstringId);
+							}
+
+							if (_jstringEvaluatorId != NULL) {
+								env->DeleteGlobalRef(_jstringEvaluatorId);
+							}
+						}
+
 						void ActiveContextClr2Java::SubmitTask(String^ taskConfigStr) {
 							ManagedLog::LOGGER->LogStart("ActiveContextClr2Java::SubmitTask");
 							JNIEnv *env = RetrieveEnv(_jvm);

--- a/lang/cs/Org.Apache.REEF.Bridge/AllocatedEvaluatorClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/AllocatedEvaluatorClr2Java.cpp
@@ -50,6 +50,25 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("AllocatedEvaluatorClr2Java::AllocatedEvaluatorClr2Java");
 					  }
 
+					  AllocatedEvaluatorClr2Java::~AllocatedEvaluatorClr2Java() {
+						  this->!AllocatedEvaluatorClr2Java();
+					  }
+
+					  AllocatedEvaluatorClr2Java::!AllocatedEvaluatorClr2Java() {
+						  JNIEnv *env = RetrieveEnv(_jvm);
+						  if (_jobjectAllocatedEvaluator != NULL) {
+							  env->DeleteGlobalRef(_jobjectAllocatedEvaluator);
+						  }
+
+						  if (_jstringId != NULL) {
+							  env->DeleteGlobalRef(_jstringId);
+						  }
+
+						  if (_jstringNameServerInfo != NULL) {
+							  env->DeleteGlobalRef(_jstringNameServerInfo);
+						  }
+					  }
+
 					  void AllocatedEvaluatorClr2Java::SubmitContext(String^ contextConfigStr) {
 						  ManagedLog::LOGGER->LogStart("AllocatedEvaluatorClr2Java::SubmitContext");
 						  JNIEnv *env = RetrieveEnv(_jvm);

--- a/lang/cs/Org.Apache.REEF.Bridge/ClosedContextClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/ClosedContextClr2Java.cpp
@@ -47,6 +47,25 @@ namespace Org {
                             ManagedLog::LOGGER->LogStop("ClosedContextClr2Java::ClosedContextClr2Java");
                         }
 
+                        ClosedContextClr2Java::~ClosedContextClr2Java() {
+                            this->!ClosedContextClr2Java();
+                        }
+
+                        ClosedContextClr2Java::!ClosedContextClr2Java() {
+                            JNIEnv *env = RetrieveEnv(_jvm);
+                            if (_jobjectClosedContext != NULL) {
+                                env->DeleteGlobalRef(_jobjectClosedContext);
+                            }
+                            
+                            if (_jstringContextId != NULL) {
+                                env->DeleteGlobalRef(_jstringContextId);
+                            }
+
+                            if (_jstringEvaluatorId != NULL) {
+                                env->DeleteGlobalRef(_jstringEvaluatorId);
+                            }
+                        }
+
                         /**
                          * Gets the Parent context of the closed context through a JNI call to Java.
                          */

--- a/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
+++ b/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
@@ -55,12 +55,14 @@ namespace Org {
                         };
 
                         public ref class AllocatedEvaluatorClr2Java : public IAllocatedEvaluaotrClr2Java {
-                            jobject  _jobjectAllocatedEvaluator;
+                            jobject  _jobjectAllocatedEvaluator = NULL;
                             JavaVM* _jvm;
-                            jstring _jstringId;
-                            jstring _jstringNameServerInfo;
+                            jstring _jstringId = NULL;
+                            jstring _jstringNameServerInfo = NULL;
                         public:
                             AllocatedEvaluatorClr2Java(JNIEnv *env, jobject jallocatedEvaluator);
+                            ~AllocatedEvaluatorClr2Java();
+                            !AllocatedEvaluatorClr2Java();
                             virtual void SubmitContextAndTask(String^ contextConfigStr, String^ taskConfigStr);
                             virtual void SubmitContext(String^ contextConfigStr);
                             virtual void SubmitContextAndService(String^ contextConfigStr, String^ serviceConfigStr);
@@ -73,12 +75,14 @@ namespace Org {
                         };
 
                         public ref class ActiveContextClr2Java : public IActiveContextClr2Java {
-                            jobject _jobjectActiveContext;
-                            jstring _jstringId;
-                            jstring _jstringEvaluatorId;
+                            jobject _jobjectActiveContext = NULL;
+                            jstring _jstringId = NULL;
+                            jstring _jstringEvaluatorId = NULL;
                             JavaVM* _jvm;
                         public:
                             ActiveContextClr2Java(JNIEnv *env, jobject jallocatedEvaluator);
+                            ~ActiveContextClr2Java();
+                            !ActiveContextClr2Java();
                             virtual void SubmitTask(String^ taskConfigStr);
                             virtual void Close();
                             virtual void OnError(String^ message);
@@ -89,40 +93,48 @@ namespace Org {
                         };
 
                         public ref class EvaluatorRequestorClr2Java : public IEvaluatorRequestorClr2Java {
-                            jobject  _jobjectEvaluatorRequestor;
+                            jobject  _jobjectEvaluatorRequestor = NULL;
                             JavaVM* _jvm;
                         public:
                             EvaluatorRequestorClr2Java(JNIEnv *env, jobject jevaluatorRequestor);
+                            ~EvaluatorRequestorClr2Java();
+                            !EvaluatorRequestorClr2Java();
                             virtual void OnError(String^ message);
                             virtual void Submit(IEvaluatorRequest^ request);
                         };
 
                         public ref class TaskMessageClr2Java : public ITaskMessageClr2Java {
-                            jobject  _jobjectTaskMessage;
+                            jobject  _jobjectTaskMessage = NULL;
                             JavaVM* _jvm;
-                            jstring _jstringId;
+                            jstring _jstringId = NULL;
                         public:
                             TaskMessageClr2Java(JNIEnv *env, jobject jtaskMessage);
+                            ~TaskMessageClr2Java();
+                            !TaskMessageClr2Java();
                             virtual void OnError(String^ message);
                             virtual String^ GetId();
                         };
 
                         public ref class FailedTaskClr2Java : public IFailedTaskClr2Java {
-                            jobject  _jobjectFailedTask;
+                            jobject  _jobjectFailedTask = NULL;
                             JavaVM* _jvm;
                         public:
                             FailedTaskClr2Java(JNIEnv *env, jobject jfailedTask);
+                            ~FailedTaskClr2Java();
+                            !FailedTaskClr2Java();
                             virtual void OnError(String^ message);
                             virtual IActiveContextClr2Java^ GetActiveContext();
                             virtual String^ GetString();
                         };
 
                         public ref class RunningTaskClr2Java : public IRunningTaskClr2Java {
-                            jobject  _jobjectRunningTask;
+                            jobject  _jobjectRunningTask = NULL;
                             JavaVM* _jvm;
-                            jstring _jstringId;
+                            jstring _jstringId = NULL;
                         public:
                             RunningTaskClr2Java(JNIEnv *env, jobject jrunningTask);
+                            ~RunningTaskClr2Java();
+                            !RunningTaskClr2Java();
                             virtual void OnError(String^ message);
                             virtual IActiveContextClr2Java^ GetActiveContext();
                             virtual String^ GetId();
@@ -130,21 +142,25 @@ namespace Org {
                         };
 
                         public ref class FailedEvaluatorClr2Java : public IFailedEvaluatorClr2Java {
-                            jobject  _jobjectFailedEvaluator;
+                            jobject  _jobjectFailedEvaluator = NULL;
                             JavaVM* _jvm;
-                            jstring _jstringId;
+                            jstring _jstringId = NULL;
                         public:
                             FailedEvaluatorClr2Java(JNIEnv *env, jobject jfailedEvaluator);
+                            ~FailedEvaluatorClr2Java();
+                            !FailedEvaluatorClr2Java();
                             virtual void OnError(String^ message);
                             virtual IEvaluatorRequestorClr2Java^ GetEvaluatorRequestor();
                             virtual String^ GetId();
                         };
 
                         public ref class HttpServerClr2Java : public IHttpServerBridgeClr2Java {
-                            jobject _jhttpServerEventBridge;
+                            jobject _jhttpServerEventBridge = NULL;
                             JavaVM* _jvm;
                         public:
                             HttpServerClr2Java(JNIEnv *env, jobject jhttpServerEventBridge);
+                            ~HttpServerClr2Java();
+                            !HttpServerClr2Java();
                             virtual void OnError(String^ message);
                             virtual String^ GetQueryString();
                             virtual void SetUriSpecification(String^ uriSpecification);
@@ -154,11 +170,13 @@ namespace Org {
                         };
 
                         public ref class CompletedTaskClr2Java : public ICompletedTaskClr2Java {
-                            jobject  _jobjectCompletedTask;
+                            jobject  _jobjectCompletedTask = NULL;
                             JavaVM* _jvm;
-                            jstring _jstringId;
+                            jstring _jstringId = NULL;
                         public:
                             CompletedTaskClr2Java(JNIEnv *env, jobject jcompletedTask);
+                            ~CompletedTaskClr2Java();
+                            !CompletedTaskClr2Java();
                             virtual void OnError(String^ message);
                             virtual IActiveContextClr2Java^ GetActiveContext();
                             virtual String^ GetId();
@@ -166,11 +184,13 @@ namespace Org {
                         };
 
                         public ref class SuspendedTaskClr2Java : public ISuspendedTaskClr2Java {
-                            jobject  _jobjectSuspendedTask;
+                            jobject  _jobjectSuspendedTask = NULL;
                             JavaVM* _jvm;
-                            jstring _jstringId;
+                            jstring _jstringId = NULL;
                         public:
                             SuspendedTaskClr2Java(JNIEnv *env, jobject jobjectSuspendedTask);
+                            ~SuspendedTaskClr2Java();
+                            !SuspendedTaskClr2Java();
                             virtual void OnError(String^ message);
                             virtual IActiveContextClr2Java^ GetActiveContext();
                             virtual String^ GetId();
@@ -178,22 +198,26 @@ namespace Org {
                         };
 
                         public ref class CompletedEvaluatorClr2Java : public ICompletedEvaluatorClr2Java {
-                            jobject  _jobjectCompletedEvaluator;
+                            jobject  _jobjectCompletedEvaluator = NULL;
                             JavaVM* _jvm;
-                            jstring _jstringId;
+                            jstring _jstringId = NULL;
                         public:
                             CompletedEvaluatorClr2Java(JNIEnv *env, jobject jobjectCompletedEvaluator);
+                            ~CompletedEvaluatorClr2Java();
+                            !CompletedEvaluatorClr2Java();
                             virtual void OnError(String^ message);
                             virtual String^ GetId();
                         };
 
                         public ref class ClosedContextClr2Java : public IClosedContextClr2Java {
-                            jobject  _jobjectClosedContext;
+                            jobject  _jobjectClosedContext = NULL;
                             JavaVM* _jvm;
-                            jstring _jstringContextId;
-                            jstring _jstringEvaluatorId;
+                            jstring _jstringContextId = NULL;
+                            jstring _jstringEvaluatorId = NULL;
                         public:
                             ClosedContextClr2Java(JNIEnv *env, jobject jobjectClosedContext);
+                            ~ClosedContextClr2Java();
+                            !ClosedContextClr2Java();
                             virtual void OnError(String^ message);
                             virtual String^ GetId();
                             virtual String^ GetEvaluatorId();
@@ -202,13 +226,15 @@ namespace Org {
                         };
 
                         public ref class FailedContextClr2Java : public IFailedContextClr2Java {
-                            jobject  _jobjectFailedContext;
+                            jobject  _jobjectFailedContext = NULL;
                             JavaVM* _jvm;
-                            jstring _jstringContextId;
-                            jstring _jstringEvaluatorId;
-                            jstring _jstringParentContextId;
+                            jstring _jstringContextId = NULL;
+                            jstring _jstringEvaluatorId = NULL;
+                            jstring _jstringParentContextId = NULL;
                         public:
                             FailedContextClr2Java(JNIEnv *env, jobject jobjectFailedContext);
+                            ~FailedContextClr2Java();
+                            !FailedContextClr2Java();
                             virtual void OnError(String^ message);
                             virtual String^ GetId();
                             virtual String^ GetEvaluatorId();
@@ -218,13 +244,15 @@ namespace Org {
                         };
 
                         public ref class ContextMessageClr2Java : public IContextMessageClr2Java {
-                            jobject  _jobjectContextMessage;
+                            jobject  _jobjectContextMessage = NULL;
                             JavaVM* _jvm;
-                            jbyteArray _jarrayMessage;
-                            jstring _jstringId;
-                            jstring _jstringSourceId;
+                            jbyteArray _jarrayMessage = NULL;
+                            jstring _jstringId = NULL;
+                            jstring _jstringSourceId = NULL;
                         public:
                             ContextMessageClr2Java(JNIEnv *env, jobject jobjectContextMessage);
+                            ~ContextMessageClr2Java();
+                            !ContextMessageClr2Java();
                             virtual void OnError(String^ message);
                             virtual array<byte>^ Get();
                             virtual String^ GetId();
@@ -232,13 +260,15 @@ namespace Org {
                         };
 
                         public ref class DriverRestartedClr2Java : public IDriverRestartedClr2Java {
-                            jobject _jobjectDriverRestarted;
+                            jobject _jobjectDriverRestarted = NULL;
                             JavaVM* _jvm;
                             array<String^>^ _expectedEvaluatorIds;
                             DateTime _startTime;
                             int _resubmissionAttempts;
                         public:
                             DriverRestartedClr2Java(JNIEnv *env, jobject jobjectDriverRestarted);
+                            ~DriverRestartedClr2Java();
+                            !DriverRestartedClr2Java();
                             virtual void OnError(String^ message);
                             virtual array<String^>^ GetExpectedEvaluatorIds();
                             virtual DateTime GetStartTime();
@@ -246,12 +276,14 @@ namespace Org {
                         };
 
                         public ref class DriverRestartCompletedClr2Java : public IDriverRestartCompletedClr2Java {
-                            jobject _jobjectDriverRestartCompleted;
+                            jobject _jobjectDriverRestartCompleted = NULL;
                             JavaVM* _jvm;
                             DateTime _restartCompletedTime;
                             bool _isTimedOut;
                         public:
                             DriverRestartCompletedClr2Java(JNIEnv *env, jobject jobobjectDriverRestartCompleted);
+                            ~DriverRestartCompletedClr2Java();
+                            !DriverRestartCompletedClr2Java();
                             virtual void OnError(String^ message);
                             virtual DateTime GetCompletedTime();
                             virtual bool IsTimedOut();

--- a/lang/cs/Org.Apache.REEF.Bridge/CompletedEvaluatorClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/CompletedEvaluatorClr2Java.cpp
@@ -42,6 +42,21 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("CompletedEvaluatorClr2Java::CompletedEvaluatorClr2Java");
 					  }
 
+					  CompletedEvaluatorClr2Java::~CompletedEvaluatorClr2Java() {
+						  this->!CompletedEvaluatorClr2Java();
+					  }
+
+					  CompletedEvaluatorClr2Java::!CompletedEvaluatorClr2Java() {
+						  JNIEnv *env = RetrieveEnv(_jvm);
+						  if (_jobjectCompletedEvaluator != NULL) {
+							  env->DeleteGlobalRef(_jobjectCompletedEvaluator);
+						  }
+
+						  if (_jstringId != NULL) {
+							  env->DeleteGlobalRef(_jstringId); 
+						  }
+					  }
+
 					  void CompletedEvaluatorClr2Java::OnError(String^ message) {
 						  ManagedLog::LOGGER->Log("CompletedEvaluatorClr2Java::OnError");
 						  JNIEnv *env = RetrieveEnv(_jvm);

--- a/lang/cs/Org.Apache.REEF.Bridge/CompletedTaskClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/CompletedTaskClr2Java.cpp
@@ -43,6 +43,21 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("CompletedTaskClr2Java::CompletedTaskClr2Java");
 					  }
 
+					  CompletedTaskClr2Java::~CompletedTaskClr2Java(){
+						  this->!CompletedTaskClr2Java();
+					  }
+
+					  CompletedTaskClr2Java::!CompletedTaskClr2Java() {
+						  JNIEnv *env = RetrieveEnv(_jvm);
+						  if (_jobjectCompletedTask != NULL) {
+							  env->DeleteGlobalRef(_jobjectCompletedTask);
+						  }
+
+						  if (_jstringId != NULL) {
+							  env->DeleteGlobalRef(_jstringId);
+						  }
+					  }
+
 					  void CompletedTaskClr2Java::OnError(String^ message) {
 						  ManagedLog::LOGGER->Log("CompletedTaskClr2Java::OnError");
 						  JNIEnv *env = RetrieveEnv(_jvm);

--- a/lang/cs/Org.Apache.REEF.Bridge/ContextMessageClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/ContextMessageClr2Java.cpp
@@ -48,6 +48,29 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("ContextMessageClr2Java::ContextMessageClr2Java");
 					  }
 
+					  ContextMessageClr2Java::~ContextMessageClr2Java() {
+						  this->!ContextMessageClr2Java();
+					  }
+
+					  ContextMessageClr2Java::!ContextMessageClr2Java() {
+						  JNIEnv *env = RetrieveEnv(_jvm);
+						  if (_jobjectContextMessage != NULL) {
+							  env->DeleteGlobalRef(_jobjectContextMessage);
+						  }
+
+						  if (_jstringId != NULL) {
+							  env->DeleteGlobalRef(_jstringId);
+						  }
+
+						  if (_jstringSourceId != NULL) {
+							  env->DeleteGlobalRef(_jstringSourceId);
+						  }
+
+						  if (_jarrayMessage != NULL) {
+							  env->DeleteGlobalRef(_jarrayMessage);
+						  }
+					  }
+
 					  String^ ContextMessageClr2Java::GetId() {
 						  ManagedLog::LOGGER->Log("ContextMessageClr2Java::GetId");
 						  JNIEnv *env = RetrieveEnv(_jvm);

--- a/lang/cs/Org.Apache.REEF.Bridge/DriverRestartCompletedClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/DriverRestartCompletedClr2Java.cpp
@@ -47,6 +47,17 @@ namespace Org {
 							ManagedLog::LOGGER->LogStop("DriverRestartCompletedClr2Java::DriverRestartCompletedClr2Java");
 						}
 
+						DriverRestartCompletedClr2Java::~DriverRestartCompletedClr2Java() {
+							this->!DriverRestartCompletedClr2Java();
+						}
+
+						DriverRestartCompletedClr2Java::!DriverRestartCompletedClr2Java() {
+							if (_jobjectDriverRestartCompleted != NULL) {
+								JNIEnv *env = RetrieveEnv(_jvm);
+								env->DeleteGlobalRef(_jobjectDriverRestartCompleted);
+							}
+						}
+
 						bool DriverRestartCompletedClr2Java::IsTimedOut() {
 							return _isTimedOut;
 						}

--- a/lang/cs/Org.Apache.REEF.Bridge/DriverRestartedClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/DriverRestartedClr2Java.cpp
@@ -52,7 +52,20 @@ namespace Org {
 								_expectedEvaluatorIds[i] = ManagedStringFromJavaString(env, string);
 							}
 
+							env->DeleteGlobalRef(jevaluatorIds);
+
 							ManagedLog::LOGGER->LogStop("DriverRestartedClr2Java::DriverRestartedClr2Java");
+						}
+
+						DriverRestartedClr2Java::~DriverRestartedClr2Java() {
+							this->!DriverRestartedClr2Java();
+						}
+
+						DriverRestartedClr2Java::!DriverRestartedClr2Java() {
+							if (_jobjectDriverRestarted != NULL) {
+								JNIEnv *env = RetrieveEnv(_jvm);
+								env->DeleteGlobalRef(_jobjectDriverRestarted);
+							}
 						}
 
 						array<String^>^ DriverRestartedClr2Java::GetExpectedEvaluatorIds() {

--- a/lang/cs/Org.Apache.REEF.Bridge/EvaluatorRequestorClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/EvaluatorRequestorClr2Java.cpp
@@ -39,6 +39,17 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("EvaluatorRequestorClr2Java::EvaluatorRequestorClr2Java");
 					  }
 
+					  EvaluatorRequestorClr2Java::~EvaluatorRequestorClr2Java() {
+						  this->!EvaluatorRequestorClr2Java();
+					  }
+
+					  EvaluatorRequestorClr2Java::!EvaluatorRequestorClr2Java() {
+						  if (_jobjectEvaluatorRequestor != NULL) {
+							  JNIEnv *env = RetrieveEnv(_jvm);
+							  env->DeleteGlobalRef(_jobjectEvaluatorRequestor);
+						  }
+					  }
+
 					  void EvaluatorRequestorClr2Java::Submit(IEvaluatorRequest^ request) {
 						  ManagedLog::LOGGER->LogStart("EvaluatorRequestorClr2Java::Submit");
 						  JNIEnv *env = RetrieveEnv(_jvm);

--- a/lang/cs/Org.Apache.REEF.Bridge/FailedContextClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/FailedContextClr2Java.cpp
@@ -47,6 +47,29 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("FailedContextClr2Java::FailedContextClr2Java");
 					  }
 
+					  FailedContextClr2Java::~FailedContextClr2Java() {
+						  this->!FailedContextClr2Java();
+					  }
+
+					  FailedContextClr2Java::!FailedContextClr2Java() {
+						  JNIEnv *env = RetrieveEnv(_jvm);
+						  if (_jobjectFailedContext != NULL) {
+							  env->DeleteGlobalRef(_jobjectFailedContext);
+						  }
+
+						  if (_jstringContextId != NULL) {
+							  env->DeleteGlobalRef(_jstringContextId);
+						  }
+
+						  if (_jstringEvaluatorId != NULL) {
+							  env->DeleteGlobalRef(_jstringEvaluatorId);
+						  }
+
+						  if (_jstringParentContextId != NULL) {
+							  env->DeleteGlobalRef(_jstringParentContextId);
+						  }
+					  }
+
 					  IActiveContextClr2Java^ FailedContextClr2Java::GetParentContext() {
 						  ManagedLog::LOGGER->LogStart("FailedContextClr2Java::GetParentContext");
 

--- a/lang/cs/Org.Apache.REEF.Bridge/FailedEvaluatorClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/FailedEvaluatorClr2Java.cpp
@@ -44,6 +44,21 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("FailedEvaluatorClr2Java::FailedEvaluatorClr2Java");
 					  }
 
+					  FailedEvaluatorClr2Java::~FailedEvaluatorClr2Java() {
+						  this->!FailedEvaluatorClr2Java();
+					  }
+
+					  FailedEvaluatorClr2Java::!FailedEvaluatorClr2Java() {
+						  JNIEnv *env = RetrieveEnv(_jvm);
+						  if (_jobjectFailedEvaluator != NULL) {
+							  env->DeleteGlobalRef(_jobjectFailedEvaluator);
+						  }
+
+						  if (_jstringId != NULL) {
+							  env->DeleteGlobalRef(_jstringId);
+						  }
+					  }
+
 					  IEvaluatorRequestorClr2Java^ FailedEvaluatorClr2Java::GetEvaluatorRequestor() {
 						  ManagedLog::LOGGER->LogStart("FailedEvaluatorClr2Java::GetEvaluatorRequestor");
 						  JNIEnv *env = RetrieveEnv(_jvm);

--- a/lang/cs/Org.Apache.REEF.Bridge/FailedTaskClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/FailedTaskClr2Java.cpp
@@ -39,6 +39,17 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("FailedTaskClr2Java::AllocatedEvaluatorClr2Java");
 					  }
 
+					  FailedTaskClr2Java::~FailedTaskClr2Java() {
+						  this->!FailedTaskClr2Java();
+					  }
+
+					  FailedTaskClr2Java::!FailedTaskClr2Java() {
+						  if (_jobjectFailedTask != NULL) {
+							  JNIEnv *env = RetrieveEnv(_jvm);
+							  env->DeleteGlobalRef(_jobjectFailedTask);
+						  }
+					  }
+
 					  IActiveContextClr2Java^ FailedTaskClr2Java::GetActiveContext() {
 						  ManagedLog::LOGGER->LogStart("FailedTaskClr2Java::GetActiveContext");
 

--- a/lang/cs/Org.Apache.REEF.Bridge/HttpServerClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/HttpServerClr2Java.cpp
@@ -39,6 +39,17 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("HttpServerClr2Java::HttpServerClr2Java");
 					  }
 
+					  HttpServerClr2Java::~HttpServerClr2Java() {
+						  this->!HttpServerClr2Java();
+					  }
+
+					  HttpServerClr2Java::!HttpServerClr2Java() {
+						  if (_jhttpServerEventBridge != NULL) {
+							  JNIEnv *env = RetrieveEnv(_jvm);
+							  env->DeleteGlobalRef(_jhttpServerEventBridge); 
+						  }
+					  }
+
 					  String^ HttpServerClr2Java::GetQueryString() {
 						  ManagedLog::LOGGER->LogStart("HttpServerClr2Java::GetQueryString");
 						  JNIEnv *env = RetrieveEnv(_jvm);

--- a/lang/cs/Org.Apache.REEF.Bridge/RunningTaskClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/RunningTaskClr2Java.cpp
@@ -42,6 +42,21 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("RunningTaskClr2Java::RunningTaskClr2Java");
 					  }
 
+					  RunningTaskClr2Java::~RunningTaskClr2Java() {
+						  this->!RunningTaskClr2Java();
+					  }
+
+					  RunningTaskClr2Java::!RunningTaskClr2Java() {
+						  JNIEnv *env = RetrieveEnv(_jvm);
+						  if (_jobjectRunningTask != NULL) {
+							  env->DeleteGlobalRef(_jobjectRunningTask);
+						  }
+
+						  if (_jstringId != NULL) {
+							  env->DeleteGlobalRef(_jstringId);
+						  }
+					  }
+
 					  IActiveContextClr2Java^ RunningTaskClr2Java::GetActiveContext() {
 						  ManagedLog::LOGGER->LogStart("RunningTaskClr2Java::GetActiveContext");
 

--- a/lang/cs/Org.Apache.REEF.Bridge/SuspendedTaskClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/SuspendedTaskClr2Java.cpp
@@ -42,6 +42,21 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("SuspendedTaskClr2Java::SuspendedTaskClr2Java");
 					  }
 
+					  SuspendedTaskClr2Java::~SuspendedTaskClr2Java() {
+						  this->!SuspendedTaskClr2Java();
+					  }
+
+					  SuspendedTaskClr2Java::!SuspendedTaskClr2Java() {
+						  JNIEnv *env = RetrieveEnv(_jvm);
+						  if (_jobjectSuspendedTask != NULL) {
+							  env->DeleteGlobalRef(_jobjectSuspendedTask);
+						  }
+
+						  if (_jstringId != NULL) {
+							  env->DeleteGlobalRef(_jstringId);
+						  }
+					  }
+
 					  IActiveContextClr2Java^ SuspendedTaskClr2Java::GetActiveContext() {
 						  ManagedLog::LOGGER->LogStart("SuspendedTaskClr2Java::GetActiveContext");
 						  JNIEnv *env = RetrieveEnv(_jvm);

--- a/lang/cs/Org.Apache.REEF.Bridge/TaskMessageClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/TaskMessageClr2Java.cpp
@@ -42,6 +42,21 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("TaskMessageClr2Java::TaskMessageClr2Java");
 					  }
 
+					  TaskMessageClr2Java::~TaskMessageClr2Java() {
+						  this->!TaskMessageClr2Java();
+					  }
+
+					  TaskMessageClr2Java::!TaskMessageClr2Java() {
+						  JNIEnv *env = RetrieveEnv(_jvm);
+						  if (_jobjectTaskMessage != NULL) {
+							  env->DeleteGlobalRef(_jobjectTaskMessage);
+						  }
+
+						  if (_jstringId != NULL) {
+							  env->DeleteGlobalRef(_jstringId);
+						  }
+					  }
+
 					  void TaskMessageClr2Java::OnError(String^ message) {
 						  ManagedLog::LOGGER->Log("TaskMessageClr2Java::OnError");
 						  JNIEnv *env = RetrieveEnv(_jvm);


### PR DESCRIPTION
This addressed the issue by
  * Add Finalizer and Destructor in InterOp objects.
  * Call DeleteGlobalRef where NewGlobalRef is called.

JIRA:
  [REEF-1065](https://issues.apache.org/jira/browse/REEF-1065)