### PR TITLE
[REEF-1127]  Update snapshot number for Nuget

### DIFF
--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -58,7 +58,7 @@ under the License.
   <!-- REEF NuGet properties -->
   <PropertyGroup>
     <IsSnapshot>true</IsSnapshot>
-    <SnapshotNumber>02</SnapshotNumber>
+    <SnapshotNumber>04</SnapshotNumber>
     <PushPackages>false</PushPackages>
     <NuGetRepository>https://www.nuget.org</NuGetRepository>
   </PropertyGroup>


### PR DESCRIPTION
The latest Nuget 0.14.0-snapshot-03 has been pushed and we need to updated the number to 04

JIRA: [REEF-1127](https://issues.apache.org/jira/browse/REEF-1127)

This closes #