### PR TITLE
[REEF-1055] Enable StyleCop.CSharp.ReadabilityRules and fix violations

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
@@ -170,7 +170,7 @@ namespace Org.Apache.REEF.Client.Common
         /// </summary>
         /// <param name="filePath"></param>
         /// <returns></returns>
-        private static Boolean IsAssemblyToCopy(string filePath)
+        private static bool IsAssemblyToCopy(string filePath)
         {
             var fileName = Path.GetFileName(filePath);
             if (string.IsNullOrWhiteSpace(fileName))

--- a/lang/cs/Org.Apache.REEF.Client/Common/JavaClientLauncher.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/JavaClientLauncher.cs
@@ -64,8 +64,9 @@ namespace Org.Apache.REEF.Client.Common
                 RedirectStandardError = true
             };
 
-            Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Launch Java with command: {0} {1}",
-                startInfo.FileName, startInfo.Arguments));
+            var msg = string.Format(CultureInfo.CurrentCulture, "Launch Java with command: {0} {1}",
+                startInfo.FileName, startInfo.Arguments);
+            Logger.Log(Level.Info, msg);
 
             var process = Process.Start(startInfo);
             if (process != null)

--- a/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
@@ -172,7 +172,7 @@ namespace Org.Apache.REEF.Client.Common
             return shouldRetry;
         }
 
-        private static Tuple<bool, string> CommandFailed(String reason)
+        private static Tuple<bool, string> CommandFailed(string reason)
         {
             return new Tuple<bool, string>(false, null);
         }
@@ -208,8 +208,7 @@ namespace Org.Apache.REEF.Client.Common
                     if (!ShouldRetry(httpRequestException))
                     {
                         LOGGER.Log(Level.Error,
-                            commandUri + " exception " + httpRequestException.Message + "\n" +
-                            httpRequestException.StackTrace);
+                            commandUri + " exception " + httpRequestException.Message + "\n" + httpRequestException.StackTrace);
                         result = CommandFailed(httpRequestException.Message);
                         LOGGER.Log(Level.Warning, "Connection failed. connectAttemptCount was " + connectAttemptCount + ".");
                         break;
@@ -301,7 +300,7 @@ namespace Org.Apache.REEF.Client.Common
                     _driverUrl = values[TrackingUrlKey].ToString();
                     LOGGER.Log(Level.Info, "trackingUrl[" + _driverUrl + "]");
 
-                    if (0 == String.Compare(_driverUrl, UnAssigned))
+                    if (0 == string.Compare(_driverUrl, UnAssigned))
                     {
                         resultKind = UrlResultKind.UrlNotAssignedYet;
                     }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
@@ -145,8 +145,8 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
                 catch (Exception e)
                 {
                     exceptions.Add(e);
-                    Logger.Log(Level.Verbose, string.Format(
-                        CultureInfo.CurrentCulture, "Possibly transient error in rest call {0}", e.Message));
+                    Logger.Log(Level.Verbose, 
+                        string.Format(CultureInfo.CurrentCulture, "Possibly transient error in rest call {0}", e.Message));
                 }
             }
 
@@ -169,8 +169,8 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
                 catch (Exception e)
                 {
                     exceptions.Add(e);
-                    Logger.Log(Level.Verbose, string.Format(
-                        CultureInfo.CurrentCulture, "Possibly transient error in rest call {0}", e.Message));
+                    Logger.Log(Level.Verbose, 
+                        string.Format(CultureInfo.CurrentCulture, "Possibly transient error in rest call {0}", e.Message));
                 }
             }
 

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
@@ -112,8 +112,9 @@ namespace Org.Apache.REEF.Client.Yarn
         {
             var application = await _yarnClient.GetApplicationAsync(appId);
 
-            Logger.Log(Level.Verbose, string.Format("application status {0}, Progress: {1}, trackingUri: {2}, Name: {3}, ApplicationId: {4}, State {5}.",
-                application.FinalStatus, application.Progress, application.TrackingUI, application.Name, application.Id, application.State));
+            var msg = string.Format("application status {0}, Progress: {1}, trackingUri: {2}, Name: {3}, ApplicationId: {4}, State {5}.",
+                application.FinalStatus, application.Progress, application.TrackingUI, application.Name, application.Id, application.State);
+            Logger.Log(Level.Verbose, msg);
 
             return application.FinalStatus;
         }

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Utils/EvaluatorConfigurations.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Utils/EvaluatorConfigurations.cs
@@ -73,8 +73,8 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Utils
 
                 IInjector evaluatorInjector = TangFactory.GetTang().NewInjector(evaluatorConfiguration);
 
-                LOGGER.Log(Level.Info, String.Format(CultureInfo.CurrentCulture,
-                    "Evaluator Configuration is deserialized from file {0}:", configFile));
+                LOGGER.Log(Level.Info, 
+                    string.Format(CultureInfo.CurrentCulture, "Evaluator Configuration is deserialized from file {0}:", configFile));
                 try
                 {
                     _taskConfiguration = evaluatorInjector.GetNamedInstance<InitialTaskConfiguration, string>();

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/BridgeConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/BridgeConfigurationProvider.cs
@@ -74,10 +74,10 @@ namespace Org.Apache.REEF.Driver.Bridge
 
             if (newExists && oldExists)
             {
-                Logger.Log(Level.Warning, "Found configurations in both the legacy location (" +
-                                          legacyBridgeConfigurationPath + ") and the new location (" +
-                                          newBridgeConfigurationPath +
-                                          "). Loading only the one found in the new location.");
+                var msg = "Found configurations in both the legacy location (" + legacyBridgeConfigurationPath + 
+                    ") and the new location (" + newBridgeConfigurationPath +
+                    "). Loading only the one found in the new location.";
+                Logger.Log(Level.Warning, msg);
             }
             if (newExists)
             {
@@ -85,10 +85,10 @@ namespace Org.Apache.REEF.Driver.Bridge
             }
             if (oldExists)
             {
-                Logger.Log(Level.Warning, "Only found configuration in the legacy location (" +
-                                          legacyBridgeConfigurationPath + ") and not the new location (" +
-                                          newBridgeConfigurationPath +
-                                          "). Loading only the one found in the legacy location.");
+                var msg = "Only found configuration in the legacy location (" + legacyBridgeConfigurationPath + 
+                    ") and not the new location (" + newBridgeConfigurationPath +
+                    "). Loading only the one found in the legacy location.";
+                Logger.Log(Level.Warning, msg);
                 return legacyBridgeConfigurationPath;
             }
 

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/IInteropReturnInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/IInteropReturnInfo.cs
@@ -22,8 +22,8 @@ namespace Org.Apache.REEF.Driver.Bridge
 {
     public interface IInteropReturnInfo
     {
-        void AddExceptionString(String exceptionString);       
-        Boolean HasExceptions();
+        void AddExceptionString(string exceptionString);       
+        bool HasExceptions();
         void SetReturnCode(int rc);
         int GetReturnCode();
     }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/ILogger.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/ILogger.cs
@@ -32,6 +32,6 @@ namespace Org.Apache.REEF.Driver.Bridge
 
     public interface ILogger
     {
-        void Log(TraceLevel traceLevel, String message);
+        void Log(TraceLevel traceLevel, string message);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequestBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequestBuilder.cs
@@ -41,7 +41,7 @@ namespace Org.Apache.REEF.Driver.Evaluator
             Number = 1;
             VirtualCore = 1;
             MegaBytes = 64;
-            _rackName = String.Empty;
+            _rackName = string.Empty;
             _evaluatorBatchId = Guid.NewGuid().ToString("N");
         }
 

--- a/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
@@ -143,8 +143,8 @@ namespace Org.Apache.REEF.Evaluator
             try
             {
                 var clrDriverConfig = new AvroConfigurationSerializer().FromFile(clrRuntimeConfigurationFile);
-                logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture,
-                    "Clr Driver Configuration is deserialized from file {0}:", clrRuntimeConfigurationFile));
+                logger.Log(Level.Info, 
+                    string.Format(CultureInfo.CurrentCulture, "Clr Driver Configuration is deserialized from file {0}:", clrRuntimeConfigurationFile));
                 return clrDriverConfig;
             }
             catch (Exception e)
@@ -169,8 +169,8 @@ namespace Org.Apache.REEF.Evaluator
                 .GetClassHierarchy(new string[] { typeof(ApplicationIdentifier).Assembly.GetName().Name });
             var evaluatorConfiguration = serializer.FromFile(evaluatorConfigFile, classHierarchy);
 
-            logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture,
-                "Evaluator Configuration is deserialized from file {0}:", evaluatorConfigFile));
+            logger.Log(Level.Info, 
+                string.Format(CultureInfo.CurrentCulture, "Evaluator Configuration is deserialized from file {0}:", evaluatorConfigFile));
 
             return evaluatorConfiguration;
         }

--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/HelloHttpHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/HelloHttpHandler.cs
@@ -50,9 +50,10 @@ namespace Org.Apache.REEF.Examples.AllHandlers
         /// <param name="response"></param>
         public void OnHttpRequest(ReefHttpRequest request, ReefHttpResponse response)  
         {
-            Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, 
+            var msg = string.Format(CultureInfo.CurrentCulture, 
                 "HelloHttpHandler OnHttpRequest: URL: {0}, QueryString: {1}, inputStream: {2}.", 
-                request.Url, request.Querystring, ByteUtilities.ByteArraysToString(request.InputStream)));
+                request.Url, request.Querystring, ByteUtilities.ByteArraysToString(request.InputStream));
+            Logger.Log(Level.Info, msg);
             response.Status = HttpStatusCode.OK;
             response.OutputStream =
                 ByteUtilities.StringToByteArrays("Byte array returned from HelloHttpHandler in CLR!!!");

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/MapperCountTest.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/MapperCountTest.cs
@@ -44,7 +44,7 @@ namespace Org.Apache.REEF.IMRU.Tests
                             .Set(InProcessIMRUConfiguration.NumberOfMappers, NumberOfMappers.ToString())
                             .Build())
                     .GetInstance<MapperCount>();
-            var result = tested.Run(NumberOfMappers, "", TangFactory.GetTang().NewConfigurationBuilder().Build());
+            var result = tested.Run(NumberOfMappers, string.Empty, TangFactory.GetTang().NewConfigurationBuilder().Build());
             Assert.True(NumberOfMappers == result, "The result of the run should be the number of Mappers.");
         }
     }

