### PR TITLE
[REEF-1077] Allow VortexWorker reports to report about more than a si…

### DIFF
--- a/lang/java/reef-applications/reef-vortex/src/main/avro/WorkerReport.avsc
+++ b/lang/java/reef-applications/reef-vortex/src/main/avro/WorkerReport.avsc
@@ -46,19 +46,36 @@
   {
     "namespace": "org.apache.reef.vortex.common.avro",
     "type": "record",
-    "name": "AvroWorkerReport",
+    "name": "AvroTaskletReport",
     "fields": [
       {
         "name": "reportType",
-        "type": {
+        "type": 
+		{
           "type": "enum",
           "name": "AvroReportType",
-          "symbols": ["TaskletResult", "TaskletCancelled", "TaskletFailure"]}
+          "symbols": ["TaskletResult", "TaskletCancelled", "TaskletFailure"]
+		}
       },
       {
         "name": "taskletReport",
         "type": ["null", "AvroTaskletResultReport", "AvroTaskletCancelledReport", "AvroTaskletFailureReport"],
         "default": null
+      }
+    ]
+  },
+  {
+    "namespace": "org.apache.reef.vortex.common.avro",
+    "type": "record",
+    "name": "AvroWorkerReport",
+    "fields": [
+      {
+        "name": "taskletReports",
+        "type": 
+		{
+			"type": "array",
+			"items": "AvroTaskletReport"
+		}
       }
     ]
   }

