### PR TITLE
[REEF-1034] Change default value of `JobSubmissionDirectoryPrefix` and add to `YarnDriverConfiguration`

### DIFF
--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/parameters/JobSubmissionDirectoryPrefix.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/parameters/JobSubmissionDirectoryPrefix.java
@@ -24,6 +24,6 @@ import org.apache.reef.tang.annotations.NamedParameter;
 /**
  * The job submission directory.
  */
-@NamedParameter(doc = "The job submission directory prefix.", default_value = "/vol1/tmp")
+@NamedParameter(doc = "The job submission directory prefix.", default_value = "/tmp")
 public final class JobSubmissionDirectoryPrefix implements Name<String> {
 }

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnDriverConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.reef.runtime.yarn.client;
 
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Public;
+import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectoryPrefix;
 import org.apache.reef.runtime.yarn.client.parameters.JobQueue;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
@@ -36,11 +37,17 @@ public final class YarnDriverConfiguration extends ConfigurationModuleBuilder {
    * The queue to submit this Driver to.
    */
   public static final OptionalParameter<String> QUEUE = new OptionalParameter<>();
+  
+  /**
+   * The job submission directory.
+   */
+  public static final OptionalParameter<String> JOB_SUBMISSION_DIRECTORY_PREFIX = new OptionalParameter<>();
 
   /**
    * ConfigurationModule to set YARN-Specific configuration options to be merged with DriverConfiguration.
    */
   public static final ConfigurationModule CONF = new YarnDriverConfiguration()
       .bindNamedParameter(JobQueue.class, QUEUE)
+      .bindNamedParameter(JobSubmissionDirectoryPrefix.class, JOB_SUBMISSION_DIRECTORY_PREFIX)
       .build();
 }

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/JobSubmissionDirectoryPrefix.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/JobSubmissionDirectoryPrefix.java
@@ -24,6 +24,6 @@ import org.apache.reef.tang.annotations.NamedParameter;
 /**
  * The job submission directory.
  */
-@NamedParameter(doc = "The job submission directory prefix.", default_value = "/vol1/tmp")
+@NamedParameter(doc = "The job submission directory prefix.", default_value = "/tmp")
 public final class JobSubmissionDirectoryPrefix implements Name<String> {
 }


### PR DESCRIPTION
This addressed the issue by
  * Change default value of
  `org.apache.reef.runtime.mesos.driver.parameters.JobSubmissionDirectoryPrefix`
  and `org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectoryPrefix`
  from `/vol1/tmp` to `tmp`
  * Add `OptionalParameter` bound to `JobSubmissionDirectoryPrefix` to
  `org.apache.reef.runtime.yarn.client.YarnDriverConfiguration`

JIRA:
  [REEF-1034] https://issues.apache.org/jira/browse/REEF-1034