--- a/lang/cs/Org.Apache.REEF.IMRU/InProcess/InProcessIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/InProcess/InProcessIMRUClient.cs
@@ -92,8 +92,7 @@ namespace Org.Apache.REEF.IMRU.InProcess
                 (ISet<IPerMapperConfigGenerator>)injector.GetNamedInstance(typeof(PerMapConfigGeneratorSet));
 
             injector.BindVolatileInstance(GenericType<MapFunctions<TMapInput, TMapOutput>>.Class,
-                MakeMapFunctions<TMapInput, TMapOutput>(jobDefinition.MapFunctionConfiguration,
-                    jobDefinition.PartitionedDatasetConfiguration, perMapConfigGenerators));
+                MakeMapFunctions<TMapInput, TMapOutput>(jobDefinition.MapFunctionConfiguration, jobDefinition.PartitionedDatasetConfiguration, perMapConfigGenerators));
 
             var runner = injector.GetInstance<IMRURunner<TMapInput, TMapOutput, TResult>>();
             return runner.Run();

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ConfigurationManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ConfigurationManager.cs
@@ -49,10 +49,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             [Parameter(typeof(SerializedUpdateConfiguration))] string updateConfig,
             [Parameter(typeof(SerializedMapInputCodecConfiguration))] string mapInputCodecConfig,
             [Parameter(typeof(SerializedUpdateFunctionCodecsConfiguration))] string updateFunctionCodecsConfig,
-            [Parameter(typeof(SerializedMapOutputPipelineDataConverterConfiguration))] string
-                mapOutputPipelineDataConverterConfiguration,
-            [Parameter(typeof(SerializedMapInputPipelineDataConverterConfiguration))] string
-                mapInputPipelineDataConverterConfiguration,
+            [Parameter(typeof(SerializedMapOutputPipelineDataConverterConfiguration))] string mapOutputPipelineDataConverterConfiguration,
+            [Parameter(typeof(SerializedMapInputPipelineDataConverterConfiguration))] string mapInputPipelineDataConverterConfiguration,
             [Parameter(typeof(SerializedResultHandlerConfiguration))] string resultHandlerConfiguration)
         {
             try

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -118,9 +118,9 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                 new ServiceAndContextConfigurationProvider<TMapInput, TMapOutput>(dataSet.Count + 1, groupCommDriver,
                     _configurationManager, _partitionDescriptorStack);
 
-            Logger.Log(Level.Info,
-                string.Format("map task memory:{0}, update task memory:{1}, map task cores:{2}, update task cores:{3}",
-                    _memoryPerMapper, _memoryForUpdateTask, _coresPerMapper, _coresForUpdateTask));
+            var msg = string.Format("map task memory:{0}, update task memory:{1}, map task cores:{2}, update task cores:{3}",
+                _memoryPerMapper, _memoryForUpdateTask, _coresPerMapper, _coresForUpdateTask);
+            Logger.Log(Level.Info, msg);
         }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             
             foreach (var task in _completedTasks)
             {
-                Logger.Log(Level.Verbose, String.Format("Disposing task: {0}", task.Id));
+                Logger.Log(Level.Verbose, string.Format("Disposing task: {0}", task.Id));
                 task.ActiveContext.Dispose();
             }
         }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/WriteResultHandler.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/WriteResultHandler.cs
@@ -96,7 +96,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.ResultHandler
         {
             string localFileFolder = Path.GetTempPath() + "-partition-" + Guid.NewGuid().ToString("N").Substring(0, 8);
             Directory.CreateDirectory(localFileFolder);
-            var localFilePath = String.Format("{0}\\{1}", localFileFolder, Guid.NewGuid().ToString("N").Substring(0, 8));
+            var localFilePath = string.Format("{0}\\{1}", localFileFolder, Guid.NewGuid().ToString("N").Substring(0, 8));
 
             if (File.Exists(localFilePath))
             {

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HDFSCommandRunner.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HDFSCommandRunner.cs
@@ -120,7 +120,7 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
             };
             for (var attemptNumber = 0; attemptNumber < _numberOfRetries; ++attemptNumber)
             {
-                var processName = String.Format("HDFS_Attempt_{0}_of_{1}", attemptNumber, _numberOfRetries);
+                var processName = string.Format("HDFS_Attempt_{0}_of_{1}", attemptNumber, _numberOfRetries);
                 var result = RunAttempt(processStartInfo, _timeOutInMilliSeconds, processName);
                 if (null != result)
                 {

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileInputPartitionDescriptor.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileInputPartitionDescriptor.cs
@@ -58,8 +58,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
 
             foreach (string p in _filePaths)
             {
-                builder = builder.BindSetEntry<FilePathsInInputPartition, string>
-                    (GenericType<FilePathsInInputPartition>.Class, p);
+                builder = builder.BindSetEntry<FilePathsInInputPartition, string>(GenericType<FilePathsInInputPartition>.Class, p);
             }
 
             return Configurations.Merge(builder.Build(), _filePartitionDeserializerConfig);

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartition.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartition.cs
@@ -95,8 +95,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
             foreach (var sourceFilePath in _filePaths)
             {
                 Uri sourceUri = _fileSystem.CreateUriForPath(sourceFilePath);
-                Logger.Log(Level.Info, string.Format
-                        (CultureInfo.CurrentCulture, "sourceUri {0}: ", sourceUri));
+                Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "sourceUri {0}: ", sourceUri));
                 if (!_fileSystem.Exists(sourceUri))
                 {
                     throw new FileNotFoundException(string.Format(CultureInfo.CurrentCulture,
@@ -104,8 +103,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
                 }
 
                 var localFilePath = _localFileFolder + "\\" + Guid.NewGuid().ToString("N").Substring(0, 8);
-                Logger.Log(Level.Info, string.Format
-                       (CultureInfo.CurrentCulture, "localFilePath {0}: ", localFilePath));
+                Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "localFilePath {0}: ", localFilePath));
                 if (File.Exists(localFilePath))
                 {
                     File.Delete(localFilePath);
@@ -115,13 +113,13 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
                 _fileSystem.CopyToLocal(sourceUri, localFilePath);
                 if (File.Exists(localFilePath))
                 {
-                    Logger.Log(Level.Info, string.Format
-                        (CultureInfo.CurrentCulture, "File {0} is Copied to local {1}.", sourceUri, localFilePath));
+                    Logger.Log(Level.Info, 
+                        string.Format(CultureInfo.CurrentCulture, "File {0} is Copied to local {1}.", sourceUri, localFilePath));
                 }
                 else
                 {
-                    string msg = string.Format
-                        (CultureInfo.CurrentCulture, "The IFilesystem completed the copy of `{0}` to `{1}`. But the file `{1}` does not exist.", sourceUri, localFilePath);
+                    string msg = string.Format(CultureInfo.CurrentCulture, 
+                        "The IFilesystem completed the copy of `{0}` to `{1}`. But the file `{1}` does not exist.", sourceUri, localFilePath);
                     Exceptions.Throw(new FileLoadException(msg), msg, Logger);
                 }
             }

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionInputDataSet.cs
@@ -126,7 +126,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         /// <returns></returns>
         private static string FormId(ISet<string> filePaths)
         {
-            string id = "";
+            string id = string.Empty;
             try
             {
                 if (filePaths != null && filePaths.Count > 0)

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/MasterTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/MasterTask.cs
@@ -91,10 +91,10 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
 
                 if (i >= 2)
                 {
-                    Logger.Log(Level.Info,
-                        string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
+                    var msg = string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
                             broadcastTime.ElapsedMilliseconds / ((double)(i - 1)),
-                            reduceTime.ElapsedMilliseconds / ((double)(i - 1))));
+                            reduceTime.ElapsedMilliseconds / ((double)(i - 1)));
+                    Logger.Log(Level.Info, msg);
                 }
             }
 

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/SlaveTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/SlaveTask.cs
@@ -76,10 +76,10 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
                 
                 if (i >= 1)
                 {
-                    Logger.Log(Level.Info,
-                        string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
+                    var msg = string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
                             broadcastTime.ElapsedMilliseconds / ((double)i),
-                            reduceTime.ElapsedMilliseconds / ((double)i)));
+                            reduceTime.ElapsedMilliseconds / ((double)i));
+                    Logger.Log(Level.Info, msg);
                 }
             }
 

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
@@ -269,20 +269,20 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
 
             public byte[] Encode(int[] obj)
             {
-                var result = new byte[sizeof(Int32) * obj.Length];
+                var result = new byte[sizeof(int) * obj.Length];
                 Buffer.BlockCopy(obj, 0, result, 0, result.Length);
                 return result;
             }
 
             public int[] Decode(byte[] data)
             {
-                if (data.Length % sizeof(Int32) != 0)
+                if (data.Length % sizeof(int) != 0)
                 {
                     throw new Exception(
                         "error inside integer array decoder, byte array length not a multiple of integer size");
                 }
 
-                var result = new int[data.Length / sizeof(Int32)];
+                var result = new int[data.Length / sizeof(int)];
                 Buffer.BlockCopy(data, 0, result, 0, data.Length);
                 return result;
             }

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedMasterTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedMasterTask.cs
@@ -102,10 +102,10 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
 
                 if (i >= 2)
                 {
-                    Logger.Log(Level.Info,
-                        string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
+                    var msg = string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
                             broadcastTime.ElapsedMilliseconds / ((double)(i - 1)),
-                            reduceTime.ElapsedMilliseconds / ((double)(i - 1))));
+                            reduceTime.ElapsedMilliseconds / ((double)(i - 1)));
+                    Logger.Log(Level.Info, msg);
                 }
             }
 

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedSlaveTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedSlaveTask.cs
@@ -95,10 +95,10 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
 
                 if (i >= 1)
                 {
-                    Logger.Log(Level.Info,
-                        string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
+                    var msg = string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
                             broadcastTime.ElapsedMilliseconds / ((double)i),
-                            reduceTime.ElapsedMilliseconds / ((double)i)));
+                            reduceTime.ElapsedMilliseconds / ((double)i));
+                    Logger.Log(Level.Info, msg);
                 }
             }
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
@@ -59,7 +59,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         private readonly INameClient _nameClient;
         private readonly Sender _sender;
         private readonly BlockingCollection<NodeStruct<T>> _nodesWithData;
-        private readonly Object _thisLock = new Object();
+        private readonly object _thisLock = new object();
 
         /// <summary>
         /// Creates a new OperatorTopology object.

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/Codec/StreamingCodecFunctionCache.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/Codec/StreamingCodecFunctionCache.cs
@@ -148,8 +148,8 @@ namespace Org.Apache.REEF.Network.NetworkService.Codec
                 var codec = _injector.GetInstance(codecType);
 
                 MethodInfo readMethod = codec.GetType().GetMethod("Read");