--- a/lang/java/reef-applications/reef-vortex/src/main/avro/WorkerReport.avsc
+++ b/lang/java/reef-applications/reef-vortex/src/main/avro/WorkerReport.avsc
@@ -50,12 +50,12 @@
     "fields": [
       {
         "name": "reportType",
-        "type": 
-		{
+        "type":
+        {
           "type": "enum",
           "name": "AvroReportType",
           "symbols": ["TaskletResult", "TaskletCancelled", "TaskletFailure"]
-		}
+        }
       },
       {
         "name": "taskletReport",
@@ -71,11 +71,11 @@
     "fields": [
       {
         "name": "taskletReports",
-        "type": 
-		{
-			"type": "array",
-			"items": "AvroTaskletReport"
-		}
+        "type":
+        {
+          "type": "array",
+          "items": "AvroTaskletReport"
+        }
       }
     ]
   }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletFailureReport.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletFailureReport.java
@@ -24,7 +24,7 @@ import org.apache.reef.annotations.Unstable;
  * Report of a tasklet exception.
  */
 @Unstable
-public final class TaskletFailureReport implements WorkerReport {
+public final class TaskletFailureReport implements TaskletReport {
   private final int taskletId;
   private final Exception exception;
 
@@ -38,11 +38,11 @@ public final class TaskletFailureReport implements WorkerReport {
   }
 
   /**
-   * @return the type of this WorkerReport.
+   * @return the type of this TaskletReport.
    */
   @Override
-  public WorkerReportType getType() {
-    return WorkerReportType.TaskletFailure;
+  public TaskletReportType getType() {
+    return TaskletReportType.TaskletFailure;
   }
 
   /**

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletReport.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletReport.java
@@ -25,7 +25,7 @@ import org.apache.reef.annotations.audience.Private;
 import java.io.Serializable;
 
 /**
- * The interface for a status report from the {@link org.apache.reef.vortex.evaluator.VortexWorker}
+ * The interface for a status report from the {@link org.apache.reef.vortex.evaluator.VortexWorker}.
  */
 @Unstable
 @Private

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletReport.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletReport.java
@@ -19,28 +19,34 @@
 package org.apache.reef.vortex.common;
 
 import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+
+import java.io.Serializable;
 
 /**
- * The report of a cancelled Tasklet.
+ * The interface for a status report from the {@link org.apache.reef.vortex.evaluator.VortexWorker}
  */
 @Unstable
-public final class TaskletCancelledReport implements TaskletReport {
-  private int taskletId;
+@Private
+@DriverSide
+public interface TaskletReport extends Serializable {
+  /**
+   * Type of TaskletReport.
+   */
+  enum TaskletReportType {
+    TaskletResult,
+    TaskletCancelled,
+    TaskletFailure
+  }
 
   /**
-   * @param taskletId of the cancelled tasklet.
+   * @return the type of this TaskletReport.
    */
-  public TaskletCancelledReport(final int taskletId) {
-    this.taskletId = taskletId;
-  }
+  TaskletReportType getType();
 
-  @Override
-  public TaskletReportType getType() {
-    return TaskletReportType.TaskletCancelled;
-  }
-
-  @Override
-  public int getTaskletId() {
-    return taskletId;
-  }
+  /**
+   * @return the taskletId of this TaskletReport.
+   */
+  int getTaskletId();
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletResultReport.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletResultReport.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
  * Report of a tasklet execution result.
  */
 @Unstable
-public final class TaskletResultReport<TOutput extends Serializable> implements WorkerReport {
+public final class TaskletResultReport<TOutput extends Serializable> implements TaskletReport {
   private final int taskletId;
   private final TOutput result;
 
@@ -40,11 +40,11 @@ public final class TaskletResultReport<TOutput extends Serializable> implements 
   }
 
   /**
-   * @return the type of this WorkerReport.
+   * @return the type of this TaskletReport.
    */
   @Override
-  public WorkerReportType getType() {
-    return WorkerReportType.TaskletResult;
+  public TaskletReportType getType() {
+    return TaskletReportType.TaskletResult;
   }
 
   /**

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/VortexAvroUtils.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/VortexAvroUtils.java
@@ -29,6 +29,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Serialize and deserialize Vortex message to/from byte array.
@@ -81,52 +83,62 @@ public final class VortexAvroUtils {
   }
 
   /**
-   * Serialize WorkerReport to byte array.
+   * Serialize TaskletReport to byte array.
    * @param workerReport Worker report message to serialize.
    * @return Serialized byte array.
    */
   public static byte[] toBytes(final WorkerReport workerReport) {
-    // Convert WorkerReport message to Avro message.
-    final AvroWorkerReport avroWorkerReport;
-    switch (workerReport.getType()) {
-    case TaskletResult:
-      final TaskletResultReport taskletResultReport = (TaskletResultReport) workerReport;
-      // TODO[REEF-1005]: Allow custom codecs for input/output data in Vortex.
-      final byte[] serializedOutput = SerializationUtils.serialize(taskletResultReport.getResult());
-      avroWorkerReport = AvroWorkerReport.newBuilder()
-          .setReportType(AvroReportType.TaskletResult)
-          .setTaskletReport(
-              AvroTaskletResultReport.newBuilder()
-                  .setTaskletId(taskletResultReport.getTaskletId())
-                  .setSerializedOutput(ByteBuffer.wrap(serializedOutput))
-                  .build())
-          .build();
-      break;
-    case TaskletCancelled:
-      final TaskletCancelledReport taskletCancelledReport = (TaskletCancelledReport) workerReport;
-      avroWorkerReport = AvroWorkerReport.newBuilder()
-          .setReportType(AvroReportType.TaskletCancelled)
-          .setTaskletReport(
-              AvroTaskletCancelledReport.newBuilder()
-                  .setTaskletId(workerReport.getTaskletId())
-                  .build())
-          .build();
-      break;
-    case TaskletFailure:
-      final TaskletFailureReport taskletFailureReport = (TaskletFailureReport) workerReport;
-      final byte[] serializedException = SerializationUtils.serialize(taskletFailureReport.getException());
-      avroWorkerReport = AvroWorkerReport.newBuilder()
-          .setReportType(AvroReportType.TaskletFailure)
-          .setTaskletReport(
-              AvroTaskletFailureReport.newBuilder()
-                  .setTaskletId(taskletFailureReport.getTaskletId())
-                  .setSerializedException(ByteBuffer.wrap(serializedException))
-                  .build())
-          .build();
-      break;
-    default:
-      throw new RuntimeException("Undefined message type");
+    final List<AvroTaskletReport> workerTaskletReports = new ArrayList<>();
+
+    for (final TaskletReport taskletReport : workerReport.getTaskletReports()) {
+      final AvroTaskletReport avroTaskletReport;
+      switch (taskletReport.getType()) {
+      case TaskletResult:
+        final TaskletResultReport taskletResultReport = (TaskletResultReport) taskletReport;
+        // TODO[REEF-1005]: Allow custom codecs for input/output data in Vortex.
+        final byte[] serializedOutput = SerializationUtils.serialize(taskletResultReport.getResult());
+        avroTaskletReport = AvroTaskletReport.newBuilder()
+            .setReportType(AvroReportType.TaskletResult)
+            .setTaskletReport(
+                AvroTaskletResultReport.newBuilder()
+                    .setTaskletId(taskletResultReport.getTaskletId())
+                    .setSerializedOutput(ByteBuffer.wrap(serializedOutput))
+                    .build())
+            .build();
+        break;
+      case TaskletCancelled:
+        final TaskletCancelledReport taskletCancelledReport = (TaskletCancelledReport) taskletReport;
+        avroTaskletReport = AvroTaskletReport.newBuilder()
+            .setReportType(AvroReportType.TaskletCancelled)
+            .setTaskletReport(
+                AvroTaskletCancelledReport.newBuilder()
+                    .setTaskletId(taskletCancelledReport.getTaskletId())
+                    .build())
+            .build();
+        break;
+      case TaskletFailure:
+        final TaskletFailureReport taskletFailureReport = (TaskletFailureReport) taskletReport;
+        final byte[] serializedException = SerializationUtils.serialize(taskletFailureReport.getException());
+        avroTaskletReport = AvroTaskletReport.newBuilder()
+            .setReportType(AvroReportType.TaskletFailure)
+            .setTaskletReport(
+                AvroTaskletFailureReport.newBuilder()
+                    .setTaskletId(taskletFailureReport.getTaskletId())
+                    .setSerializedException(ByteBuffer.wrap(serializedException))
+                    .build())
+            .build();
+        break;
+      default:
+        throw new RuntimeException("Undefined message type");
+      }
+
+      workerTaskletReports.add(avroTaskletReport);
     }
+
+    // Convert WorkerReport message to Avro message.
+    final AvroWorkerReport avroWorkerReport = AvroWorkerReport.newBuilder()
+        .setTaskletReports(workerTaskletReports)
+        .build();
 
     // Serialize the Avro message to byte array.
     return toBytes(avroWorkerReport, AvroWorkerReport.class);
@@ -172,33 +184,41 @@ public final class VortexAvroUtils {
    * @return De-serialized WorkerReport.
    */
   public static WorkerReport toWorkerReport(final byte[] bytes) {
-    final WorkerReport workerReport;
     final AvroWorkerReport avroWorkerReport = toAvroObject(bytes, AvroWorkerReport.class);
-    switch (avroWorkerReport.getReportType()) {
-    case TaskletResult:
-      final AvroTaskletResultReport taskletResultReport =
-          (AvroTaskletResultReport)avroWorkerReport.getTaskletReport();
-      // TODO[REEF-1005]: Allow custom codecs for input/output data in Vortex.
-      final Serializable output =
-          (Serializable) SerializationUtils.deserialize(taskletResultReport.getSerializedOutput().array());
-      workerReport = new TaskletResultReport<>(taskletResultReport.getTaskletId(), output);
-      break;
-    case TaskletCancelled:
-      final AvroTaskletCancelledReport taskletCancelledReport =
-          (AvroTaskletCancelledReport)avroWorkerReport.getTaskletReport();
-      workerReport = new TaskletCancelledReport(taskletCancelledReport.getTaskletId());
-      break;
-    case TaskletFailure:
-      final AvroTaskletFailureReport taskletFailureReport =
-          (AvroTaskletFailureReport)avroWorkerReport.getTaskletReport();
-      final Exception exception =
-          (Exception) SerializationUtils.deserialize(taskletFailureReport.getSerializedException().array());
-      workerReport = new TaskletFailureReport(taskletFailureReport.getTaskletId(), exception);
-      break;
-    default:
-      throw new RuntimeException("Undefined WorkerReport type");
+    final List<TaskletReport> workerTaskletReports = new ArrayList<>();
+
+    for (final AvroTaskletReport avroTaskletReport : avroWorkerReport.getTaskletReports()) {
+      final TaskletReport taskletReport;
+
+      switch (avroTaskletReport.getReportType()) {
+      case TaskletResult:
+        final AvroTaskletResultReport taskletResultReport =
+            (AvroTaskletResultReport)avroTaskletReport.getTaskletReport();
+        // TODO[REEF-1005]: Allow custom codecs for input/output data in Vortex.
+        final Serializable output =
+            (Serializable) SerializationUtils.deserialize(taskletResultReport.getSerializedOutput().array());
+        taskletReport = new TaskletResultReport<>(taskletResultReport.getTaskletId(), output);
+        break;
+      case TaskletCancelled:
+        final AvroTaskletCancelledReport taskletCancelledReport =
+            (AvroTaskletCancelledReport)avroTaskletReport.getTaskletReport();
+        taskletReport = new TaskletCancelledReport(taskletCancelledReport.getTaskletId());
+        break;
+      case TaskletFailure:
+        final AvroTaskletFailureReport taskletFailureReport =
+            (AvroTaskletFailureReport)avroTaskletReport.getTaskletReport();
+        final Exception exception =
+            (Exception) SerializationUtils.deserialize(taskletFailureReport.getSerializedException().array());
+        taskletReport = new TaskletFailureReport(taskletFailureReport.getTaskletId(), exception);
+        break;
+      default:
+        throw new RuntimeException("Undefined TaskletReport type");
+      }
+
+      workerTaskletReports.add(taskletReport);
     }
-    return workerReport;
+
+    return new WorkerReport(workerTaskletReports);
   }
 
   /**

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/VortexAvroUtils.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/VortexAvroUtils.java
@@ -83,7 +83,7 @@ public final class VortexAvroUtils {
   }
 
   /**
-   * Serialize TaskletReport to byte array.
+   * Serialize WorkerReport to byte array.
    * @param workerReport Worker report message to serialize.
    * @return Serialized byte array.
    */

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/WorkerReport.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/WorkerReport.java
@@ -19,30 +19,34 @@
 package org.apache.reef.vortex.common;
 
 import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Worker-to-Master protocol.
+ * A report of Tasklet statuses sent form the {@link org.apache.reef.vortex.evaluator.VortexWorker}
+ * to the {@link org.apache.reef.vortex.driver.VortexMaster}.
  */
+@Private
 @Unstable
-public interface WorkerReport extends Serializable {
-  /**
-   * Type of WorkerReport.
-   */
-  enum WorkerReportType {
-    TaskletResult,
-    TaskletCancelled,
-    TaskletFailure
+@DriverSide
+public final class WorkerReport implements Serializable {
+  private ArrayList<TaskletReport> taskletReports;
+
+  public WorkerReport(final Collection<TaskletReport> taskletReports) {
+    this.taskletReports = new ArrayList<>(taskletReports);
   }
 
   /**
-   * @return the type of this WorkerReport.
+   * @return the list of Tasklet reports.
    */
-  WorkerReportType getType();
-
-  /**
-   * @return the taskletId of this WorkerReport.
-   */
-  int getTaskletId();
+  public List<TaskletReport> getTaskletReports() {
+    return Collections.unmodifiableList(taskletReports);
+  }
 }


### PR DESCRIPTION
…ngle Tasklet

This addressed the issue by
  * Change the original WorkerReport to TaskletReport.
  * Allow WorkerReports to hold a List of TaskletReports.

JIRA:
  [REEF-1077](https://issues.apache.org/jira/browse/REEF-1077)