### PR TITLE
[REEF-1075] Create Tasklet abstraction to enable one-to-many mapping …

### DIFF
--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/Tasklet.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/Tasklet.java
@@ -20,7 +20,6 @@ package org.apache.reef.vortex.driver;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.vortex.api.VortexFunction;
-import org.apache.reef.vortex.api.VortexFuture;
 
 import java.io.Serializable;
 
@@ -32,16 +31,16 @@ class Tasklet<TInput extends Serializable, TOutput extends Serializable> {
   private final int taskletId;
   private final VortexFunction<TInput, TOutput> userTask;
   private final TInput input;
-  private final VortexFuture<TOutput> vortexFuture;
+  private final TaskletStateDelegate<TOutput> stateDelegate;
 
   Tasklet(final int taskletId,
           final VortexFunction<TInput, TOutput> userTask,
           final TInput input,
-          final VortexFuture<TOutput> vortexFuture) {
+          final TaskletStateDelegate<TOutput> taskletStateDelegate) {
     this.taskletId = taskletId;
     this.userTask = userTask;
     this.input = input;
-    this.vortexFuture = vortexFuture;
+    this.stateDelegate = taskletStateDelegate;
   }
 
   /**
@@ -69,28 +68,28 @@ class Tasklet<TInput extends Serializable, TOutput extends Serializable> {
    * Called by VortexMaster to let the user know that the task completed.
    */
   void completed(final TOutput result) {
-    vortexFuture.completed(result);
+    stateDelegate.completed(getId(), result);
   }
 
   /**
    * Called by VortexMaster to let the user know that the task threw an exception.
    */
   void threwException(final Exception exception) {
-    vortexFuture.threwException(exception);
+    stateDelegate.threwException(getId(), exception);
   }
 
   /**
    * Called by VortexMaster to let the user know that the task has been cancelled.
    */
   void cancelled(){
-    vortexFuture.cancelled();
+    stateDelegate.cancelled(getId());
   }
 
   /**
    * For tests.
    */
   boolean isCompleted() {
-    return vortexFuture.isDone();
+    return stateDelegate.isDone(getId());
   }
 
   /**

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/TaskletStateDelegate.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/TaskletStateDelegate.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.driver;
+
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+
+import java.io.Serializable;
+
+/**
+ * A Delegate used by the VortexMaster to trigger and query state transitions of a Tasklet.
+ */
+@Private
+@DriverSide
+public interface TaskletStateDelegate<TOutput extends Serializable> {
+
+  /**
+   * Used by the VortexMaster to query whether the Tasklet is done.
+   * @param taskletId the ID of the Tasklet to query.
+   * @return true if the Tasklet completed, failed, or was cancelled; false otherwise.
+   */
+  boolean isDone(final int taskletId);
+
+  /**
+   * Called by VortexMaster to let the user know that the task completed.
+   * @param taskletId the ID of the Tasklet that completed.
+   * @param result the result of the Tasklet computation
+   */
+  void completed(final int taskletId, final TOutput result);
+
+  /**
+   * Called by VortexMaster to let the user know that the Tasklet was cancelled.
+   * @param taskletId the ID of the Tasklet that was cancelled.
+   */
+  void cancelled(final int taskletId);
+
+  /**
+   * Called by VortexMaster to let the user know that the task threw an exception.
+   * @param taskletId the ID of the Tasklet that threw an Exception.
+   * @param exception the Exception that was thrown in the Tasklet.
+   */
+  void threwException(final int taskletId, final Exception exception);
+}


### PR DESCRIPTION
…of "Future-like" object to TaskletIds

This addressed the issue by
  * Added TaskletStateDelegate and have VortexFuture inherit from it.
  * Changed Tasklet to use TaskletStateDelegate instead of VortexFuture.

JIRA:
  [REEF-1075](https://issues.apache.org/jira/browse/REEF-1075)