### PR TITLE
[REEF-806] Expose the sequence number of Evaluator heartbeats

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ContextMessageBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ContextMessageBridge.java
@@ -18,6 +18,7 @@
  */
 package org.apache.reef.javabridge;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.reef.annotations.audience.Interop;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ContextMessage;
@@ -61,5 +62,12 @@ public final class ContextMessageBridge extends NativeBridge implements ContextM
   @Override
   public String getMessageSourceID() {
     return messageSourceId;
+  }
+
+  @Override
+  public long getSequenceNumber(){
+    // TODO[REEF-1085] once REEF.NET supports sequence numbers, ensure the numbers
+    // can propagate between C# and Java implementations
+    throw new NotImplementedException("A Java-CLR bridge lacks support of sequence numbers on the REEF.NET side.");
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextMessage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextMessage.java
@@ -22,6 +22,7 @@ import org.apache.reef.annotations.Provided;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.io.Message;
+import org.apache.reef.io.Numberable;
 import org.apache.reef.io.naming.Identifiable;
 
 /**
@@ -30,7 +31,7 @@ import org.apache.reef.io.naming.Identifiable;
 @Public
 @DriverSide
 @Provided
-public interface ContextMessage extends Message, Identifiable {
+public interface ContextMessage extends Message, Identifiable, Numberable {
 
   /**
    * @return the message sent by the Context.
@@ -48,5 +49,26 @@ public interface ContextMessage extends Message, Identifiable {
    * @return the ID of the ContextMessageSource that sent the message on the Context.
    */
   String getMessageSourceID();
+
+  /**
+   * @return the sequence number of the message
+   *
+   * Terminology: a source sends a message to a target.
+   * Example sources are Tasks or Contexts. Example targets are Drivers.
+   *
+   * The method guarantees that sequence numbers increase strictly monotonically per message source.
+   * So numbers of messages from different sources should not be compared to each other.
+   *
+   * Clients of this method must not assume any particular method implementation
+   * because it may change in the future.
+   *
+   * The current implementation returns the timestamp of a heartbeat that contained the message.
+   * A heartbeat may contain several messages; all such message will get the same sequence number.
+   * A source can attach only one message to a single heartbeat, so the strict sequence number monotonicity
+   * per source is guaranteed.
+   *
+   */
+  @Override
+  long getSequenceNumber();
 
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/TaskMessage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/TaskMessage.java
@@ -22,6 +22,7 @@ import org.apache.reef.annotations.Provided;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.io.Message;
+import org.apache.reef.io.Numberable;
 import org.apache.reef.io.naming.Identifiable;
 
 /**
@@ -30,7 +31,7 @@ import org.apache.reef.io.naming.Identifiable;
 @DriverSide
 @Public
 @Provided
-public interface TaskMessage extends Message, Identifiable {
+public interface TaskMessage extends Message, Identifiable, Numberable {
 
   /**
    * @return the message.
@@ -43,6 +44,27 @@ public interface TaskMessage extends Message, Identifiable {
    */
   @Override
   String getId();
+
+  /**
+   * @return the sequence number of the message
+   *
+   * Terminology: a source sends a message to a target.
+   * Example sources are Tasks or Contexts. Example targets are Drivers.
+   *
+   * The method guarantees that sequence numbers increase strictly monotonically per message source.
+   * So numbers of messages from different sources should not be compared to each other.
+   *
+   * Clients of this method must not assume any particular method implementation
+   * because it may change in the future.
+   *
+   * The current implementation returns the timestamp of a heartbeat that contained the message.
+   * A heartbeat may contain several messages; all such message will get the same sequence number.
+   * A source can attach only one message to a single heartbeat, so the strict sequence number monotonicity
+   * per source is guaranteed.
+   *
+   */
+  @Override
+  long getSequenceNumber();
 
   /**
    * @return the id of the context the sending task is running in.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/Numberable.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/Numberable.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.io;
+
+/**
+ * Interface for objects which can form ordered sequences, e.g. {@link Message}.
+ */
+public interface Numberable {
+
+  /**
+   *
+   * @return the number of an object in a ordered sequences of similar objects
+   *
+   * Guarantees of this method - such as partial or total order - are implementation-specific.
+   */
+  long getSequenceNumber();
+
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextMessageImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextMessageImpl.java
@@ -28,14 +28,18 @@ import org.apache.reef.driver.context.ContextMessage;
 @Private
 @DriverSide
 public final class ContextMessageImpl implements ContextMessage {
+
   private final byte[] theMessage;
   private final String theContextID;
   private final String theMessageSourceId;
+  private final long sequenceNumber;
 
-  public ContextMessageImpl(final byte[] theMessage, final String theContextID, final String theMessageSourceId) {
+  public ContextMessageImpl(final byte[] theMessage, final String theContextID, final String theMessageSourceId,
+                            final long sequenceNumber) {
     this.theMessage = theMessage;
     this.theContextID = theContextID;
     this.theMessageSourceId = theMessageSourceId;
+    this.sequenceNumber = sequenceNumber;
   }
 
   @Override
@@ -51,5 +55,10 @@ public final class ContextMessageImpl implements ContextMessage {
   @Override
   public String getMessageSourceID() {
     return this.theMessageSourceId;
+  }
+
+  @Override
+  public long getSequenceNumber() {
+    return this.sequenceNumber;
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
@@ -198,7 +198,8 @@ public final class ContextRepresenters {
              contextMessage : contextStatus.getContextMessageList()) {
       final byte[] theMessage = contextMessage.getMessage();
       final String sourceID = contextMessage.getSourceId();
-      this.messageDispatcher.onContextMessage(new ContextMessageImpl(theMessage, contextID, sourceID));
+      final long sequenceNumber = contextMessage.getSequenceNumber();
+      this.messageDispatcher.onContextMessage(new ContextMessageImpl(theMessage, contextID, sourceID, sequenceNumber));
     }
 
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/pojos/ContextMessagePOJO.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/pojos/ContextMessagePOJO.java
@@ -21,6 +21,7 @@ package org.apache.reef.runtime.common.driver.evaluator.pojos;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.io.Numberable;
 import org.apache.reef.proto.ReefServiceProtos;
 
 /**
@@ -28,15 +29,17 @@ import org.apache.reef.proto.ReefServiceProtos;
  */
 @DriverSide
 @Private
-public final class ContextMessagePOJO {
+public final class ContextMessagePOJO implements Numberable {
 
   private final byte[] message;
   private final String sourceId;
+  private final long sequenceNumber;
 
 
-  ContextMessagePOJO(final ReefServiceProtos.ContextStatusProto.ContextMessageProto proto){
+  ContextMessagePOJO(final ReefServiceProtos.ContextStatusProto.ContextMessageProto proto, final long sequenceNumber){
     message = proto.getMessage().toByteArray();
     sourceId = proto.getSourceId();
+    this.sequenceNumber = sequenceNumber;
   }
 
   /**
@@ -51,5 +54,15 @@ public final class ContextMessagePOJO {
    */
   public String getSourceId(){
     return sourceId;
+  }
+
+  /**
+   * @return the sequence number of a message
+   *
+   * {@see ContextMessage#getSequenceNumber()}
+   */
+  @Override
+  public long getSequenceNumber(){
+    return this.sequenceNumber;
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/pojos/ContextStatusPOJO.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/pojos/ContextStatusPOJO.java
@@ -41,7 +41,7 @@ public final class ContextStatusPOJO {
   private final List<ContextMessagePOJO> contextMessages = new ArrayList<>();
 
 
-  public ContextStatusPOJO(final ReefServiceProtos.ContextStatusProto proto){
+  public ContextStatusPOJO(final ReefServiceProtos.ContextStatusProto proto, final long sequenceNumber){
 
     contextId = proto.getContextId();
     parentId = proto.hasParentId() ? proto.getParentId() : null;
@@ -49,7 +49,7 @@ public final class ContextStatusPOJO {
     contextState = proto.hasContextState()? getContextStateFromProto(proto.getContextState()) : null;
 
     for (final ContextMessageProto contextMessageProto : proto.getContextMessageList()) {
-      contextMessages.add(new ContextMessagePOJO(contextMessageProto));
+      contextMessages.add(new ContextMessagePOJO(contextMessageProto,  sequenceNumber));
     }
 
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/pojos/TaskMessagePOJO.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/pojos/TaskMessagePOJO.java
@@ -21,6 +21,7 @@ package org.apache.reef.runtime.common.driver.evaluator.pojos;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.io.Numberable;
 import org.apache.reef.proto.ReefServiceProtos;
 
 /**
@@ -28,14 +29,16 @@ import org.apache.reef.proto.ReefServiceProtos;
  */
 @DriverSide
 @Private
-public final class TaskMessagePOJO {
+public final class TaskMessagePOJO implements Numberable {
 
   private final byte[] message;
   private final String sourceId;
+  private final long sequenceNumber;
 
-  TaskMessagePOJO(final ReefServiceProtos.TaskStatusProto.TaskMessageProto proto){
+  TaskMessagePOJO(final ReefServiceProtos.TaskStatusProto.TaskMessageProto proto, final long sequenceNumber) {
     message = proto.getMessage().toByteArray();
     sourceId = proto.getSourceId();
+    this.sequenceNumber = sequenceNumber;
   }
 
   /**
@@ -51,4 +54,15 @@ public final class TaskMessagePOJO {
   public String getSourceId(){
     return sourceId;
   }
+
+  /**
+   * @return the sequence number of a message
+   *
+   * {@see TaskMessage#getSequenceNumber()}
+   */
+  @Override
+  public long getSequenceNumber(){
+    return this.sequenceNumber;
+  }
+
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/pojos/TaskStatusPOJO.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/pojos/TaskStatusPOJO.java
@@ -40,7 +40,7 @@ public final class TaskStatusPOJO {
   private final byte[] result;
   private final List<TaskMessagePOJO> taskMessages = new ArrayList<>();
 
-  public TaskStatusPOJO(final ReefServiceProtos.TaskStatusProto proto){
+  public TaskStatusPOJO(final ReefServiceProtos.TaskStatusProto proto, final long sequenceNumber){
 
     taskId = proto.getTaskId();
     contextId = proto.getContextId();
@@ -48,7 +48,7 @@ public final class TaskStatusPOJO {
     result = proto.hasResult() ? proto.getResult().toByteArray() : null;
 
     for (final TaskMessageProto taskMessageProto : proto.getTaskMessageList()) {
-      taskMessages.add(new TaskMessagePOJO(taskMessageProto));
+      taskMessages.add(new TaskMessagePOJO(taskMessageProto, sequenceNumber));
     }
 
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskMessageImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskMessageImpl.java
@@ -33,13 +33,16 @@ public final class TaskMessageImpl implements TaskMessage {
   private final String taskId;
   private final String contextId;
   private final String theMessageSourceId;
+  private final long   sequenceNumber;
 
   public TaskMessageImpl(final byte[] theMessage, final String taskId,
-                         final String contextId, final String theMessageSourceId) {
+                         final String contextId, final String theMessageSourceId,
+                         final long sequenceNumber) {
     this.theMessage = theMessage;
     this.taskId = taskId;
     this.contextId = contextId;
     this.theMessageSourceId = theMessageSourceId;
+    this.sequenceNumber = sequenceNumber;
   }
 
   @Override
@@ -61,4 +64,10 @@ public final class TaskMessageImpl implements TaskMessage {
   public String getMessageSourceID() {
     return this.theMessageSourceId;
   }
+
+  @Override
+  public long getSequenceNumber() {
+    return this.sequenceNumber;
+  }
+  
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
@@ -149,10 +149,10 @@ public final class TaskRepresenter {
     }
 
     for (final TaskMessagePOJO
-             taskMessageProto : taskStatus.getTaskMessageList()) {
+             taskMessagePOJO : taskStatus.getTaskMessageList()) {
       this.messageDispatcher.onTaskMessage(
-          new TaskMessageImpl(taskMessageProto.getMessage(),
-              this.taskId, this.context.getId(), taskMessageProto.getSourceId()));
+          new TaskMessageImpl(taskMessagePOJO.getMessage(),
+              this.taskId, this.context.getId(), taskMessagePOJO.getSourceId(), taskMessagePOJO.getSequenceNumber()));
     }
   }
 


### PR DESCRIPTION
This patch:
 * Adds the Numberable interface to mark objects that can form ordered sequences, e.g. messages
 * Makes DriverSide TaskMessage and ContextMessage interfaces extend Numberable
 * In TaskMessageImpl and ContextMessageImpl, exposes the timestamp of an evaluator heartbeat as a sequence number
   via Numberable getSequenceNumber()

JIRA:
 [REEF-806] (https://issues.apache.org/jira/browse/REEF-806)