### PR TITLE
[REEF-1064] Node-local evaluator requests don't respect locality

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
@@ -91,6 +91,10 @@ public final class EvaluatorRequestorImpl implements EvaluatorRequestor {
         relaxLocality = false;
       }
     }
+    // if the user specified any node, then we assume they do not want to relax locality
+    if (!req.getNodeNames().isEmpty()) {
+      relaxLocality = false;
+    }
 
     try (LoggingScope ls = loggingScopeFactory.evaluatorSubmit(req.getNumber())) {
       final ResourceRequestEvent request = ResourceRequestEventImpl


### PR DESCRIPTION
This addressed the issue by
  * Set `relaxLocality` parameter to `AMRMClient.ContainerRequest()` to
  `false` if a node name is specified in `EvaluatorRequest`

JIRA:
  [REEF-1064](https://issues.apache.org/jira/browse/REEF-1064)