### PR TITLE
[REEF-1083] Implement OnCompleted for the wake remote observers

### DIFF
--- a/lang/cs/.nuget/packages.config
+++ b/lang/cs/.nuget/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The issue is addressed by Implementing OnCompleted method for ProxyObservers to dispose the observer and remove it from cache

JIRA:
  [REEF-1083](https://issues.apache.org/jira/browse/REEF-1083)