### PR TITLE
[REEF-1109] Enable EmptyCatchBlock checkstyle check

### DIFF
--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
@@ -250,7 +250,7 @@ public class DefaultVortexMasterTest {
     try {
       future.cancel(true, 100, TimeUnit.MILLISECONDS);
       fail();
-    } catch (final TimeoutException e) {
+    } catch (final TimeoutException expected) {
       // TimeoutException is expected.
     }
 

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
@@ -181,7 +181,9 @@ public final class YarnJobSubmissionClient {
           reader.close();
           break;
         }
-      } catch (Exception ex) {
+      } catch (Exception ignored) {
+        // readLine might throw IOException although httpEndpointPath file exists.
+        // the for-loop waits until the actual content of file is written completely
       }
       try{
         Thread.sleep(1000);

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/JavaBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/JavaBridge.java
@@ -21,6 +21,8 @@ package org.apache.reef.javabridge;
 import org.apache.reef.annotations.audience.Interop;
 import org.apache.reef.annotations.audience.Private;
 
+import java.util.logging.Logger;
+
 /**
  * TODO[JIRA REEF-383] Document/Refactor JavaBridge.
  */
@@ -28,12 +30,14 @@ import org.apache.reef.annotations.audience.Private;
 @Interop(CppFiles = "JavaClrBridge.cs")
 public class JavaBridge {
   private static final String CPP_BRIDGE = "JavaClrBridge";
+  private static final Logger LOG = Logger.getLogger(JavaBridge.class.toString());
 
   static {
     try {
       System.loadLibrary(CPP_BRIDGE);
     } catch (final UnsatisfiedLinkError e) {
       // TODO[JIRA REEF-383] Document/Refactor JavaBridge
+      LOG.severe("Cannot load native JavaClrBridge.");
     }
   }
 }

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckpointService.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckpointService.java
@@ -129,7 +129,7 @@ public class FSCheckpointService implements CheckpointService {
       if (!fs.delete(tmp, false)) {
         throw new IOException("Failed to delete checkpoint during abort");
       }
-    } catch (final FileNotFoundException e) {
+    } catch (final FileNotFoundException ignored) {
       // IGNORE
     }
   }
