### PR TITLE
[REEF-1075] Create Tasklet abstraction to enable one-to-many mapping …

### DIFF
--- a/lang/java/reef-applications/reef-vortex/src/main/avro/WorkerReport.avsc
+++ b/lang/java/reef-applications/reef-vortex/src/main/avro/WorkerReport.avsc
@@ -22,6 +22,15 @@
     "type": "record",
     "name": "AvroTaskletResultReport",
     "fields": [
+      {"name": "taskletId", "type": "int"},
+      {"name": "serializedOutput", "type": "bytes"}
+    ]
+  },
+  {
+    "namespace": "org.apache.reef.vortex.common.avro",
+    "type": "record",
+    "name": "AvroTaskletAggregationResultReport",
+    "fields": [
       {
         "name": "taskletIds",
         "type":
@@ -46,6 +55,15 @@
     "type": "record",
     "name": "AvroTaskletFailureReport",
     "fields": [
+      {"name": "taskletId", "type": "int"},
+      {"name": "serializedException", "type": "bytes"}
+    ]
+  },
+  {
+    "namespace": "org.apache.reef.vortex.common.avro",
+    "type": "record",
+    "name": "AvroTaskletAggregationFailureReport",
+    "fields": [
       {
         "name": "taskletIds",
         "type":
@@ -68,12 +86,24 @@
         {
           "type": "enum",
           "name": "AvroReportType",
-          "symbols": ["TaskletResult", "TaskletCancelled", "TaskletFailure"]
+          "symbols": [
+            "TaskletResult",
+            "TaskletAggregationResult",
+            "TaskletCancelled",
+            "TaskletFailure",
+            "TaskletAggregationFailure"
+          ]
         }
       },
       {
         "name": "taskletReport",
-        "type": ["AvroTaskletResultReport", "AvroTaskletCancelledReport", "AvroTaskletFailureReport"]
+        "type": [
+          "AvroTaskletResultReport",
+          "AvroTaskletAggregationResultReport",
+          "AvroTaskletCancelledReport",
+          "AvroTaskletFailureReport",
+          "AvroTaskletAggregationFailureReport"
+        ]
       }
     ]
   },

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletAggregationFailureReport.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletAggregationFailureReport.java
@@ -19,25 +19,25 @@
 package org.apache.reef.vortex.common;
 
 import org.apache.reef.annotations.Unstable;
-import org.apache.reef.annotations.audience.DriverSide;
-import org.apache.reef.annotations.audience.Private;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
- * Report of a Tasklet exception.
+ * Report of a tasklet exception on aggregation.
  */
 @Unstable
-@Private
-@DriverSide
-public final class TaskletFailureReport implements TaskletReport {
-  private final int taskletId;
+public final class TaskletAggregationFailureReport implements TaskletReport {
+  private final List<Integer> taskletIds;
   private final Exception exception;
 
   /**
-   * @param taskletId of the failed Tasklet.
+   * @param taskletIds of the failed tasklet(s).
    * @param exception that caused the tasklet failure.
    */
-  public TaskletFailureReport(final int taskletId, final Exception exception) {
-    this.taskletId = taskletId;
+  public TaskletAggregationFailureReport(final List<Integer> taskletIds, final Exception exception) {
+    this.taskletIds = Collections.unmodifiableList(new ArrayList<>(taskletIds));
     this.exception = exception;
   }
 
@@ -46,18 +46,18 @@ public final class TaskletFailureReport implements TaskletReport {
    */
   @Override
   public TaskletReportType getType() {
-    return TaskletReportType.TaskletFailure;
+    return TaskletReportType.TaskletAggregationFailure;
   }
 
   /**
-   * @return the taskletId of this TaskletReport.
+   * @return the taskletIds that failed on aggregation.
    */
-  public int getTaskletId() {
-    return taskletId;
+  public List<Integer> getTaskletIds() {
+    return taskletIds;
   }
 
   /**
-   * @return the exception that caused the Tasklet failure.
+   * @return the exception that caused the tasklet aggregation failure.
    */
   public Exception getException() {
     return exception;

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletAggregationResultReport.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletAggregationResultReport.java
@@ -22,23 +22,28 @@ import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
- * Report of a Tasklet exception.
+ * Report of a Tasklet aggregation execution result.
  */
-@Unstable
 @Private
 @DriverSide
-public final class TaskletFailureReport implements TaskletReport {
-  private final int taskletId;
-  private final Exception exception;
+@Unstable
+public final class TaskletAggregationResultReport<TOutput extends Serializable> implements TaskletReport {
+  private final List<Integer> taskletIds;
+  private final TOutput result;
 
   /**
-   * @param taskletId of the failed Tasklet.
-   * @param exception that caused the tasklet failure.
+   * @param taskletIds of the tasklets.
+   * @param result of the tasklet execution.
    */
-  public TaskletFailureReport(final int taskletId, final Exception exception) {
-    this.taskletId = taskletId;
-    this.exception = exception;
+  public TaskletAggregationResultReport(final List<Integer> taskletIds, final TOutput result) {
+    this.taskletIds = Collections.unmodifiableList(new ArrayList<>(taskletIds));
+    this.result = result;
   }
 
   /**
@@ -46,20 +51,21 @@ public final class TaskletFailureReport implements TaskletReport {
    */
   @Override
   public TaskletReportType getType() {
-    return TaskletReportType.TaskletFailure;
+    return TaskletReportType.TaskletAggregationResult;
   }
 
   /**
-   * @return the taskletId of this TaskletReport.
+   * @return the TaskletId(s) of this TaskletReport
    */
-  public int getTaskletId() {
-    return taskletId;
+  public List<Integer> getTaskletIds() {
+    return taskletIds;
   }
 
   /**
-   * @return the exception that caused the Tasklet failure.
+   * @return the result of the Tasklet aggregation execution.
    */
-  public Exception getException() {
-    return exception;
+  public TOutput getResult() {
+    return result;
   }
+
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletReport.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletReport.java
@@ -36,8 +36,10 @@ public interface TaskletReport extends Serializable {
    */
   enum TaskletReportType {
     TaskletResult,
+    TaskletAggregationResult,
     TaskletCancelled,
-    TaskletFailure
+    TaskletFailure,
+    TaskletAggregationFailure
   }
 
   /**

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletResultReport.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletResultReport.java
@@ -19,26 +19,27 @@
 package org.apache.reef.vortex.common;
 
 import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Report of a tasklet execution result.
  */
 @Unstable
+@Private
+@DriverSide
 public final class TaskletResultReport<TOutput extends Serializable> implements TaskletReport {
-  private final List<Integer> taskletIds;
+  private final int taskletId;
   private final TOutput result;
 
   /**
-   * @param taskletIds of the tasklets.
-   * @param result of the tasklet execution.
+   * @param taskletId of the Tasklet.
+   * @param result of the Tasklet execution.
    */
-  public TaskletResultReport(final List<Integer> taskletIds, final TOutput result) {
-    this.taskletIds = Collections.unmodifiableList(new ArrayList<>(taskletIds));
+  public TaskletResultReport(final int taskletId, final TOutput result) {
+    this.taskletId = taskletId;
     this.result = result;
   }
 
@@ -51,16 +52,14 @@ public final class TaskletResultReport<TOutput extends Serializable> implements 
   }
 
   /**
-   * Returns multiple TaskletIds if the result is from an Aggregation.
-   * Returns a single TaskletId if the result is from a single Tasklet.
-   * @return the TaskletId(s) of this TaskletReport
+   * @return the TaskletId of this TaskletReport
    */
-  public List<Integer> getTaskletIds() {
-    return taskletIds;
+  public int getTaskletId() {
+    return taskletId;
   }
 
   /**
-   * @return the result of the tasklet execution.
+   * @return the result of the Tasklet execution.
    */
   public TOutput getResult() {
     return result;

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/VortexFutureDelegate.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/VortexFutureDelegate.java
@@ -22,44 +22,40 @@ import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 
+import java.io.Serializable;
+import java.util.List;
+
 /**
- * Report of a Tasklet exception.
+ * Exposes functions to be called by the {@link org.apache.reef.vortex.driver.VortexMaster}
+ * to note that a list of Tasklets associated with a Future has completed.
  */
 @Unstable
-@Private
 @DriverSide
-public final class TaskletFailureReport implements TaskletReport {
-  private final int taskletId;
-  private final Exception exception;
+@Private
+public interface VortexFutureDelegate<TOutput extends Serializable> {
 
   /**
-   * @param taskletId of the failed Tasklet.
-   * @param exception that caused the tasklet failure.
+   * A Tasklet associated with the future has completed with a result.
    */
-  public TaskletFailureReport(final int taskletId, final Exception exception) {
-    this.taskletId = taskletId;
-    this.exception = exception;
-  }
+  void completed(final int taskletId, final TOutput result);
 
   /**
-   * @return the type of this TaskletReport.
+   * The list of aggregated Tasklets associated with the Future that have completed with a result.
    */
-  @Override
-  public TaskletReportType getType() {
-    return TaskletReportType.TaskletFailure;
-  }
+  void aggregationCompleted(final List<Integer> taskletIds, final TOutput result);
 
   /**
-   * @return the taskletId of this TaskletReport.
+   * A Tasklet associated with the Future has thrown an Exception.
    */
-  public int getTaskletId() {
-    return taskletId;
-  }
+  void threwException(final int taskletId, final Exception exception);
 
   /**
-   * @return the exception that caused the Tasklet failure.
+   * The list of Tasklets associated with the Future that have thrown an Exception.
    */
-  public Exception getException() {
-    return exception;
-  }
+  void aggregationThrewException(final List<Integer> taskletIds, final Exception exception);
+
+  /**
+   * A Tasklet associated with the Future has been cancelled.
+   */
+  void cancelled(final int taskletId);
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/FirstFitSchedulingPolicy.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/FirstFitSchedulingPolicy.java
@@ -125,33 +125,17 @@ class FirstFitSchedulingPolicy implements SchedulingPolicy {
 
   /**
    * @param vortexWorker that the tasklet completed in
-   * @param tasklet completed
+   * @param tasklets completed
    */
   @Override
-  public void taskletCompleted(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
+  public void taskletsDone(final VortexWorkerManager vortexWorker, final List<Tasklet> tasklets) {
     final String workerId = vortexWorker.getId();
-    removeTasklet(workerId);
+    removeTasklet(workerId, tasklets);
   }
 
-  /**
-   * @param vortexWorker that the tasklet failed in
-   * @param tasklet failed
-   */
-  @Override
-  public void taskletFailed(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
-    final String workerId = vortexWorker.getId();
-    removeTasklet(workerId);
-  }
-
-  @Override
-  public void taskletCancelled(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
-    final String workerId = vortexWorker.getId();
-    removeTasklet(workerId);
-  }
-
-  private void removeTasklet(final String workerId) {
+  private void removeTasklet(final String workerId, final List<Tasklet> tasklets) {
     if (idLoadMap.containsKey(workerId)) {
-      idLoadMap.put(workerId, Math.max(0, idLoadMap.get(workerId) - 1));
+      idLoadMap.put(workerId, Math.max(0, idLoadMap.get(workerId) - tasklets.size()));
     }
   }
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RandomSchedulingPolicy.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RandomSchedulingPolicy.java
@@ -90,24 +90,7 @@ class RandomSchedulingPolicy implements SchedulingPolicy {
    * Do nothing.
    */
   @Override
-  public void taskletCompleted(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
+  public void taskletsDone(final VortexWorkerManager vortexWorker, final List<Tasklet> tasklets) {
     // Do nothing
   }
-
-  /**
-   * Do nothing.
-   */
-  @Override
-  public void taskletFailed(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
-    // Do nothing
-  }
-
-  /**
-   * Do nothing.
-   */
-  @Override
-  public void taskletCancelled(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
-    // Do nothing
-  }
-
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/SchedulingPolicy.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/SchedulingPolicy.java
@@ -21,6 +21,8 @@ package org.apache.reef.vortex.driver;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.util.Optional;
 
+import java.util.List;
+
 /**
  * For choosing which worker to schedule the tasklet onto.
  */
@@ -49,17 +51,7 @@ interface SchedulingPolicy {
   void taskletLaunched(final VortexWorkerManager vortexWorker, final Tasklet tasklet);
 
   /**
-   * Tasklet completed.
+   * Tasklets completed.
    */
-  void taskletCompleted(final VortexWorkerManager vortexWorker, final Tasklet tasklet);
-
-  /**
-   * Tasklet failed.
-   */
-  void taskletFailed(final VortexWorkerManager vortexWorker, final Tasklet tasklet);
-
-  /**
-   * Tasklet cancelled.
-   */
-  void taskletCancelled(final VortexWorkerManager vortexWorker, final Tasklet tasklet);
+  void taskletsDone(final VortexWorkerManager vortexWorker, final List<Tasklet> tasklets);
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/Tasklet.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/Tasklet.java
@@ -20,7 +20,7 @@ package org.apache.reef.vortex.driver;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.vortex.api.VortexFunction;
-import org.apache.reef.vortex.api.VortexFuture;
+import org.apache.reef.vortex.common.VortexFutureDelegate;
 
 import java.io.Serializable;
 
@@ -32,16 +32,16 @@ class Tasklet<TInput extends Serializable, TOutput extends Serializable> {
   private final int taskletId;
   private final VortexFunction<TInput, TOutput> userTask;
   private final TInput input;
-  private final VortexFuture<TOutput> vortexFuture;
+  private final VortexFutureDelegate delegate;
 
   Tasklet(final int taskletId,
           final VortexFunction<TInput, TOutput> userTask,
           final TInput input,
-          final VortexFuture<TOutput> vortexFuture) {
+          final VortexFutureDelegate delegate) {
     this.taskletId = taskletId;
     this.userTask = userTask;
     this.input = input;
-    this.vortexFuture = vortexFuture;
+    this.delegate = delegate;
   }
 
   /**
@@ -66,31 +66,10 @@ class Tasklet<TInput extends Serializable, TOutput extends Serializable> {
   }
 
   /**
-   * Called by VortexMaster to let the user know that the task completed.
+   * Called by {@link RunningWorkers} to cancel the Tasklet before launch.
    */
-  void completed(final TOutput result) {
-    vortexFuture.completed(result);
-  }
-
-  /**
-   * Called by VortexMaster to let the user know that the task threw an exception.
-   */
-  void threwException(final Exception exception) {
-    vortexFuture.threwException(exception);
-  }
-
-  /**
-   * Called by VortexMaster to let the user know that the task has been cancelled.
-   */
-  void cancelled(){
-    vortexFuture.cancelled();
-  }
-
-  /**
-   * For tests.
-   */
-  boolean isCompleted() {
-    return vortexFuture.isDone();
+  void cancelled() {
+    delegate.cancelled(taskletId);
   }
 
   /**

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexDriver.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexDriver.java
@@ -37,7 +37,6 @@ import org.apache.reef.wake.impl.ThreadPoolStage;
 import org.apache.reef.wake.time.event.StartTime;
 
 import javax.inject.Inject;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -153,34 +152,7 @@ final class VortexDriver {
     public void onNext(final TaskMessage taskMessage) {
       final String workerId = taskMessage.getId();
       final WorkerReport workerReport = VortexAvroUtils.toWorkerReport(taskMessage.get());
-
-      // TODO[JIRA REEF-942]: Fix when aggregation is allowed.
-      assert workerReport.getTaskletReports().size() == 1;
-
-      final TaskletReport taskletReport = workerReport.getTaskletReports().get(0);
-      switch (taskletReport.getType()) {
-      case TaskletResult:
-        final TaskletResultReport taskletResultReport = (TaskletResultReport) taskletReport;
-
-        // TODO[JIRA REEF-942]: Fix when aggregation is allowed.
-        final List<Integer> resultTaskletIds = taskletResultReport.getTaskletIds();
-
-        assert resultTaskletIds.size() == 1;
-        vortexMaster.taskletCompleted(workerId, resultTaskletIds.get(0),
-            taskletResultReport.getResult());
-        break;
-      case TaskletCancelled:
-        final TaskletCancelledReport taskletCancelledReport = (TaskletCancelledReport) taskletReport;
-        vortexMaster.taskletCancelled(workerId, taskletCancelledReport.getTaskletId());
-        break;
-      case TaskletFailure:
-        final TaskletFailureReport taskletFailureReport = (TaskletFailureReport) taskletReport;
-        vortexMaster.taskletErrored(workerId, taskletFailureReport.getTaskletIds().get(0),
-            taskletFailureReport.getException());
-        break;
-      default:
-        throw new RuntimeException("Unknown Report");
-      }
+      vortexMaster.workerReported(workerId, workerReport);
     }
   }
 

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMaster.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMaster.java
@@ -25,6 +25,7 @@ import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.api.FutureCallback;
 import org.apache.reef.vortex.api.VortexFunction;
 import org.apache.reef.vortex.api.VortexFuture;
+import org.apache.reef.vortex.common.WorkerReport;
 
 import java.io.Serializable;
 
@@ -62,19 +63,9 @@ public interface VortexMaster {
   void workerPreempted(final String id);
 
   /**
-   * Call this when a Tasklet is completed.
+   * Call this when a worker has reported back.
    */
-  void taskletCompleted(final String workerId, final int taskletId, final Serializable result);
-
-  /**
-   * Call this when a Tasklet errored.
-   */
-  void taskletErrored(final String workerId, final int taskletId, final Exception exception);
-
-  /**
-   * Call this when a Tasklet is cancelled and the cancellation is honored.
-   */
-  void taskletCancelled(final String workerId, final int taskletId);
+  void workerReported(final String workerId, final WorkerReport workerReport);
 
   /**
    * Release all resources and shut down.

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexWorkerManager.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexWorkerManager.java
@@ -25,8 +25,7 @@ import org.apache.reef.vortex.common.TaskletCancellationRequest;
 import org.apache.reef.vortex.common.TaskletExecutionRequest;
 
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.HashMap;
+import java.util.*;
 
 /**
  * Representation of a VortexWorkerManager in Driver.
@@ -57,25 +56,13 @@ class VortexWorkerManager {
     vortexRequestor.send(reefTask, cancellationRequest);
   }
 
-  <TOutput extends Serializable> Tasklet taskletCompleted(final Integer taskletId, final TOutput result) {
-    final Tasklet<?, TOutput> tasklet = runningTasklets.remove(taskletId);
-    assert tasklet != null; // Tasklet should complete/error only once
-    tasklet.completed(result);
-    return tasklet;
-  }
+  List<Tasklet> taskletsDone(final List<Integer> taskletIds) {
+    final List<Tasklet> taskletList = new ArrayList<>();
+    for (final int taskletId : taskletIds) {
+      taskletList.add(runningTasklets.remove(taskletId));
+    }
 
-  Tasklet taskletThrewException(final Integer taskletId, final Exception exception) {
-    final Tasklet tasklet = runningTasklets.remove(taskletId);
-    assert tasklet != null; // Tasklet should complete/error only once
-    tasklet.threwException(exception);
-    return tasklet;
-  }
-
-  Tasklet taskletCancelled(final Integer taskletId) {
-    final Tasklet tasklet = runningTasklets.remove(taskletId);
-    assert tasklet != null; // Tasklet should finish only once.
-    tasklet.cancelled();
-    return tasklet;
+    return Collections.unmodifiableList(taskletList);
   }
 
   Collection<Tasklet> removed() {

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/evaluator/VortexWorker.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/evaluator/VortexWorker.java
@@ -36,7 +36,6 @@ import org.apache.reef.wake.EventHandler;
 import javax.inject.Inject;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.logging.Level;
@@ -111,8 +110,7 @@ public final class VortexWorker implements Task, TaskMessageSource {
                         // Command Executor: Execute the command
                         final Serializable result = taskletExecutionRequest.execute();
                         final TaskletReport taskletReport =
-                            new TaskletResultReport<>(Collections.singletonList(
-                                taskletExecutionRequest.getTaskletId()), result);
+                            new TaskletResultReport<>(taskletExecutionRequest.getTaskletId(), result);
                         taskletReports.add(taskletReport);
                       } catch (final InterruptedException ex) {
                         // Assumes that user's thread follows convention that cancelled Futures
@@ -124,8 +122,7 @@ public final class VortexWorker implements Task, TaskMessageSource {
                       } catch (Exception e) {
                         // Command Executor: Tasklet throws an exception
                         final TaskletReport taskletReport =
-                            new TaskletFailureReport(Collections.singletonList(
-                                taskletExecutionRequest.getTaskletId()), e);
+                            new TaskletFailureReport(taskletExecutionRequest.getTaskletId(), e);
                         taskletReports.add(taskletReport);
                       }
 


### PR DESCRIPTION
…of "Future-like" object to TaskletIds

This addressed the issue by
  * Added VortexFutureDelegate to map a single result/failure to multiple tasklets.
  * Moved logic of calling back to Future to VortexMaster.

JIRA:
  [REEF-1075](https://issues.apache.org/jira/browse/REEF-1075)