### PR TITLE
[REEF-1126] Update copyright year and fix obsolete assembly version

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache REEF
-Copyright 2015 The Apache Software Foundation.
+Copyright 2015-2016 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/dev/change_version.py
+++ b/dev/change_version.py
@@ -238,8 +238,8 @@ def change_version(reef_home, new_version, pom_only):
         change_assembly_info_cs(reef_home + "/lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp", new_version)
         print reef_home + "/lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp"
 
-        change_assembly_info_cs(reef_home + "lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp", new_version)
-        print reef_home + "lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp"
+        change_assembly_info_cs(reef_home + "/lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp", new_version)
+        print reef_home + "/lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp"
 
         change_constants_cs(reef_home + "/lang/cs/Org.Apache.REEF.Driver/Constants.cs", new_version)
         print reef_home + "/lang/cs/Org.Apache.REEF.Driver/Constants.cs"

--- a/dev/change_version.py
+++ b/dev/change_version.py
@@ -116,7 +116,8 @@ def change_constants_cs(file, new_version):
     f.close()
 
 """
-Change version in every AssemblyInfo.cs and lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp
+Change version in every AssemblyInfo.cs, lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp,
+and lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp
 """
 def change_assembly_info_cs(file, new_version):
     changed_str = ""
@@ -236,6 +237,9 @@ def change_version(reef_home, new_version, pom_only):
 
         change_assembly_info_cs(reef_home + "/lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp", new_version)
         print reef_home + "/lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp"
+
+        change_assembly_info_cs(reef_home + "lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp", new_version)
+        print reef_home + "lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp"
 
         change_constants_cs(reef_home + "/lang/cs/Org.Apache.REEF.Driver/Constants.cs", new_version)
         print reef_home + "/lang/cs/Org.Apache.REEF.Driver/Constants.cs"

--- a/lang/cs/Org.Apache.REEF.All/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.All/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.All")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp
@@ -35,7 +35,7 @@ using namespace System::Security::Permissions;
 [assembly:AssemblyConfigurationAttribute(L"")];
 [assembly:AssemblyCompanyAttribute(L"")];
 [assembly:AssemblyProductAttribute(L"OrgApacheREEFJavaClrBridge")];
-[assembly:AssemblyCopyrightAttribute(L"Copyright (c)  2015")];
+[assembly:AssemblyCopyrightAttribute(L"Copyright (c) 2016")];
 [assembly:AssemblyTrademarkAttribute(L"")];
 [assembly:AssemblyCultureAttribute(L"")];
 

--- a/lang/cs/Org.Apache.REEF.Client.Tests/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/Properties/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Client.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Client/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Client")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp
+++ b/lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp
@@ -32,7 +32,7 @@ using namespace System::Security::Permissions;
 [assembly:AssemblyConfiguration("")]
 [assembly:AssemblyCompany("")]
 [assembly:AssemblyProduct("Org.Apache.REEF.ClrDriver")]
-[assembly:AssemblyCopyright("Copyright ©  2015")]
+[assembly:AssemblyCopyright("Copyright Â© 2016")]
 [assembly:AssemblyTrademark("")]
 [assembly:AssemblyCulture("")]
 
@@ -48,8 +48,8 @@ using namespace System::Security::Permissions;
 // You can specify all the value or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 
-[assembly:AssemblyVersion("0.13.0.0")]
-[assembly:AssemblyFileVersion("0.13.0.0")]
+[assembly:AssemblyVersion("0.14.0.0")]
+[assembly:AssemblyFileVersion("0.14.0.0")]
 
 [assembly:ComVisible(false)];
 

--- a/lang/cs/Org.Apache.REEF.Common.Tests/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Common.Tests/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Common.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Common/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Common")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Driver/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Driver")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Evaluator.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Evaluator/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Evaluator")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Examples.AllHandlers")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Examples.DriverRestart/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.DriverRestart/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Examples.DriverRestart")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Examples.HelloREEF")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Examples/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Examples")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.IMRU.Examples")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.IO.TestClient/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.IO.TestClient/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.IO.TestClient")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Tests.Yarn")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Network.Examples/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/Properties/AssemblyInfo.cs
@@ -27,7 +27,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Network.Examples")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Network.Tests/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Network.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Network/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Network")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Tang.Examples")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Tang.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Tang.Tools/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tools/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Tang.Tools")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Tang/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Tang")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Tests/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Utilities/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Utilities")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Wake.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/lang/cs/Org.Apache.REEF.Wake/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Org.Apache.REEF.Wake")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
This updates the year of copyright statements and
fix the obsolete version number in AssemblyInfo.cpp.

JIRA:
  [REEF-1126](https://issues.apache.org/jira/browse/REEF-1126)

Pull request:
  This closes #