@@ -144,7 +144,7 @@ public class FSCheckpointService implements CheckpointService {
     final Path tmp = ((FSCheckpointID) id).getPath();
     try {
       return fs.delete(tmp, false);
-    } catch (final FileNotFoundException e) {
+    } catch (final FileNotFoundException ignored) {
       // IGNORE
     }
     return true;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFUncaughtExceptionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFUncaughtExceptionHandler.java
@@ -67,7 +67,7 @@ public final class REEFUncaughtExceptionHandler implements Thread.UncaughtExcept
       this.errorHandler.onNext(new Exception(msg, throwable));
       try {
         this.wait(100);
-      } catch (final InterruptedException e) {
+      } catch (final InterruptedException expected) {
         // try-catch block used to wait and give process a chance to setup communication with its parent
       }
       this.errorHandler.close();

--- a/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
@@ -223,6 +223,10 @@
         <module name="ForbidReturnInFinallyBlockCheck"/>
         <module name="ForbidThrowAnonymousExceptionsCheck"/>
         <module name="UselessSingleCatchCheck"/>
+        <module name="EmptyCatchBlock">
+            <property name="commentFormat" value="This is expected"/>
+            <property name="exceptionVariableName" value="expected|ignored"/>
+        </module>
     </module>
 
 </module>

--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -225,6 +225,11 @@
         <module name="ForbidReturnInFinallyBlockCheck"/>
         <module name="ForbidThrowAnonymousExceptionsCheck"/>
         <module name="UselessSingleCatchCheck"/>
+        <module name="EmptyCatchBlock">
+            <property name="commentFormat" value="This is expected"/>
+            <property name="exceptionVariableName" value="expected|ignored"/>
+        </module>
+
     </module>
 
 </module>

--- a/lang/java/reef-tang/tang-tint/src/main/java/org/apache/reef/tang/util/Tint.java
+++ b/lang/java/reef-tang/tang-tint/src/main/java/org/apache/reef/tang/util/Tint.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.logging.Logger;
 
 /**
  * Tang Static Analytics Tool.
@@ -61,6 +62,8 @@ public class Tint {
   private final MonotonicMultiMap<String, String> usages = new MonotonicMultiMap<>();
   private final Set<ClassNode<?>> knownClasses = new MonotonicSet<>();
   private final Set<String> divs = new MonotonicSet<>();
+
+  private static final Logger LOG = Logger.getLogger(Tint.class.getName());
 
   {
     divs.add("doc");
@@ -492,7 +495,8 @@ public class Tint {
                     }
                   }
                 } catch (final NameResolutionException ex) {
-                  //
+                  LOG.warning("The class " + e.getValue() + " not found in the class hierarchy."
+                          + " The exception message: " + ex.getMessage());
                 }
                 try {
                   final String s = e.getValue();
@@ -509,7 +513,8 @@ public class Tint {
                     }
                   }
                 } catch (final NameResolutionException ex) {
-                  //
+                  LOG.warning("The class " + e.getValue() + " not found in the class hierarchy."
+                               + " The exception message: " + ex.getMessage());
                 }
               }
             }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/ClassHierarchyImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/ClassHierarchyImpl.java
@@ -298,7 +298,7 @@ public class ClassHierarchyImpl implements JavaClassHierarchy {
     try {
       final Node n = getAlreadyBoundNode(c);
       return n;
-    } catch (final NameResolutionException e) {
+    } catch (final NameResolutionException ignored) {
       // node not bound yet
     }
     // First, walk up the class hierarchy, registering all out parents. This
@@ -380,7 +380,7 @@ public class ClassHierarchyImpl implements JavaClassHierarchy {
     }
     try {
       return getAlreadyBoundNode(c);
-    } catch (final NameResolutionException e) {
+    } catch (final NameResolutionException ignored) {
       // node not bound yet
     }
 

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/TestClassHierarchy.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/TestClassHierarchy.java
@@ -71,20 +71,19 @@ public class TestClassHierarchy {
     Node n = null;
     try {
       n = ns.getNode("java");
-    } catch (final NameResolutionException e) {
+    } catch (final NameResolutionException expected) {
     }
     Assert.assertNull(n);
     try {
       n = ns.getNode("java.lang");
-    } catch (final NameResolutionException e) {
+    } catch (final NameResolutionException expected) {
     }
     Assert.assertNull(n);
     Assert.assertNotNull(ns.getNode("java.lang.String"));
     try {
       ns.getNode("com.microsoft");
       Assert.fail("Didn't get expected exception");
-    } catch (final NameResolutionException e) {
-
+    } catch (final NameResolutionException expected) {
     }
   }
 

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/cancellation/TaskletCancellationTestStart.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/cancellation/TaskletCancellationTestStart.java
@@ -48,7 +48,7 @@ public final class TaskletCancellationTestStart implements VortexStart {
       // Hacky way to increase probability that the task has been launched.
       // TODO[JIRA REEF-1051]: Query the VortexMaster for the Tasklet status.
       future.get(10, TimeUnit.SECONDS);
-    } catch (final TimeoutException e) {
+    } catch (final TimeoutException ignored) {
       // Harmless.
     } catch (final Exception e) {
       e.printStackTrace();
@@ -60,8 +60,8 @@ public final class TaskletCancellationTestStart implements VortexStart {
     try {
       future.get();
       Assert.fail();
-    } catch (final CancellationException e) {
-      // Expected.
+    } catch (final CancellationException expected) {
+      // This is expected.
     } catch (final ExecutionException|InterruptedException e) {
       e.printStackTrace();
       Assert.fail();

--- a/lang/java/reef-utils-hadoop/src/main/java/org/apache/reef/util/logging/DFSHandler.java
+++ b/lang/java/reef-utils-hadoop/src/main/java/org/apache/reef/util/logging/DFSHandler.java
@@ -129,7 +129,7 @@ public final class DFSHandler extends Handler {
     this.streamHandler.flush();
     try {
       this.logOutputStream.flush();
-    } catch (final IOException e) {
+    } catch (final IOException ignored) {
       // Eating it as it has nowhere to go.
     }
   }
@@ -139,7 +139,7 @@ public final class DFSHandler extends Handler {
     this.streamHandler.close();
     try {
       this.logOutputStream.close();
-    } catch (final IOException e) {
+    } catch (final IOException ignored) {
       // Eating it as it has nowhere to go.
     }
   }

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/WrappedValue.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/WrappedValue.java
@@ -83,7 +83,7 @@ final class WrappedValue<V> {
     while (!value.isPresent()) {
       try {
         this.wait();
-      } catch (final InterruptedException e) {
+      } catch (final InterruptedException ignored) {
         // Ignore, as while loop will be re-entered
       }
     }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
@@ -254,7 +254,7 @@ public final class RuntimeClock implements Clock {
               break; // we're done.
             }
           }
-        } catch (final InterruptedException e) {
+        } catch (final InterruptedException expected) {
           // waiting interrupted - return to loop
         }
       }


### PR DESCRIPTION
This patch:
 * Adds the EmptyCatchBlock check to checkstyle.xml and checkstyle-strict.xml
 * Fixes the violations of the check in the REEF Java codebase

JIRA: 
 [REEF-1109] (https://issues.apache.org/jira/browse/REEF-1109)