-                _readFuncCache[messageType] = (Func<IDataReader, T>)Delegate.CreateDelegate
-                    (typeof(Func<IDataReader, T>), codec, readMethod);
+                _readFuncCache[messageType] = 
+                    (Func<IDataReader, T>)Delegate.CreateDelegate(typeof(Func<IDataReader, T>), codec, readMethod);
 
                 MethodInfo readAsyncMethod = codec.GetType().GetMethod("ReadAsync");
                 MethodInfo genericHelper = GetType()
@@ -177,8 +177,8 @@ namespace Org.Apache.REEF.Network.NetworkService.Codec
 
         private Action<T, IDataWriter> WriteHelperFunc<T1>(MethodInfo method, object codec) where T1 : class
         {
-            Action<T1, IDataWriter> func = (Action<T1, IDataWriter>)Delegate.CreateDelegate
-                (typeof(Action<T1, IDataWriter>), codec, method);
+            Action<T1, IDataWriter> func = 
+                (Action<T1, IDataWriter>)Delegate.CreateDelegate(typeof(Action<T1, IDataWriter>), codec, method);
 
             Action<T, IDataWriter> ret = (obj, writer) => func(obj as T1, writer);
             return ret;
@@ -188,8 +188,8 @@ namespace Org.Apache.REEF.Network.NetworkService.Codec
             where T1 : class
         {
             Func<T1, IDataWriter, CancellationToken, Task> func =
-                (Func<T1, IDataWriter, CancellationToken, Task>)Delegate.CreateDelegate
-                    (typeof(Func<T1, IDataWriter, CancellationToken, Task>), codec, method);
+                (Func<T1, IDataWriter, CancellationToken, Task>)
+                Delegate.CreateDelegate(typeof(Func<T1, IDataWriter, CancellationToken, Task>), codec, method);
 
             Func<T, IDataWriter, CancellationToken, Task> ret = (obj, writer, token) => func(obj as T1, writer, token);
             return ret;
@@ -199,8 +199,8 @@ namespace Org.Apache.REEF.Network.NetworkService.Codec
             where T1 : class
         {
             Func<IDataReader, CancellationToken, Task<T1>> func =
-                (Func<IDataReader, CancellationToken, Task<T1>>)Delegate.CreateDelegate
-                    (typeof(Func<IDataReader, CancellationToken, Task<T1>>), codec, method);
+                (Func<IDataReader, CancellationToken, Task<T1>>)
+                Delegate.CreateDelegate(typeof(Func<IDataReader, CancellationToken, Task<T1>>), codec, method);
 
             Func<IDataReader, CancellationToken, T1> func1 = (writer, token) => func(writer, token).Result;
             Func<IDataReader, CancellationToken, T> func2 = (writer, token) => ((T)(object)func1(writer, token));

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/DocumentedLocalNamedParameter.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/DocumentedLocalNamedParameter.cs
@@ -26,12 +26,12 @@ namespace Org.Apache.REEF.Tang.Examples
     {
         readonly string value;
         [NamedParameter(Documentation = "doc stuff", ShortName = "DocFoo", DefaultValue = "some value")]
-        public sealed class Foo : Name<String> 
+        public sealed class Foo : Name<string> 
         {
         }
 
         [Inject]
-        public DocumentedLocalNamedParameter([Parameter(typeof(Foo))] String s) 
+        public DocumentedLocalNamedParameter([Parameter(typeof(Foo))] string s) 
         {
             value = s;
         }

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/NamedParameterConstructors.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/NamedParameterConstructors.cs
@@ -25,12 +25,12 @@ namespace Org.Apache.REEF.Tang.Examples
     public class NamedParameterConstructors
     {
         [NamedParameter]
-        public class X : Name<String> 
+        public class X : Name<string> 
         {
-        };
+        }
 
         [Inject]
-        public NamedParameterConstructors(String x, [Parameter(typeof(X))] String y) 
+        public NamedParameterConstructors(string x, [Parameter(typeof(X))] string y) 
         {
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/ShortNameFooAB.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/ShortNameFooAB.cs
@@ -23,13 +23,13 @@ using Org.Apache.REEF.Tang.Annotations;
 namespace Org.Apache.REEF.Tang.Examples
 {
     [NamedParameter(ShortName = "fooA")]
-    public class ShortNameFooA : Name<String> 
+    public class ShortNameFooA : Name<string> 
     {
     }
 
     // when same short name is used, exception would throw when building the class hierarchy
     [NamedParameter(ShortName = "fooB")]
-    public class ShortNameFooB : Name<Int32> 
+    public class ShortNameFooB : Name<int> 
     {
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/SimpleConstructors.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/SimpleConstructors.cs
@@ -35,7 +35,7 @@ namespace Org.Apache.REEF.Tang.Examples
         }
 
         [Inject]
-        public SimpleConstructors(int x, String y) 
+        public SimpleConstructors(int x, string y) 
         {
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/Timer.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/Timer.cs
@@ -26,7 +26,7 @@ namespace Org.Apache.REEF.Tang.Examples
     public class Timer
     {
         [NamedParameter("Number of seconds to sleep", "sec", "10")]
-        public class Seconds : Name<Int32> 
+        public class Seconds : Name<int> 
         { 
         }
         private readonly int seconds;

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/TweetExample.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/TweetExample.cs
@@ -24,12 +24,12 @@ namespace Org.Apache.REEF.Tang.Examples
 {
     public interface ISMS
     {
-        void SendSMS(String msg, long phoneNumber);
+        void SendSMS(string msg, long phoneNumber);
     }
 
     public interface ITweetFactory
     {
-        String GetTweet();
+        string GetTweet();
     } 
 
     public class MockTweetFactory : ITweetFactory 
@@ -39,7 +39,7 @@ namespace Org.Apache.REEF.Tang.Examples
         {
         }
 
-        public String GetTweet() 
+        public string GetTweet() 
         {
             return "@tw #bbq bbqftw!!! gopher://vuwed.wefd/bbqftw!";
         }
@@ -52,7 +52,7 @@ namespace Org.Apache.REEF.Tang.Examples
         {
         }
 
-        public void SendSMS(String msg, long phoneNumber) 
+        public void SendSMS(string msg, long phoneNumber) 
         {
             if (phoneNumber != 8675309) 
             {

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
@@ -61,7 +61,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             }
             Assert.Null(n);
 
-            Assert.NotNull(ns.GetNode(typeof(System.String).AssemblyQualifiedName));
+            Assert.NotNull(ns.GetNode(typeof(string).AssemblyQualifiedName));
 
             string msg = null;  
             try
@@ -94,7 +94,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             }
             Assert.Null(n);
 
-            Assert.NotNull(ns.GetNode(typeof(System.Int32).AssemblyQualifiedName));
+            Assert.NotNull(ns.GetNode(typeof(int).AssemblyQualifiedName));
 
             string msg = null;      
             try
@@ -556,7 +556,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
     class NamedParameterTypeMismatch 
     {
         [NamedParameter(Documentation = "doc.stuff", DefaultValue = "1")]
-        class Foo : Name<Int32> 
+        class Foo : Name<int> 
         {
         }
 
@@ -634,13 +634,13 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
     }
 
     [NamedParameter(ShortName = "foo")]
-    public class ShortNameFooA : Name<String>
+    public class ShortNameFooA : Name<string>
     {
     }
 
     // when same short name is used, exception would throw when building the class hierarchy
     [NamedParameter(ShortName = "foo")]
-    public class ShortNameFooB : Name<Int32>
+    public class ShortNameFooB : Name<int>
     {
     }
 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestParameterParser.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestParameterParser.cs
@@ -33,14 +33,14 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         public void ParseIntTest()
         {
             var parser = new ParameterParser();
-            Int32 o = (Int32)parser.Parse(typeof(Int32), "4");
+            int o = (int)parser.Parse(typeof(int), "4");
         }
 
         [Fact]
         public void ParseBoolTest()
         {
             var parser = new ParameterParser();
-            Boolean o = (Boolean)parser.Parse(typeof(Boolean), "false");
+            bool o = (bool)parser.Parse(typeof(bool), "false");
         }
 
         [Fact]
@@ -61,35 +61,35 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         public void ParseDoubleTest()
         {
             var parser = new ParameterParser();
-            Double o = (Double)parser.Parse(typeof(double), "12.6");
+            double o = (double)parser.Parse(typeof(double), "12.6");
         }
 
         [Fact]
         public void ParseCharTest()
         {
             var parser = new ParameterParser();
-            Char o = (Char)parser.Parse(typeof(char), "c");
+            char o = (char)parser.Parse(typeof(char), "c");
         }
 
         [Fact]
         public void ParseByteTest()
         {
             var parser = new ParameterParser();
-            Byte o = (Byte)parser.Parse(typeof(byte), "8");
+            byte o = (byte)parser.Parse(typeof(byte), "8");
         }
 
         [Fact]
         public void ParseShortTest()
         {
             var parser = new ParameterParser();
-            Int16 o = (Int16)parser.Parse(typeof(short), "8");
+            short o = (short)parser.Parse(typeof(short), "8");
         }
 
         [Fact]
         public void ParseFloatTest()
         {
             var parser = new ParameterParser();
-            Single o = (Single)parser.Parse(typeof(float), "8.567");
+            float o = (float)parser.Parse(typeof(float), "8.567");
         }
 
         [Fact]
@@ -226,7 +226,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         {
             private readonly Bar bar;
             [Inject]
-            public BarParser(String s)
+            public BarParser(string s)
             {
                 this.bar = new Bar(s);
             }
@@ -282,7 +282,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         {
             readonly ParseableType instance;
             [Inject]
-            public TypeParser(String s)
+            public TypeParser(string s)
             {
                 if (s.Equals("a")) 
                 { 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestSerilization.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestSerilization.cs
@@ -172,7 +172,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Type timerType = typeof(Timer);
             ITang tang = TangFactory.GetTang();
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder(new string[] { FileNames.Examples });
-            cb.BindNamedParameter<Timer.Seconds, Int32>(GenericType<Timer.Seconds>.Class, "2");
+            cb.BindNamedParameter<Timer.Seconds, int>(GenericType<Timer.Seconds>.Class, "2");
             IConfiguration conf = cb.Build();
             IInjector injector = tang.NewInjector(conf);
             Org.Apache.REEF.Tang.Implementations.InjectionPlan.InjectionPlan ip = injector.GetInjectionPlan(timerType);

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Configuration/TestConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Configuration/TestConfiguration.cs
@@ -54,7 +54,7 @@ namespace Org.Apache.REEF.Tang.Tests.Configuration
             serializer.ToFile(conf1, "task.config");
 
             ICsConfigurationBuilder cb2 = tang.NewConfigurationBuilder();
-            cb2.BindNamedParameter<Timer.Seconds, Int32>(GenericType<Timer.Seconds>.Class, "2");
+            cb2.BindNamedParameter<Timer.Seconds, int>(GenericType<Timer.Seconds>.Class, "2");
             IConfiguration conf2 = cb2.Build();
             serializer.ToFile(conf2, "timer.config");
 
@@ -354,7 +354,7 @@ namespace Org.Apache.REEF.Tang.Tests.Configuration
             Type timerType = typeof(Timer);
             ITang tang = TangFactory.GetTang();
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder(new string[] { FileNames.Examples });
-            cb.BindNamedParameter<Timer.Seconds, Int32>(GenericType<Timer.Seconds>.Class, "2");
+            cb.BindNamedParameter<Timer.Seconds, int>(GenericType<Timer.Seconds>.Class, "2");
             IConfiguration conf = cb.Build();
 
             ConfigurationFile.WriteConfigurationFile(conf, "timerConf.txt");
@@ -406,7 +406,7 @@ namespace Org.Apache.REEF.Tang.Tests.Configuration
 
             ITang tang = TangFactory.GetTang();
             IConfiguration conf = tang.NewConfigurationBuilder(classHierarchyImpl)
-                                      .BindNamedParameter<Timer.Seconds, Int32>(GenericType<Timer.Seconds>.Class, "1")
+                                      .BindNamedParameter<Timer.Seconds, int>(GenericType<Timer.Seconds>.Class, "1")
                                       .Build();
 
             ConfigurationFile.WriteConfigurationFile(conf, "timerConfH.txt");

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Tang/TestTang.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Tang/TestTang.cs
@@ -106,8 +106,8 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         public void TestRepeatedOKArgs()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
-            cb.BindNamedParameter<RepeatedNamedArgs.A, Int32>(GenericType<RepeatedNamedArgs.A>.Class, "1");
-            cb.BindNamedParameter<RepeatedNamedArgs.B, Int32>(GenericType<RepeatedNamedArgs.B>.Class, "2");
+            cb.BindNamedParameter<RepeatedNamedArgs.A, int>(GenericType<RepeatedNamedArgs.A>.Class, "1");
+            cb.BindNamedParameter<RepeatedNamedArgs.B, int>(GenericType<RepeatedNamedArgs.B>.Class, "2");
 
             IInjector injector = tang.NewInjector(cb.Build());
             injector.GetInstance(typeof(RepeatedNamedArgs));
@@ -288,14 +288,14 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         public void testThreeConstructors() 
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
-            cb.BindNamedParameter<ThreeConstructors.TCInt, Int32>(GenericType<ThreeConstructors.TCInt>.Class, "1");
+            cb.BindNamedParameter<ThreeConstructors.TCInt, int>(GenericType<ThreeConstructors.TCInt>.Class, "1");
             cb.BindNamedParameter<ThreeConstructors.TCString, string>(GenericType<ThreeConstructors.TCString>.Class, "s");
             ThreeConstructors tc = tang.NewInjector(cb.Build()).GetInstance<ThreeConstructors>();
             Assert.AreEqual(1, tc.i);
             Assert.AreEqual("s", tc.s);
     
             cb = tang.NewConfigurationBuilder();
-            cb.BindNamedParameter<ThreeConstructors.TCInt, Int32>(GenericType<ThreeConstructors.TCInt>.Class, "1");
+            cb.BindNamedParameter<ThreeConstructors.TCInt, int>(GenericType<ThreeConstructors.TCInt>.Class, "1");
             tc = tang.NewInjector(cb.Build()).GetInstance<ThreeConstructors>();
             Assert.AreEqual(1, tc.i);
             Assert.AreEqual("default", tc.s);
@@ -347,7 +347,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             try
             {
                 ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
-                cb.BindNamedParameter<TwoConstructors.TCInt, Int32>(GenericType<TwoConstructors.TCInt>.Class, "1");
+                cb.BindNamedParameter<TwoConstructors.TCInt, int>(GenericType<TwoConstructors.TCInt>.Class, "1");
                 cb.BindNamedParameter<ThreeConstructors.TCString, string>(GenericType<ThreeConstructors.TCString>.Class, "s");
                 tang.NewInjector(cb.Build()).GetInstance<TwoConstructors>();
                 msg = @"Cannot inject Org.Apache.REEF.Tang.Tests.Tang.TwoConstructors, Org.Apache.REEF.Tang.Test, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null " +
@@ -552,7 +552,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder(EmptyStringAsDefaultParamConf.ConfigurationModule.Build());
             var value = tang.NewInjector(cb.Build()).GetNamedInstance<EmptyStringAsDefaultParam, string>();
-            Assert.IsNotNull(value.Equals(""));
+            Assert.IsNotNull(value.Equals(string.Empty));
         }
     }
 
@@ -610,12 +610,12 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
     public class RepeatedNamedArgs
     {
         [NamedParameter]
-        public class A : Name<Int32>
+        public class A : Name<int>
         {
         }
 
         [NamedParameter]
-        public class B : Name<Int32>
+        public class B : Name<int>
         {
         }
 
@@ -663,7 +663,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
     }
 
     [NamedParameter(Documentation = "woo", ShortName = "woo", DefaultValue = "42")]
-    internal class Param : Name<Int32>
+    internal class Param : Name<int>
     {
     }
 
@@ -711,7 +711,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         public string b;
 
         [Inject]
-        private TwoNamedStringArgs([Parameter(typeof(A))] string a, [Parameter(typeof(B))] String b)
+        private TwoNamedStringArgs([Parameter(typeof(A))] string a, [Parameter(typeof(B))] string b)
         {
             this.a = a;
             this.b = b;
@@ -875,7 +875,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         public float f;
 
         [NamedParameter]
-        public class TCInt : Name<Int32> 
+        public class TCInt : Name<int> 
         { 
         }
 
@@ -922,7 +922,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         public string s;
 
         [NamedParameter]
-        public class TCInt : Name<Int32> 
+        public class TCInt : Name<int> 
         { 
         }
 
@@ -963,7 +963,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         }
   
         [Inject]
-        public SingletonMultiConst([Parameter(typeof(A))] String a) 
+        public SingletonMultiConst([Parameter(typeof(A))] string a) 
         { 
         }
         
@@ -1113,7 +1113,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
     { 
     }
 
-    internal class Foo : Name<String>
+    internal class Foo : Name<string>
     {
     }
 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Utilities/TestUtilities.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Utilities/TestUtilities.cs
@@ -59,12 +59,12 @@ namespace Org.Apache.REEF.Tang.Tests.Utilities
         public void TestGetInterfaceTargetForTypeInheritFromGeneric()
         {
             Type result = ReflectionUtilities.GetInterfaceTarget(typeof(IExternalConstructor<>), typeof(Foo));
-            Assert.Equal(result, typeof(Int32));
+            Assert.Equal(result, typeof(int));
         }
 
-        class Foo : IExternalConstructor<Int32>
+        class Foo : IExternalConstructor<int>
         {
-            public Int32 NewInstance()
+            public int NewInstance()
             {
                 return 3;
             }

--- a/lang/cs/Org.Apache.REEF.Tang/Exceptions/BindException.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Exceptions/BindException.cs
@@ -24,7 +24,7 @@ namespace Org.Apache.REEF.Tang.Exceptions
     public class BindException : SystemException
     {
         // private static readonly long serialVersionUID = 1L;
-        public BindException(String message)
+        public BindException(string message)
             : base(message)
         {           
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Exceptions/ClassHierarchyException.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Exceptions/ClassHierarchyException.cs
@@ -23,7 +23,7 @@ namespace Org.Apache.REEF.Tang.Exceptions
 {
     public class ClassHierarchyException : SystemException
     {
-        public ClassHierarchyException(String msg) : base(msg)
+        public ClassHierarchyException(string msg) : base(msg)
         {           
         }
 

--- a/lang/cs/Org.Apache.REEF.Tang/Exceptions/IllegalStateException.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Exceptions/IllegalStateException.cs
@@ -28,7 +28,7 @@ namespace Org.Apache.REEF.Tang.Exceptions
         {
         }
 
-        public IllegalStateException(String msg)
+        public IllegalStateException(string msg)
             : base(msg)
         {           
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Exceptions/InjectionException.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Exceptions/InjectionException.cs
@@ -23,7 +23,7 @@ namespace Org.Apache.REEF.Tang.Exceptions
 {
     public class InjectionException : Exception
     {
-        public InjectionException(String msg)
+        public InjectionException(string msg)
             : base(msg)
         {           
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Exceptions/NameResolutionException.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Exceptions/NameResolutionException.cs
@@ -24,7 +24,7 @@ namespace Org.Apache.REEF.Tang.Exceptions
     public class NameResolutionException : BindException
     {
         // private static readonly long serialVersionUID = 1L;
-        public NameResolutionException(String name, String longestPrefix) :
+        public NameResolutionException(string name, string longestPrefix) :
             base(string.Format("Could not resolve {0}.  Search ended at prefix {1}. This can happen due to typos in class names that are passed as strings, or because Tang uses Assembly loader other than the one that generated the class reference ((make sure you use the full name of a class)",
                 name, longestPrefix))
         {

--- a/lang/cs/Org.Apache.REEF.Tang/Exceptions/ParseException.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Exceptions/ParseException.cs
@@ -24,7 +24,7 @@ namespace Org.Apache.REEF.Tang.Exceptions
     public class ParseException : BindException
     {
        // private static readonly long serialVersionUID = 1L;
-        public ParseException(String message)
+        public ParseException(string message)
             : base(message)
         {           
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Formats/ConfigurationFile.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Formats/ConfigurationFile.cs
@@ -49,7 +49,7 @@ namespace Org.Apache.REEF.Tang.Formats
             }
         }
 
-        public static String ToConfigurationString(IConfiguration c) 
+        public static string ToConfigurationString(IConfiguration c) 
         {
             StringBuilder sb = new StringBuilder();
             foreach (string s in ToConfigurationStringList(c)) 
@@ -95,7 +95,7 @@ namespace Org.Apache.REEF.Tang.Formats
             }
         }
 
-        public static HashSet<String> ToConfigurationStringList(IConfiguration c) 
+        public static HashSet<string> ToConfigurationStringList(IConfiguration c) 
         {
             ConfigurationImpl conf = (ConfigurationImpl)c;
             HashSet<string> l = new HashSet<string>();
@@ -297,7 +297,7 @@ namespace Org.Apache.REEF.Tang.Formats
             // return in.ReplaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\\\"");
         }
 
-        public static StringBuilder Join(StringBuilder sb, String sep, IConstructorArg[] types) 
+        public static StringBuilder Join(StringBuilder sb, string sep, IConstructorArg[] types) 
         {
             if (types.Length > 0) 
             {

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AbstractNode.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AbstractNode.cs
@@ -29,19 +29,19 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         /// It is from Type.FullName. This name is used as Name in a Node. 
         /// It is not unique for a generic type with different type of arguments.
         /// It is used for toString or debug info as AssemblyQualifiedName is really long
-        private readonly String name;
+        private readonly string name;
 
         /// It is from Type.AssemblyQualifiedName. THis name is used as full name in a Node
         /// It is unique for a generic type with different type of arguments.
-        private readonly String fullName;
+        private readonly string fullName;
 
         // parent node in the class hierarchy
         private readonly INode parent; 
         
         // children in the class hierarchy
-        protected IDictionary<String, INode> children = new MonotonicTreeMap<string, INode>();
+        protected IDictionary<string, INode> children = new MonotonicTreeMap<string, INode>();
 
-        public AbstractNode(INode parent, String name, String fullName)
+        public AbstractNode(INode parent, string name, string fullName)
         {
             this.parent = parent;
             this.name = name;
@@ -57,12 +57,12 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             return children.Values;
         }
 
-        public bool Contains(String key) 
+        public bool Contains(string key) 
         {
             return children.ContainsKey(key);
         }
 
-        public INode Get(String key)
+        public INode Get(string key)
         {
             INode val;
             if (children.TryGetValue(key, out val))
@@ -92,7 +92,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             return parent;
         }
 
-        public override bool Equals(Object o) 
+        public override bool Equals(object o) 
         {
             if (o == null)
             {
@@ -133,7 +133,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             return fullName.GetHashCode();
         }
 
-        public override String ToString()
+        public override string ToString()
         {
             return "[" + this.GetType().FullName + " '" + fullName + "']";
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchy.cs
@@ -77,11 +77,11 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         private void ParseSubHierarchy(INode parent, AvroNode n)
         {
             INode parsed = null;
-            if (n.packageNode != null && !n.packageNode.Equals(""))
+            if (n.packageNode != null && !n.packageNode.Equals(string.Empty))
             {
                 parsed = new PackageNodeImpl(parent, n.name, n.fullName);
             }
-            else if (n.namedParameterNode != null && !n.namedParameterNode.Equals(""))
+            else if (n.namedParameterNode != null && !n.namedParameterNode.Equals(string.Empty))
             {
                 AvroNamedParameterNode np = (AvroNamedParameterNode)n.namedParameterNode;
                 parsed = new NamedParameterNodeImpl(parent, n.name,
@@ -89,7 +89,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                     np.isSet, np.isList, np.documentation, np.shortName,
                     np.instanceDefault.ToArray());
             }
-            else if (n.classNode != null && !n.classNode.Equals(""))
+            else if (n.classNode != null && !n.classNode.Equals(string.Empty))
             {
                 AvroClassNode cn = (AvroClassNode)n.classNode;
                 IList<IConstructorDef> injectableConstructors = new List<IConstructorDef>();
@@ -125,7 +125,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
         private void WireUpInheritanceRelationships(AvroNode n)
         {
-            if (n.classNode != null && !n.classNode.Equals(""))
+            if (n.classNode != null && !n.classNode.Equals(string.Empty))
             {
                 AvroClassNode cn = (AvroClassNode)n.classNode;
                 IClassNode iface = null;
@@ -197,7 +197,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
         private void AddAlias(INamedParameterNode np)
         {
-            if (np.GetAlias() != null && !np.GetAlias().Equals(""))
+            if (np.GetAlias() != null && !np.GetAlias().Equals(string.Empty))
             {
                 IDictionary<string, string> mapping = null;
                 _aliasLookupTable.TryGetValue(np.GetAliasLanguage().ToString(), out mapping);

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchySerializer.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchySerializer.cs
@@ -256,13 +256,13 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             return null;
         }
 
-        private AvroNode NewClassNode(String name,
-            String fullName,
+        private AvroNode NewClassNode(string name,
+            string fullName,
             bool isInjectionCandidate,
             bool isExternalConstructor, bool isUnit,
             IList<AvroConstructorDef> injectableConstructors,
             IList<AvroConstructorDef> otherConstructors,
-            IList<String> implFullNames, IList<AvroNode> children)
+            IList<string> implFullNames, IList<AvroNode> children)
         {
             AvroClassNode classNode = new AvroClassNode();
 

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
@@ -64,8 +64,9 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             rootNode = NodeFactory.CreateRootPackageNode();
             loader = new AssemblyLoader(assemblies);
            
-            foreach (Type p in parameterParsers) // p must be extend from IExternalConstructor
+            foreach (Type p in parameterParsers)
             {
+                // p must be extend from IExternalConstructor
                 try 
                 {
                     Parameterparser.AddParser(p);
@@ -294,7 +295,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             }
 
             string shortName = np.GetShortName();
-            if (shortName != null && !shortName.Equals(""))
+            if (shortName != null && !shortName.Equals(string.Empty))
             {
                 INamedParameterNode oldNode = null;
                 shortNames.TryGetValue(shortName, out oldNode);
@@ -583,7 +584,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         public object ParseDefaultValue(INamedParameterNode name)
         {
             string[] vals = name.GetDefaultInstanceAsStrings();
-            object[] ret = new Object[vals.Length];
+            object[] ret = new object[vals.Length];
             for (int i = 0; i < vals.Length; i++)
             {
                 string val = vals[i];

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassNodeImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassNodeImpl.cs
@@ -37,13 +37,13 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         private readonly IList<IConstructorDef> injectableConstructors;
         private readonly IList<IConstructorDef> allConstructors;
         private readonly MonotonicSet<IClassNode> knownImpls;
-        private readonly String defaultImpl;
+        private readonly string defaultImpl;
 
-        public ClassNodeImpl(INode parent, String simpleName, String fullName,
+        public ClassNodeImpl(INode parent, string simpleName, string fullName,
             bool unit, bool injectable, bool externalConstructor,
             IList<IConstructorDef> injectableConstructors,
             IList<IConstructorDef> allConstructors,
-            String defaultImplementation)
+            string defaultImplementation)
             : base(parent, simpleName, fullName)
         {
             this.unit = unit;
@@ -75,7 +75,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             return externalConstructor;
         }
 
-        public override String ToString()
+        public override string ToString()
         {
             StringBuilder sb = new StringBuilder(base.ToString() + ": ");
             if (GetInjectableConstructors() != null)
@@ -148,7 +148,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             return false;
         }
 
-        public String GetDefaultImplementation()
+        public string GetDefaultImplementation()
         {
             return defaultImpl;
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ConstructorArgImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ConstructorArgImpl.cs
@@ -24,11 +24,11 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 {
     public class ConstructorArgImpl : IConstructorArg
     {
-        private readonly String type;
-        private readonly String name;
+        private readonly string type;
+        private readonly string name;
         private readonly bool isInjectionFuture;
 
-        public ConstructorArgImpl(String type, String namedParameterName, bool isInjectionFuture)
+        public ConstructorArgImpl(string type, string namedParameterName, bool isInjectionFuture)
         {
             this.type = type;
             this.name = namedParameterName;
@@ -58,7 +58,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             return isInjectionFuture;
         }
 
-        public override String ToString()
+        public override string ToString()
         {
             return name == null ? type : type + " " + name;
         }
@@ -68,7 +68,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             return 0;
         }
 
-        public override bool Equals(Object o)
+        public override bool Equals(object o)
         {
             ConstructorArgImpl arg = (ConstructorArgImpl)o;
             if (!type.Equals(arg.type))

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ConstructorDefImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ConstructorDefImpl.cs
@@ -32,9 +32,9 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(ConstructorDefImpl));
 
         private readonly IList<IConstructorArg> args = new List<IConstructorArg>();
-        private readonly String className;
+        private readonly string className;
 
-        public ConstructorDefImpl(String className, IConstructorArg[] args, bool injectable)
+        public ConstructorDefImpl(string className, IConstructorArg[] args, bool injectable)
         {
             this.args = args;
             this.className = className;
@@ -60,12 +60,12 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             return args;
         }
 
-        public String GetClassName()
+        public string GetClassName()
         {
             return className;
         }
 
-        private String Join(String sep, Object[] vals)
+        private string Join(string sep, object[] vals)
         {
             if (vals.Length != 0)
             {
@@ -78,11 +78,11 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             }
             else
             {
-                return "";
+                return string.Empty;
             }
         }
 
-        public override String ToString()
+        public override string ToString()
         {
             StringBuilder sb = new StringBuilder(className);
             sb.Append("(");
@@ -150,7 +150,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             return true;
         }
 
-        public override bool Equals(Object o)
+        public override bool Equals(object o)
         {
             return EqualsIgnoreOrder((IConstructorDef)o);
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NamedParameterNodeImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NamedParameterNodeImpl.cs
@@ -26,19 +26,19 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 {
     public class NamedParameterNodeImpl : AbstractNode, INamedParameterNode
     {
-        private readonly String fullArgName;
-        private readonly String simpleArgName;
-        private readonly String documentation;
-        private readonly String shortName;
-        private readonly String[] defaultInstanceAsStrings;
+        private readonly string fullArgName;
+        private readonly string simpleArgName;
+        private readonly string documentation;
+        private readonly string shortName;
+        private readonly string[] defaultInstanceAsStrings;
         private readonly bool isSet;
         private readonly bool isList;
         private readonly string alias;
         private readonly Language aliasLanguage;
 
-        public NamedParameterNodeImpl(INode parent, String simpleName,
-            String fullName, String fullArgName, String simpleArgName, bool isSet, bool isList,
-            String documentation, String shortName, String[] defaultInstanceAsStrings, string alias = null, Language aliasLanguage = Language.Cs)
+        public NamedParameterNodeImpl(INode parent, string simpleName,
+            string fullName, string fullArgName, string simpleArgName, bool isSet, bool isList,
+            string documentation, string shortName, string[] defaultInstanceAsStrings, string alias = null, Language aliasLanguage = Language.Cs)
             : base(parent, simpleName, fullName)
         {
             this.fullArgName = fullArgName;
@@ -52,32 +52,32 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             this.aliasLanguage = aliasLanguage;
         }
 
-        public override String ToString()
+        public override string ToString()
         {
             return GetSimpleArgName() + " " + GetName();
         }
 
-        public String GetSimpleArgName()
+        public string GetSimpleArgName()
         {
             return simpleArgName;
         }
 
-        public String GetFullArgName()
+        public string GetFullArgName()
         {
             return fullArgName;
         }
 
-        public String GetDocumentation()
+        public string GetDocumentation()
         {
             return documentation;
         }
 
-        public String GetShortName()
+        public string GetShortName()
         {
             return shortName;
         }
 
-        public String[] GetDefaultInstanceAsStrings()
+        public string[] GetDefaultInstanceAsStrings()
         {
             return defaultInstanceAsStrings;
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
@@ -251,23 +251,23 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
             if (default_count == 0)
             {
-                defaultInstanceAsStrings = new String[] { };
+                defaultInstanceAsStrings = new string[] { };
             }
             else if (hasClassDefault)
             {
                 Type default_class = namedParameter.DefaultClass;
                 AssertIsSubclassOf(clazz, default_class, argClass);
-                defaultInstanceAsStrings = new String[] { ReflectionUtilities.GetAssemblyQualifiedName(default_class) };
+                defaultInstanceAsStrings = new string[] { ReflectionUtilities.GetAssemblyQualifiedName(default_class) };
             }
             else if (hasStringDefault)
             {
                 // Don't know if the string is a class or literal here, so don't bother validating.
-                defaultInstanceAsStrings = new String[] { namedParameter.DefaultValue };
+                defaultInstanceAsStrings = new string[] { namedParameter.DefaultValue };
             }
             else if (hasClassSetDefault)
             {
                 Type[] clzs = namedParameter.DefaultClasses;
-                defaultInstanceAsStrings = new String[clzs.Length];
+                defaultInstanceAsStrings = new string[clzs.Length];
                 for (int i = 0; i < clzs.Length; i++)
                 {
                     AssertIsSubclassOf(clazz, clzs[i], argClass);

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/PackageNodeImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/PackageNodeImpl.cs
@@ -24,13 +24,13 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 {
     public class PackageNodeImpl : AbstractNode, IPackageNode
     {
-        public PackageNodeImpl(INode parent, String name, String fullName) : 
+        public PackageNodeImpl(INode parent, string name, string fullName) : 
             base(parent, name, fullName)
         {
         }
 
         public PackageNodeImpl()
-            : base(null, "", "[root node]")
+            : base(null, string.Empty, "[root node]")
         {
         }
 

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ParameterParser.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ParameterParser.cs
@@ -31,7 +31,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(ParameterParser));
 
-        readonly MonotonicTreeMap<String, ConstructorInfo> parsers = new MonotonicTreeMap<String, ConstructorInfo>();
+        readonly MonotonicTreeMap<string, ConstructorInfo> parsers = new MonotonicTreeMap<string, ConstructorInfo>();
 
         // ec: ACons, tc: A
         public void AddParser(Type ec)
@@ -91,16 +91,19 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         }
 
         // (Integer, "3") return object of new Integer(3)
-        public object Parse(Type c, String s)
+        public object Parse(Type c, string s)
         {
             Type d = ReflectionUtilities.BoxClass(c);
-            foreach (Type e in ReflectionUtilities.ClassAndAncestors(d)) // get all the super classes of Integer for example
+            foreach (Type e in ReflectionUtilities.ClassAndAncestors(d))
             {
+                // get all the super classes of Integer for example
                 string name = ReflectionUtilities.GetAssemblyQualifiedName(e);
                 if (parsers.ContainsKey(name))
                 {
                     object ret = Parse(name, s);
-                    if (c.IsAssignableFrom(ret.GetType())) // check if ret can be cast as c
+
+                    // check if ret can be cast as c
+                    if (c.IsAssignableFrom(ret.GetType()))
                     {
                         return ret;
                     }
@@ -137,37 +140,37 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             {
                 return (object)value;
             }
-            if (name.Equals(typeof(Byte).Name))
+            if (name.Equals(typeof(byte).Name))
             {
-                return (object)(Byte)Byte.Parse(value);
+                return (object)(byte)byte.Parse(value);
             }
-            if (name.Equals(typeof(Char).Name))
+            if (name.Equals(typeof(char).Name))
             {
-                return (object)(Char)value[0];
+                return (object)(char)value[0];
             }
             if (name.Equals(typeof(short).Name))
             {
-                return (System.Int16)System.Int16.Parse(value);
+                return (short)short.Parse(value);
             }
             if (name.Equals(typeof(int).Name))
             {
-                return (object)(Int32)Int32.Parse(value);
+                return (object)(int)int.Parse(value);
             }
             if (name.Equals(typeof(long).Name))
             {
-                return (object)(Int64)Int64.Parse(value);
+                return (object)(long)long.Parse(value);
             }
             if (name.Equals(typeof(float).Name))
             {
-                return (object)(Single)Single.Parse(value);
+                return (object)(float)float.Parse(value);
             }
-            if (name.Equals(typeof(Double).Name))
+            if (name.Equals(typeof(double).Name))
             {
-                return (object)(Double)Double.Parse(value);
+                return (object)(double)double.Parse(value);
             }
-            if (name.Equals(typeof(Boolean).Name))
+            if (name.Equals(typeof(bool).Name))
             {
-                return (object)(Boolean)Boolean.Parse(value);
+                return (object)(bool)bool.Parse(value);
             }
             if (name.Equals(typeof(byte[]).Name))  
             {
@@ -181,10 +184,10 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         private static readonly ISet<string> BUILTIN_NAMES = new HashSet<string>(new string[]
             {
                 typeof(string).AssemblyQualifiedName, 
-                typeof(Byte).AssemblyQualifiedName,
+                typeof(byte).AssemblyQualifiedName,
                 typeof(char).AssemblyQualifiedName,
                 typeof(short).AssemblyQualifiedName,
-                typeof(Int32).AssemblyQualifiedName,
+                typeof(int).AssemblyQualifiedName,
                 typeof(long).AssemblyQualifiedName,
                 typeof(float).AssemblyQualifiedName,
                 typeof(double).AssemblyQualifiedName,

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/ConfigurationBuilderImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/ConfigurationBuilderImpl.cs
@@ -37,7 +37,7 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
 
         public readonly IDictionary<IClassNode, IClassNode> BoundImpls = new MonotonicTreeMap<IClassNode, IClassNode>();
         public readonly IDictionary<IClassNode, IClassNode> BoundConstructors = new MonotonicTreeMap<IClassNode, IClassNode>();
-        public readonly IDictionary<INamedParameterNode, String> NamedParameters = new MonotonicTreeMap<INamedParameterNode, String>();
+        public readonly IDictionary<INamedParameterNode, string> NamedParameters = new MonotonicTreeMap<INamedParameterNode, string>();
         public readonly IDictionary<IClassNode, IConstructorDef> LegacyConstructors = new MonotonicTreeMap<IClassNode, IConstructorDef>();
         public readonly MonotonicMultiMap<INamedParameterNode, object> BoundSetEntries = new MonotonicMultiMap<INamedParameterNode, object>();
         public readonly IDictionary<INamedParameterNode, IList<object>> BoundLists = new MonotonicTreeMap<INamedParameterNode, IList<object>>();
@@ -147,7 +147,7 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
 
             foreach (KeyValuePair<INamedParameterNode, object> e in builder.BoundSetEntries) 
             {
-                String name = ((INamedParameterNode)e.Key).GetFullName();
+                string name = ((INamedParameterNode)e.Key).GetFullName();
                 if (e.Value is INode) 
                 {
                     BindSetEntry(name, (INode)e.Value);
@@ -260,7 +260,7 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
             }
         }
 
-        public void BindParameter(INamedParameterNode name, String value)
+        public void BindParameter(INamedParameterNode name, string value)
         {
             /* Parse and discard value; this is just for type checking, skip for now*/
             if (this.ClassHierarchy is ICsClassHierarchy) 
@@ -291,17 +291,17 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
             }
         }
 
-        public void BindSetEntry(String iface, String impl)
+        public void BindSetEntry(string iface, string impl)
         {
             BoundSetEntries.Add((INamedParameterNode)this.ClassHierarchy.GetNode(iface), impl);
         }
 
-        public void BindSetEntry(String iface, INode impl)
+        public void BindSetEntry(string iface, INode impl)
         {
             BoundSetEntries.Add((INamedParameterNode)ClassHierarchy.GetNode(iface), impl);
         }
 
-        public void BindSetEntry(INamedParameterNode iface, String impl)
+        public void BindSetEntry(INamedParameterNode iface, string impl)
         {
             BoundSetEntries.Add(iface, impl);
         }
@@ -352,7 +352,7 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
             return param.GetSimpleArgName() + "=" + Join(",", param.GetDefaultInstanceAsStrings());
         }
 
-        private String Join(string sep, string[] s)
+        private string Join(string sep, string[] s)
         {
             if (s.Length == 0)
             {

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/ConfigurationImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/ConfigurationImpl.cs
@@ -98,7 +98,7 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
             return Builder.LegacyConstructors.Keys;
         }
 
-        public ISet<Object> GetBoundSet(INamedParameterNode np) 
+        public ISet<object> GetBoundSet(INamedParameterNode np) 
         {
             return Builder.BoundSetEntries.GetValuesForKey(np);
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/CsConfigurationBuilderImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/CsConfigurationBuilderImpl.cs
@@ -373,8 +373,8 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
 
             Type valType = ReflectionUtilities.GetInterfaceTarget(typeof(ISet<>), setType);
 
-            if (!valType.IsAssignableFrom(impl))
             //// if (!ReflectionUtilities.GetRawClass(valType).IsAssignableFrom(impl))
+            if (!valType.IsAssignableFrom(impl))
             {
                 var ex = new BindException("BindSetEntry got implementation " + impl + " that is incompatible with expected type " + valType);
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/Constructor.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/Constructor.cs
@@ -107,7 +107,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
             return sb.ToString();
         }
 
-        private String ShallowArgString(InjectionPlan arg) 
+        private string ShallowArgString(InjectionPlan arg) 
         {
             if (arg is Constructor || arg is Subplan) 
             {

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectionPlan.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectionPlan.cs
@@ -81,9 +81,9 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
             }
         }
 
-        public String ToPrettyString()
+        public string ToPrettyString()
         {
-            String ugly = node.GetFullName() + ":\n" + ToString();
+            string ugly = node.GetFullName() + ":\n" + ToString();
             StringBuilder pretty = new StringBuilder();
             int currentIndent = 1;
             for (int i = 0; i < ugly.Length; i++)

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectorImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectorImpl.cs
@@ -40,7 +40,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
         readonly IDictionary<INamedParameterNode, object> namedParameterInstances = new MonotonicTreeMap<INamedParameterNode, object>();
         private readonly ICsClassHierarchy classHierarchy;
         private readonly IConfiguration configuration;
-        readonly IDictionary<IClassNode, Object> instances = new MonotonicTreeMap<IClassNode, Object>();
+        readonly IDictionary<IClassNode, object> instances = new MonotonicTreeMap<IClassNode, object>();
         private Aspect aspect;
         private readonly ISet<IInjectionFuture<object>> pendingFutures = new HashSet<IInjectionFuture<object>>();
 
@@ -170,7 +170,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                     {
                         Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Caught(e, Level.Error, LOGGER);
                         StringBuilder sb = new StringBuilder("Internal Tang error?  Could not call constructor " + constructor.GetConstructorDef() + " with arguments [");
-                        foreach (Object o in args)
+                        foreach (object o in args)
                         {
                             sb.Append("\n\t" + o);
                         }
@@ -277,8 +277,8 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
 
         private object GetCachedInstance(IClassNode cn)
         {
+            //// if (cn.GetFullName().Equals(ReflectionUtilities.NonGenericFullName(typeof(IInjector))))
             if (cn.GetFullName().Equals(ReflectionUtilities.GetAssemblyQualifiedName(typeof(IInjector))))
-                //// if (cn.GetFullName().Equals(ReflectionUtilities.NonGenericFullName(typeof(IInjector))))
             {
                 return this.ForkInjector(); // TODO: We should be insisting on injection futures here! .forkInjector();
             }
@@ -509,7 +509,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
         {
             List<InjectionPlan> sub_ips = new List<InjectionPlan>();
 
-            #region each implementation
+            // each implementation
             foreach (IClassNode thisCN in candidateImplementations)
             {
                 List<InjectionPlan> constructors = new List<InjectionPlan>();
@@ -524,13 +524,13 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                     constructorList.Add(c);
                 }
 
-                #region each constructor
+                // each constructor
                 foreach (IConstructorDef def in constructorList)
                 {
                     List<InjectionPlan> args = new List<InjectionPlan>();
                     IConstructorArg[] defArgs = def.GetArgs().ToArray<IConstructorArg>();
 
-                    #region each argument
+                    // each argument
                     foreach (IConstructorArg arg in defArgs)
                     {
                         if (!arg.IsInjectionFuture())
@@ -569,18 +569,16 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                             }
                         }
                     }
-                    #endregion each argument
 
                     Constructor constructor = new Constructor(thisCN, def, args.ToArray());
                     constructors.Add(constructor);
                 }
-                #endregion each constructor
 
                 // The constructors are embedded in a lattice defined by
                 // isMoreSpecificThan().  We want to see if, amongst the injectable
                 // plans, there is a unique dominant plan, and select it.
                 // First, compute the set of injectable plans.
-                List<Int32> liveIndices = new List<Int32>();
+                List<int> liveIndices = new List<int>();
                 for (int i = 0; i < constructors.Count; i++)
                 {
                     if (constructors[i].GetNumAlternatives() > 0)
@@ -599,8 +597,9 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                         IConstructorDef ci = ((Constructor)constructors[liveIndices[i]]).GetConstructorDef();
                         IConstructorDef cj = ((Constructor)constructors[liveIndices[j]]).GetConstructorDef();
 
-                        if (ci.IsMoreSpecificThan(cj)) // ci's arguments is a superset of cj's
+                        if (ci.IsMoreSpecificThan(cj))
                         {
+                            // ci's arguments is a superset of cj's
                             k = i;
                         }
                         else if (cj.IsMoreSpecificThan(ci))
@@ -618,7 +617,6 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                     sub_ips.Add(WrapInjectionPlans(thisCN, constructors, false, k != -1 ? liveIndices[k] : -1));
                 }
             }
-            #endregion each implementation
             return sub_ips;
         }
 
@@ -935,7 +933,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                 || cn.GetFullName().Equals(ReflectionUtilities.GetAssemblyQualifiedName(typeof(InjectorImpl))))
                 {
                     // This would imply that we're treating injector as a singleton somewhere.  It should be copied fresh each time.
-                    Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new IllegalStateException(""), LOGGER);
+                    Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new IllegalStateException(string.Empty), LOGGER);
                 }
                 try
                 {
@@ -959,7 +957,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
             foreach (INamedParameterNode np in old.namedParameterInstances.Keys)
             {
                 // if (!builder.namedParameters.containsKey(np)) {
-                Object o = null;
+                object o = null;
                 old.namedParameterInstances.TryGetValue(np, out o);
                 INamedParameterNode new_np = (INamedParameterNode)injector.classHierarchy.GetNode(np.GetFullName());
                 injector.namedParameterInstances.Add(new_np, o);
@@ -1003,7 +1001,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
             if (n is INamedParameterNode) 
             {
                 INamedParameterNode np = (INamedParameterNode)n;
-                Object old = this.configuration.GetNamedParameter(np);
+                object old = this.configuration.GetNamedParameter(np);
                 if (old != null) 
                 {
                     // XXX need to get the binding site here!

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/Subplan.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/Subplan.cs
@@ -45,12 +45,14 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new IndexOutOfRangeException(), LOGGER);
             }
             this.selectedIndex = selectedIndex;
-            if (selectedIndex != -1) // one was bound
+            if (selectedIndex != -1)
             {
+                // one was bound
                 this.numAlternatives = alternatives[selectedIndex].GetNumAlternatives();
             }
-            else // no one was bound, but anyone could be used
+            else
             {
+                // no one was bound, but anyone could be used
                 int numAlternatives = 0;
                 foreach (InjectionPlan a in alternatives)
                 {

--- a/lang/cs/Org.Apache.REEF.Tang/Interface/IConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Interface/IConfiguration.cs
@@ -29,8 +29,8 @@ namespace Org.Apache.REEF.Tang.Interface
         string GetNamedParameter(INamedParameterNode np);
         IClassHierarchy GetClassHierarchy();
 
-        ISet<Object> GetBoundSet(INamedParameterNode np); // named parameter for a set
-        IList<Object> GetBoundList(INamedParameterNode np); // named parameter for a list
+        ISet<object> GetBoundSet(INamedParameterNode np); // named parameter for a set
+        IList<object> GetBoundList(INamedParameterNode np); // named parameter for a list
 
         IClassNode GetBoundConstructor(IClassNode cn);
         IClassNode GetBoundImplementation(IClassNode cn);

--- a/lang/cs/Org.Apache.REEF.Tang/Interface/IInjector.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Interface/IInjector.cs
@@ -75,7 +75,7 @@ namespace Org.Apache.REEF.Tang.Interface
         /// </summary>
         /// <param name="name">The name.</param>
         /// <returns></returns>
-        InjectionPlan GetInjectionPlan(String name);
+        InjectionPlan GetInjectionPlan(string name);
 
         /// <summary>
         /// Binds the aspect.
@@ -105,7 +105,7 @@ namespace Org.Apache.REEF.Tang.Interface
         /// <returns>
         ///   <c>true</c> if [is parameter set] [the specified name]; otherwise, <c>false</c>.
         /// </returns>
-        bool IsParameterSet(String name);
+        bool IsParameterSet(string name);
 
         /// <summary>
         /// Determines whether the specified clazz is injectable.

--- a/lang/cs/Org.Apache.REEF.Tang/Protobuf/ProtocolBufferClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Protobuf/ProtocolBufferClassHierarchy.cs
@@ -134,7 +134,7 @@ namespace Org.Apache.REEF.Tang.Protobuf
         }
 
         private static Org.Apache.REEF.Tang.Protobuf.ConstructorDef newConstructorDef(
-             String fullClassName, IList<Org.Apache.REEF.Tang.Protobuf.ConstructorArg> args)
+             string fullClassName, IList<Org.Apache.REEF.Tang.Protobuf.ConstructorArg> args)
         {
             Org.Apache.REEF.Tang.Protobuf.ConstructorDef constDef = new Org.Apache.REEF.Tang.Protobuf.ConstructorDef();
             constDef.full_class_name = fullClassName;
@@ -146,12 +146,12 @@ namespace Org.Apache.REEF.Tang.Protobuf
             return constDef;
         }
 
-        private static Org.Apache.REEF.Tang.Protobuf.Node NewClassNode(String name,
-            String fullName, bool isInjectionCandidate,
+        private static Org.Apache.REEF.Tang.Protobuf.Node NewClassNode(string name,
+            string fullName, bool isInjectionCandidate,
             bool isExternalConstructor, bool isUnit,
             IList<Org.Apache.REEF.Tang.Protobuf.ConstructorDef> injectableConstructors,
             IList<Org.Apache.REEF.Tang.Protobuf.ConstructorDef> otherConstructors,
-            IList<String> implFullNames, IList<Org.Apache.REEF.Tang.Protobuf.Node> children)
+            IList<string> implFullNames, IList<Org.Apache.REEF.Tang.Protobuf.Node> children)
         {
             Org.Apache.REEF.Tang.Protobuf.ClassNode classNode = new Org.Apache.REEF.Tang.Protobuf.ClassNode();
             classNode.is_injection_candidate = isInjectionCandidate;
@@ -423,7 +423,7 @@ namespace Org.Apache.REEF.Tang.Protobuf
                         + n.full_name + " does not exist.  Full record is " + n, e);
                     Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER); 
                 }
-                foreach (String impl in cn.impl_full_names)
+                foreach (string impl in cn.impl_full_names)
                 {
                     try
                     {
@@ -459,7 +459,7 @@ namespace Org.Apache.REEF.Tang.Protobuf
             }
         }
 
-        public INode GetNode(String fullName)
+        public INode GetNode(string fullName)
         {
             INode ret;
             lookupTable.TryGetValue(fullName, out ret);

--- a/lang/cs/Org.Apache.REEF.Tang/Protobuf/ProtocolBufferInjectionPlan.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Protobuf/ProtocolBufferInjectionPlan.cs
@@ -190,7 +190,7 @@ namespace Org.Apache.REEF.Tang.Protobuf
             return null;
         }
 
-        private static object Parse(String type, String value)
+        private static object Parse(string type, string value)
         {
             // XXX this is a placeholder for now.  We need a parser API that will
             // either produce a live java object or (partially) validate stuff to

--- a/lang/cs/Org.Apache.REEF.Tang/Util/AssemblyLoader.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/AssemblyLoader.cs
@@ -82,7 +82,7 @@ namespace Org.Apache.REEF.Tang.Util
         /// </summary>
         /// <param name="path"></param>
         /// <returns>True, if the path given is an assembly</returns>
-        public static Boolean IsAssembly(string path)
+        public static bool IsAssembly(string path)
         {
             if (string.IsNullOrWhiteSpace(path) || Path.GetExtension(path).ToLower() != ".dll")
             {

--- a/lang/cs/Org.Apache.REEF.Tang/Util/MonotonicSet.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/MonotonicSet.cs
@@ -97,7 +97,7 @@ namespace Org.Apache.REEF.Tang.Util
             Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new NotSupportedException("Attempt to clear MonotonicSet!"), LOGGER);
         }
 
-        public bool Remove(Object o)
+        public bool Remove(object o)
         {
             Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new NotSupportedException("Attempt to remove " + o
                 + " from MonotonicSet!"), LOGGER);

--- a/lang/cs/Org.Apache.REEF.Tang/Util/MonotonicTreeMap.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/MonotonicTreeMap.cs
@@ -36,7 +36,7 @@ namespace Org.Apache.REEF.Tang.Util
             try
             {
                 TVal val;
-                if (base.TryGetValue(key, out val))
+                if (TryGetValue(key, out val))
                 {
                     var ex = new ArgumentException("Attempt to re-add: [" + key
                                                    + "]\n old value: " + val + " new value " + value);

--- a/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
@@ -214,35 +214,35 @@ namespace Org.Apache.REEF.Tang.Util
             {
                 if (c == typeof(bool))
                 {
-                    return typeof(Boolean);
+                    return typeof(bool);
                 }
                 else if (c == typeof(byte))
                 {
-                    return typeof(Byte);
+                    return typeof(byte);
                 }
                 else if (c == typeof(char))
                 {
-                    return typeof(Char);
+                    return typeof(char);
                 }
                 else if (c == typeof(short))
                 {
-                    return typeof(Int16);
+                    return typeof(short);
                 }
                 else if (c == typeof(int))
                 {
-                    return typeof(Int32);
+                    return typeof(int);
                 }
                 else if (c == typeof(long))
                 {
-                    return typeof(Int64);
+                    return typeof(long);
                 }
                 else if (c == typeof(float))
                 {
-                    return typeof(Single);
+                    return typeof(float);
                 }
                 else if (c == typeof(double))
                 {
-                    return typeof(Double);
+                    return typeof(double);
                 }
                 else
                 {
@@ -486,8 +486,9 @@ namespace Org.Apache.REEF.Tang.Util
                 return args[0];
             }
 
-            if (ImplementName(type)) // Implement Name<> but no  [NamedParameter] attribute
+            if (ImplementName(type))
             {
+                // Implement Name<> but no  [NamedParameter] attribute
                 var ex = new ClassHierarchyException("Named parameter " + GetName(type)
                                   + " is missing its [NamedParameter] attribute.");
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);

--- a/lang/cs/Org.Apache.REEF.Tang/Util/SetValuedKey.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/SetValuedKey.cs
@@ -46,7 +46,7 @@ namespace Org.Apache.REEF.Tang.Util
             return i;
         }
 
-        public override bool Equals(Object o)
+        public override bool Equals(object o)
         {
             SetValuedKey other = (SetValuedKey)o;
             if (other.key.Count != this.key.Count) 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/HelloSimpleEventHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/HelloSimpleEventHandlers.cs
@@ -422,7 +422,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
     }
 
     [NamedParameter(Documentation = "NumberOfTasks", ShortName = "NumberOfTasks", DefaultValue = "2")]
-    class NumberOfEvaluators : Name<Int32>
+    class NumberOfEvaluators : Name<int>
     {        
     }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
@@ -78,7 +78,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
                 .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(HelloTask).Assembly.GetName().Name)
                 .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
                 .BindNamedParameter<IsRetain, bool>(GenericType<IsRetain>.Class, "false")
-                .BindNamedParameter<NumberOfEvaluators, Int32>(GenericType<NumberOfEvaluators>.Class, "1")
+                .BindNamedParameter<NumberOfEvaluators, int>(GenericType<NumberOfEvaluators>.Class, "1")
                 .Build();
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -256,12 +256,10 @@ namespace Org.Apache.REEF.Tests.Functional
         private static string GetStorageConnectionString()
         {
             var accountName = GetEnvironmentVariable(StorageAccountNameEnvironmentVariable,
-                "Please set " + StorageAccountNameEnvironmentVariable +
-                " to the storage account name to be used for the tests");
+                "Please set " + StorageAccountNameEnvironmentVariable + " to the storage account name to be used for the tests");
 
             var accountKey = GetEnvironmentVariable(StorageAccountKeyEnvironmentVariable,
-                "Please set " + StorageAccountKeyEnvironmentVariable +
-                " to the key of the storage account to be used for the tests");
+                "Please set " + StorageAccountKeyEnvironmentVariable + " to the key of the storage account to be used for the tests");
 
             var result = @"DefaultEndpointsProtocol=https;AccountName=" + accountName + ";AccountKey=" + accountKey;
             return result;

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManager.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManager.cs
@@ -148,10 +148,10 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
             {
                 TransportClient<IRemoteEvent<T>> client = 
                     new TransportClient<IRemoteEvent<T>>(remoteEndpoint, _codec, _observerContainer);
-                LOGGER.Log(Level.Info, 
-                    String.Format("NewClientConnection: Local {0} connected to Remote {1}",
+                var msg = string.Format("NewClientConnection: Local {0} connected to Remote {1}",
                     client.Link.LocalEndpoint.ToString(), 
-                    client.Link.RemoteEndpoint.ToString()));
+                    client.Link.RemoteEndpoint.ToString());
+                LOGGER.Log(Level.Info, msg);
 
                 remoteObserver = new ProxyObserver(client);
                 _cachedClients[remoteEndpoint] = remoteObserver;

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataReader.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataReader.cs
@@ -139,8 +139,8 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// <returns>read short</returns>
         public short ReadInt16()
         {
-            byte[] intBytes = new byte[sizeof(Int16)];
-            int readBytes = Read(ref intBytes, 0, sizeof(Int16));
+            byte[] intBytes = new byte[sizeof(short)];
+            int readBytes = Read(ref intBytes, 0, sizeof(short));
 
             if (readBytes == -1)
             {
@@ -293,8 +293,8 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// <returns>Task handler that reads short</returns>
         public async Task<short> ReadInt16Async(CancellationToken token)
         {
-            byte[] intBytes = new byte[sizeof(Int16)];
-            int readBytes = await ReadAsync(intBytes, 0, sizeof(Int16), token);
+            byte[] intBytes = new byte[sizeof(short)];
+            int readBytes = await ReadAsync(intBytes, 0, sizeof(short), token);
 
             if (readBytes == -1)
             {

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportServer.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportServer.cs
@@ -110,7 +110,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
                 Exceptions.Throw(exception, "Could not find a port to listen on", LOGGER);
             }
             LOGGER.Log(Level.Info,
-                String.Format("Listening on {0}", _listener.LocalEndpoint.ToString()));
+                string.Format("Listening on {0}", _listener.LocalEndpoint.ToString()));
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TransportServer.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TransportServer.cs
@@ -115,7 +115,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
                 Exceptions.Throw(exception, "Could not find a port to listen on", LOGGER);
             }
             LOGGER.Log(Level.Info,
-                String.Format("Listening on {0}", _listener.LocalEndpoint.ToString()));
+                string.Format("Listening on {0}", _listener.LocalEndpoint.ToString()));
         }
 
         /// <summary>

--- a/lang/cs/Settings.StyleCop
+++ b/lang/cs/Settings.StyleCop
@@ -552,12 +552,12 @@ under the License.
       <Rules>
         <Rule Name="CommentsMustContainText">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="DoNotPrefixCallsWithBaseUnlessLocalImplementationExists">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="PrefixLocalCallsWithThis">
@@ -572,27 +572,27 @@ under the License.
         </Rule>
         <Rule Name="OpeningParenthesisMustBeOnDeclarationLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ClosingParenthesisMustBeOnLineOfLastParameter">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ClosingParenthesisMustBeOnLineOfOpeningParenthesis">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="CommaMustBeOnSameLineAsPreviousParameter">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ParameterListMustFollowDeclaration">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ParameterMustFollowComma">
@@ -612,67 +612,67 @@ under the License.
         </Rule>
         <Rule Name="ParameterMustNotSpanMultipleLines">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="QueryClauseMustFollowPreviousClause">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="QueryClausesMustBeOnSeparateLinesOrAllOnOneLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="QueryClauseMustBeginOnNewLineWhenPreviousClauseSpansMultipleLines">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="QueryClausesSpanningMultipleLinesMustBeginOnOwnLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="DoNotPlaceRegionsWithinElements">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="CodeMustNotContainEmptyStatements">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="CodeMustNotContainMultipleStatementsOnOneLine">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="BlockStatementsMustNotContainEmbeddedComments">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="BlockStatementsMustNotContainEmbeddedRegions">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="UseStringEmptyForEmptyStrings">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="UseBuiltInTypeAlias">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="UseShorthandForNullableTypes">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
       </Rules>


### PR DESCRIPTION
This enables the following rules:
 * CommentsMustContainText
 * DoNotPrefixCallsWithBaseUnlessLocalImplementationExists
 * OpeningParenthesisMustBeOnDeclarationLine
 * ClosingParenthesisMustBeOnLineOfLastParameter
 * ClosingParenthesisMustBeOnLineOfOpeningParenthesis
 * CommaMustBeOnSameLineAsPreviousParameter
 * ParameterListMustFollowDeclaration
 * ParameterMustNotSpanMultipleLines
 * QueryClauseMustFollowPreviousClause
 * QueryClausesMustBeOnSeparateLinesOrAllOnOneLine
 * QueryClauseMustBeginOnNewLineWhenPreviousClauseSpansMultipleLines
 * QueryClausesSpanningMultipleLinesMustBeginOnOwnLine
 * DoNotPlaceRegionsWithinElements
 * CodeMustNotContainEmptyStatements
 * CodeMustNotContainMultipleStatementsOnOneLine
 * BlockStatementsMustNotContainEmbeddedComments
 * BlockStatementsMustNotContainEmbeddedRegions
 * UseStringEmptyForEmptyStrings
 * UseBuiltInTypeAlias
 * UseShorthandForNullableTypes

JIRA:
  [REEF-1055](https://issues.apache.org/jira/browse/REEF-1055)

Pull request:
  This closes #