### PR TITLE
[REEF-1106/1107/1110/1111] Enable exception-handling checkstyle checks with no violations

### DIFF
--- a/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
@@ -216,6 +216,13 @@
             <property name="format" value="TODO\[JIRA"/>
         </module>
         <module name="UpperEll"/>
+
+        <!-- Exception-handling checks. -->
+        <!-- See https://issues.apache.org/jira/browse/REEF-864 -->
+        <module name="MutableException"/>
+        <module name="ForbidReturnInFinallyBlockCheck"/>
+        <module name="ForbidThrowAnonymousExceptionsCheck"/>
+        <module name="UselessSingleCatchCheck"/>
     </module>
 
 </module>

--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -218,6 +218,13 @@
             <property name="format" value="TODO\[JIRA"/>
         </module>
         <module name="UpperEll"/>
+
+        <!-- Exception-handling checks. -->
+        <!-- See https://issues.apache.org/jira/browse/REEF-864 -->
+        <module name="MutableException"/>
+        <module name="ForbidReturnInFinallyBlockCheck"/>
+        <module name="ForbidThrowAnonymousExceptionsCheck"/>
+        <module name="UselessSingleCatchCheck"/>
     </module>
 
 </module>


### PR DESCRIPTION
This change enables the following checks which have no violations in our code:
 * MutableException
 * ForbidReturnInFinallyBlockCheck
 * ForbidThrowAnonymousExceptionsCheck
 * UselessSingleCatchCheck

JIRA:
  [REEF-1106](https://issues.apache.org/jira/browse/REEF-1106)
  [REEF-1107](https://issues.apache.org/jira/browse/REEF-1107)
  [REEF-1110](https://issues.apache.org/jira/browse/REEF-1110)
  [REEF-1111](https://issues.apache.org/jira/browse/REEF-1111)

Pull request:
  This closes #