### PR TITLE
[REEF-1071] Fix Driver Restart to correctly use the YARN application …

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Constants.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Constants.cs
@@ -37,5 +37,7 @@ namespace Org.Apache.REEF.Common
         public const string HttpDriverUriTarget = @"Driver/";
 
         public const string NameServerServiceName = "NameServer";
+
+        public const string ReefYarnApplicationIdEnvironmentVariable = "REEF_YARN_APPLICATION_ID";
     }
 }

--- a/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultLocalHttpDriverConnection.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultLocalHttpDriverConnection.cs
@@ -22,12 +22,12 @@ using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.Common.Evaluator
 {
-    public class DefaultLocalHttpDriverConnection : IDriverConnection
+    public sealed class DefaultLocalHttpDriverConnection : IDriverConnection
     {
         private readonly Uri _queryUri;
 
         [Inject]
-        public DefaultLocalHttpDriverConnection()
+        private DefaultLocalHttpDriverConnection()
         {
             _queryUri = new Uri(
                     string.Concat(
@@ -36,7 +36,7 @@ namespace Org.Apache.REEF.Common.Evaluator
                     Constants.HttpDriverUriTarget));
         }
 
-        public DriverInformation GetDriverInformation(string applicationId)
+        public DriverInformation GetDriverInformation()
         {
             // application id not needed for local runtime
             return DriverInformation.GetDriverInformationFromHttp(_queryUri);

--- a/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultYarnClusterHttpDriverConnection.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultYarnClusterHttpDriverConnection.cs
@@ -22,20 +22,27 @@ using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.Common.Evaluator
 {
-    public class DefaultYarnClusterHttpDriverConnection : IDriverConnection
+    public sealed class DefaultYarnClusterHttpDriverConnection : IDriverConnection
     {
+        private readonly string _applicationId;
+
         [Inject]
-        public DefaultYarnClusterHttpDriverConnection()
+        private DefaultYarnClusterHttpDriverConnection()
         {
+            _applicationId = Environment.GetEnvironmentVariable(Constants.ReefYarnApplicationIdEnvironmentVariable);
+            if (_applicationId == null)
+            {
+                throw new ApplicationException("Could not fetch the application ID from YARN's container environment variables.");
+            }
         }
 
-        public DriverInformation GetDriverInformation(string applicationId)
+        public DriverInformation GetDriverInformation()
         {
             // e.g., http://headnodehost:9014/proxy/application_1407519727821_0012/reef/v1/driver
             Uri queryUri = new Uri(
                 string.Concat(
                 Constants.HDInsightClusterHttpEndpointBaseUri,
-                applicationId + "/",
+                _applicationId + "/",
                 Constants.HttpReefUriSpecification,
                 Constants.HttpDriverUriTarget));
             return DriverInformation.GetDriverInformationFromHttp(queryUri);

--- a/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultYarnOneBoxHttpDriverConnection.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultYarnOneBoxHttpDriverConnection.cs
@@ -25,19 +25,26 @@ namespace Org.Apache.REEF.Common.Evaluator
 {
     public class DefaultYarnOneBoxHttpDriverConnection : IDriverConnection
     {
+        private readonly string _applicationId;
+
         [Inject]
-        public DefaultYarnOneBoxHttpDriverConnection()
+        private DefaultYarnOneBoxHttpDriverConnection()
         {
+            _applicationId = Environment.GetEnvironmentVariable(Constants.ReefYarnApplicationIdEnvironmentVariable);
+            if (_applicationId == null)
+            {
+                throw new ApplicationException("Could not fetch the application ID from YARN's container environment variables.");
+            }
         }
 
-        public DriverInformation GetDriverInformation(string applicationId)
+        public DriverInformation GetDriverInformation()
         {
             // e.g., http://yingdac1:8088/proxy/application_1407519727821_0012/reef/v1/driver
             string oneBoxHost = string.Format(CultureInfo.InvariantCulture, "http://{0}:8088/proxy/", Environment.MachineName);
             Uri queryUri = new Uri(
                 string.Concat(
                 oneBoxHost,
-                applicationId,
+                _applicationId + '/',
                 Constants.HttpReefUriSpecification,
                 Constants.HttpDriverUriTarget));
             return DriverInformation.GetDriverInformationFromHttp(queryUri);

--- a/lang/cs/Org.Apache.REEF.Common/Evaluator/IDriverConnection.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Evaluator/IDriverConnection.cs
@@ -21,6 +21,6 @@ namespace Org.Apache.REEF.Common.Evaluator
 {
     public interface IDriverConnection
     {
-        DriverInformation GetDriverInformation(string applicationId);
+        DriverInformation GetDriverInformation();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/HeartBeatManager.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/HeartBeatManager.cs
@@ -251,7 +251,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                     LOGGER.Log(Level.Verbose, string.Format(CultureInfo.InvariantCulture, "Ignoring regular heartbeat since Evaluator operation state is [{0}] and runtime state is [{1}]. ", _evaluatorSettings.OperationState,  _evaluatorRuntime.State));
                     try
                     {
-                        DriverInformation driverInformation = _driverConnection.GetDriverInformation(_evaluatorSettings.ApplicationId);
+                        DriverInformation driverInformation = _driverConnection.GetDriverInformation();
                         if (driverInformation == null)
                         {
                             LOGGER.Log(Level.Verbose, "In RECOVERY mode, cannot retrieve driver information, will try again later.");

--- a/lang/cs/Org.Apache.REEF.Examples.DriverRestart/DriverRestart.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.DriverRestart/DriverRestart.cs
@@ -73,7 +73,7 @@ namespace Org.Apache.REEF.Examples.DriverRestart
             var restartJobSubmission = _jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
                 .AddDriverConfiguration(driverConfiguration)
                 .AddGlobalAssemblyForType(typeof(HelloRestartDriver))
-                .SetJobIdentifier("DriverRestart")
+                .SetJobIdentifier("DriverRestart_" + Guid.NewGuid().ToString().Substring(0, 6))
                 .Build();
 
             _reefClient.SubmitAndGetJobStatus(restartJobSubmission);

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNResourceLaunchHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNResourceLaunchHandler.java
@@ -30,6 +30,7 @@ import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.yarn.client.SecurityTokenProvider;
 import org.apache.reef.runtime.yarn.util.YarnTypes;
+import org.apache.reef.runtime.yarn.util.YarnUtilities;
 import org.apache.reef.tang.InjectionFuture;
 import org.apache.reef.tang.annotations.Parameter;
 
@@ -90,7 +91,7 @@ public final class YARNResourceLaunchHandler implements ResourceLaunchHandler {
 
       final byte[] securityTokensBuffer = this.tokenProvider.getTokens();
       final ContainerLaunchContext ctx = YarnTypes.getContainerLaunchContext(
-          command, localResources, securityTokensBuffer);
+          command, localResources, securityTokensBuffer, YarnUtilities.getApplicationId());
       this.yarnContainerManager.get().submit(container, ctx);
 
       LOG.log(Level.FINEST, "TIME: End ResourceLaunch {0}", containerId);

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
@@ -18,11 +18,8 @@
  */
 package org.apache.reef.runtime.yarn.driver;
 
-import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.Container;
-import org.apache.hadoop.yarn.api.records.ContainerId;
-import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
@@ -35,6 +32,7 @@ import org.apache.reef.runtime.common.driver.EvaluatorPreserver;
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceEventImpl;
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceStatusEventImpl;
 import org.apache.reef.runtime.yarn.driver.parameters.YarnEvaluatorPreserver;
+import org.apache.reef.runtime.yarn.util.YarnUtilities;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
@@ -92,8 +90,8 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
    */
   @Override
   public int getResubmissionAttempts() {
-    final String containerIdString = getContainerIdString();
-    final ApplicationAttemptId appAttemptID = getAppAttemptId(containerIdString);
+    final String containerIdString = YarnUtilities.getContainerIdString();
+    final ApplicationAttemptId appAttemptID = YarnUtilities.getAppAttemptId(containerIdString);
 
     if (containerIdString == null || appAttemptID == null) {
       LOG.log(Level.WARNING, "Was not able to fetch application attempt, container ID is [" + containerIdString +
@@ -114,31 +112,6 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
     LOG.log(Level.FINE, "Application attempt: " + appAttempt);
     assert appAttempt > 0;
     return appAttempt - 1;
-  }
-
-  private static String getContainerIdString() {
-    try {
-      return System.getenv(ApplicationConstants.Environment.CONTAINER_ID.key());
-    } catch (Exception e) {
-      LOG.log(Level.WARNING, "Unable to get the container ID from the environment, exception " +
-          e + " was thrown.");
-      return null;
-    }
-  }
-
-  private static ApplicationAttemptId getAppAttemptId(final String containerIdString) {
-    if (containerIdString == null) {
-      return null;
-    }
-
-    try {
-      final ContainerId containerId = ConverterUtils.toContainerId(containerIdString);
-      return containerId.getApplicationAttemptId();
-    } catch (Exception e) {
-      LOG.log(Level.WARNING, "Unable to get the applicationAttempt ID from the environment, exception " +
-          e + " was thrown.");
-      return null;
-    }
   }
 
   /**

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/restart/DFSEvaluatorPreserver.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/restart/DFSEvaluatorPreserver.java
@@ -29,6 +29,7 @@ import org.apache.reef.driver.parameters.FailDriverOnEvaluatorLogErrors;
 import org.apache.reef.exception.DriverFatalRuntimeException;
 import org.apache.reef.runtime.common.driver.EvaluatorPreserver;
 import org.apache.reef.runtime.common.driver.evaluator.EvaluatorManager;
+import org.apache.reef.runtime.yarn.util.YarnUtilities;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
@@ -62,9 +63,10 @@ public final class DFSEvaluatorPreserver implements EvaluatorPreserver, AutoClos
 
   private boolean writerClosed = false;
 
-  @Inject DFSEvaluatorPreserver(@Parameter(FailDriverOnEvaluatorLogErrors.class)
-                                final boolean failDriverOnEvaluatorLogErrors) {
-    this(failDriverOnEvaluatorLogErrors, "/ReefApplications/" + EvaluatorManager.getJobIdentifier());
+  @Inject
+  DFSEvaluatorPreserver(@Parameter(FailDriverOnEvaluatorLogErrors.class)
+                        final boolean failDriverOnEvaluatorLogErrors) {
+    this(failDriverOnEvaluatorLogErrors, "/ReefApplications/" + getEvaluatorChangeLogFolderLocation());
   }
 
   @Inject
@@ -98,6 +100,23 @@ public final class DFSEvaluatorPreserver implements EvaluatorPreserver, AutoClos
       this.changeLogLocation = null;
       this.writer = null;
     }
+  }
+
+  /**
+   * @return the folder for Evaluator changelog.
+   */
+  private static String getEvaluatorChangeLogFolderLocation() {
+    final String appId = YarnUtilities.getApplicationId().toString();
+    if (appId != null) {
+      return appId;
+    }
+
+    final String jobIdentifier = EvaluatorManager.getJobIdentifier();
+    if (jobIdentifier != null) {
+      return jobIdentifier;
+    }
+
+    throw new RuntimeException("Could not retrieve a suitable DFS folder for preserving Evaluator changelog.");
   }
 
   /**

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnUtilities.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnUtilities.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.util.ConverterUtils;
+import org.apache.reef.annotations.audience.Private;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -30,6 +31,7 @@ import java.util.logging.Logger;
 /**
  * A helper class for YARN applications.
  */
+@Private
 public final class YarnUtilities {
   public static final String REEF_YARN_APPLICATION_ID_ENV_VAR = "REEF_YARN_APPLICATION_ID";
   private static final Logger LOG = Logger.getLogger(YarnUtilities.class.getName());

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnUtilities.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnUtilities.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.yarn.util;
+
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.util.ConverterUtils;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A helper class for YARN applications.
+ */
+public final class YarnUtilities {
+  public static final String REEF_YARN_APPLICATION_ID_ENV_VAR = "REEF_YARN_APPLICATION_ID";
+  private static final Logger LOG = Logger.getLogger(YarnUtilities.class.getName());
+
+  /**
+   * @return the Container ID of the running Container.
+   */
+  public static String getContainerIdString() {
+    try {
+      return System.getenv(ApplicationConstants.Environment.CONTAINER_ID.key());
+    } catch (final Exception e) {
+      LOG.log(Level.WARNING, "Unable to get the container ID from the environment, exception " +
+          e + " was thrown.");
+      return null;
+    }
+  }
+
+  /**
+   * @return the Application ID of the YARN application.
+   */
+  public static ApplicationId getApplicationId() {
+    if (getAppAttemptId() == null) {
+      return null;
+    }
+
+    return getAppAttemptId().getApplicationId();
+  }
+
+  /**
+   * @return the Application Attempt ID of the YARN application.
+   */
+  public static ApplicationAttemptId getAppAttemptId() {
+    return getAppAttemptId(getContainerIdString());
+  }
+
+  /**
+   * @param containerIdString the Container ID of the running Container.
+   * @return the Application Attempt ID of the YARN application.
+   */
+  public static ApplicationAttemptId getAppAttemptId(final String containerIdString) {
+    if (containerIdString == null) {
+      return null;
+    }
+
+    try {
+      final ContainerId containerId = ConverterUtils.toContainerId(containerIdString);
+      return containerId.getApplicationAttemptId();
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "Unable to get the applicationAttempt ID from the environment, exception " +
+          e + " was thrown.");
+      return null;
+    }
+  }
+
+  private YarnUtilities() {
+  }
+}


### PR DESCRIPTION
…ID and not use the Job ID passed in by the user

This addressed the issue by
  * Add environment variable "REEF_YARN_APPLICATION_ID" for container launch.
  * Add YarnUtilities class to help retrieve YARN application-related IDs.
  * Use YARN ApplicationId instead of user's job ID to reconnect to driver on driver restart.

JIRA:
  [REEF-1071](https://issues.apache.org/jira/browse/REEF-1071)