### PR TITLE
[REEF-1119] Apply strict checkstyle rules and make shade-jar file for Tang Tint

### DIFF
--- a/lang/java/reef-tang/tang-tint/pom.xml
+++ b/lang/java/reef-tang/tang-tint/pom.xml
@@ -39,5 +39,48 @@ under the License.
     </dependencies>
 
     <artifactId>tang-tint</artifactId>
-    <name>REFF Tang Tint</name>
+    <name>REEF Tang Tint</name>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <configuration>
+                        <configLocation>lang/java/reef-common/src/main/resources/checkstyle-strict.xml</configLocation>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputFile>
+                        ${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar
+                    </outputFile>
+                    <transformers>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Main-Class>
+                                    org.apache.reef.tang.util.Tint
+                                </Main-Class>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/lang/java/reef-tang/tang-tint/src/main/java/org/apache/reef/tang/util/Tint.java
+++ b/lang/java/reef-tang/tang-tint/src/main/java/org/apache/reef/tang/util/Tint.java
@@ -47,6 +47,9 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 
+/**
+ * Tang Static Analytics Tool.
+ */
 public class Tint {
   private static final String SETTERS = "setters";
   private static final String USES = "uses";
@@ -390,7 +393,6 @@ public class Tint {
             try {
               clz = t.ch.classForName(c.getFullName());
             } catch (final ClassNotFoundException e) {
-              // TODO Auto-generated catch block
               e.printStackTrace();
             }
             final String typ = clz.isInterface() ? "interface" : "class";
@@ -708,7 +710,7 @@ public class Tint {
       instance = "";
     }
     sb.append(cell(instance, "simpleName"));
-    sb.append(cell("", "fullName")); // TODO: Documentation string?
+    sb.append(cell("", "fullName")); // TODO[REEF-1118]: Support documentation string
     final StringBuffer uses = new StringBuffer();
     for (final String u : getUsesOf(n)) {
       uses.append("<a href='#" + u + "'>" + stripPrefix(u, pack) + "</a> ");


### PR DESCRIPTION
This PR contains the followings:
  * Make `Tint` as a single shaded jar file.
  * Apply Strict Checkstyle Rule for Tang Tint.
  * Fix a typo in the name of Tint pom.xml.

JIRA:
  [REEF-1119](https://issues.apache.org/jira/browse/REEF-1119)

Pull request:
  This closes #