### PR TITLE
[REEF-1078] Improved exceptions in `FileSystemInputPartition`

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartition.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartition.cs
@@ -121,8 +121,8 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
                 else
                 {
                     string msg = string.Format
-                        (CultureInfo.CurrentCulture, "File {0} is NOT Copied to local {1}.", sourceUri, localFilePath);
-                    Exceptions.Throw(new FileLoadException(), msg, Logger);
+                        (CultureInfo.CurrentCulture, "The IFilesystem completed the copy of `{0}` to `{1}`. But the file `{1}` does not exist.", sourceUri, localFilePath);
+                    Exceptions.Throw(new FileLoadException(msg), msg, Logger);
                 }
             }
         }


### PR DESCRIPTION
This adds a message to the `FileLoadException` thrown in `FileSystemInputPartition.CopyFromRemote` when downloaded file in fact does not exist.

JIRA:
  [REEF-1078](https://issues.apache.org/jira/browse/REEF-1078)

Pull Request:
  This closes #