### PR TITLE
[REEF-212] Remove file names from Constants.cs

### DIFF
--- a/dev/change_version.py
+++ b/dev/change_version.py
@@ -92,6 +92,7 @@ def change_pom(file, new_version):
 
 """
 Change JavaBridgeJarFileName in lang/cs/Org.Apache.REEF.Driver/Constants.cs
+or in lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs
 """
 def change_constants_cs(file, new_version):
     changed_str = ""
@@ -102,7 +103,7 @@ def change_constants_cs(file, new_version):
         if not line:
             break
 
-        if "JavaBridgeJarFileName" in line:
+        if "JavaBridgeJarFileName =" in line:
             r = re.compile('"(.*?)"')
             m = r.search(line)
             old_version = m.group(1)
@@ -242,6 +243,9 @@ def change_version(reef_home, new_version, pom_only):
 
         change_constants_cs(reef_home + "/lang/cs/Org.Apache.REEF.Driver/Constants.cs", new_version)
         print reef_home + "/lang/cs/Org.Apache.REEF.Driver/Constants.cs"
+
+        change_constants_cs(reef_home + "/lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs", new_version)
+        print reef_home + "/lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs"
 
         change_shaded_jar_name(reef_home + "/lang/cs/Org.Apache.REEF.Client/Properties/Resources.xml", new_version)
         print reef_home + "/lang/cs/Org.Apache.REEF.Client/Properties/Resources.xml"

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrHandlerHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrHandlerHelper.cs
@@ -40,7 +40,7 @@ namespace Org.Apache.REEF.Driver.Bridge
         /// <summary>
         /// The set of REEF assemblies required for the Driver.
         /// </summary>
-        [Obsolete("Deprecated in 0.14. Will be removed in 0.15.")]
+        [Obsolete("Deprecated in 0.14. Will be made internal in 0.15.")]
         public static string[] ReefAssemblies
         {
             get

--- a/lang/cs/Org.Apache.REEF.Driver/Constants.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Constants.cs
@@ -27,22 +27,25 @@ namespace Org.Apache.REEF.Driver
         /// <summary>
         /// Null handler that is not used on Java side.
         /// </summary>
+        [Obsolete("Deprecated in 0.14. Will be removed in 0.15.")]
         public const ulong NullHandler = 0;
 
         /// <summary>
         /// The class hierarchy file from .NET.
         /// </summary>
-        [Obsolete("Deprecated in 0.14, please use ClassHierarchyBin instead.")]
+        [Obsolete("Deprecated in 0.14. Will be removed in 0.15.")]
         public const string ClassHierarachyBin = "clrClassHierarchy.bin";
 
         /// <summary>
         /// The class hierarchy file from .NET.
         /// </summary>
+        [Obsolete("Deprecated in 0.14. Will be removed in 0.15.")]
         public const string ClassHierarchyBin = "clrClassHierarchy.bin";
 
         /// <summary>
         /// The file containing user supplied libraries.
         /// </summary>
+        [Obsolete("Deprecated in 0.14. Will be removed in 0.15.")]
         public const string GlobalUserSuppliedJavaLibraries = "userSuppliedGlobalLibraries.txt";
 
         /// <summary>
@@ -58,18 +61,10 @@ namespace Org.Apache.REEF.Driver
         /// <summary>
         /// The bridge JAR name.
         /// </summary>
+        [Obsolete("Deprecated in 0.14. Will be removed in 0.15.")]
         public const string JavaBridgeJarFileName = "reef-bridge-java-0.14.0-SNAPSHOT-shaded.jar";
 
         public const string BridgeLaunchClass = "org.apache.reef.javabridge.generic.Launch";
-
-        [Obsolete(message: "Deprecated in 0.13. Use BridgeLaunchClass instead.")]
-        public const string BridgeLaunchHeadlessClass = "org.apache.reef.javabridge.generic.LaunchHeadless";
-
-        /// <summary>
-        /// The direct launcher class, deprecated in 0.13, please use DirectREEFLauncherClass instead.
-        /// </summary>
-        [Obsolete("Deprecated in 0.13, please use DirectREEFLauncherClass instead.")]
-        public const string DirectLauncherClass = "org.apache.reef.runtime.common.Launcher";
 
         /// <summary>
         /// The direct launcher class.

--- a/lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs
@@ -41,6 +41,11 @@ namespace Org.Apache.REEF.Driver
         public const string NameServerConfigFile = "nameServer.config";
         public const string UserSuppliedGlobalLibraries = "userSuppliedGlobalLibraries.txt";
 
+        /// <summary>
+        /// The bridge JAR name.
+        /// </summary>
+        public const string JavaBridgeJarFileName = "reef-bridge-java-0.14.0-SNAPSHOT-shaded.jar";
+
         private static readonly Logger Log = Logger.GetLogger(typeof(DriverConfigGenerator));
 
         public static void DriverConfigurationBuilder(DriverConfigurationSettings driverConfigurationSettings)
@@ -142,7 +147,7 @@ namespace Org.Apache.REEF.Driver
 
         private static void ExtractConfigFromJar(string jarfileFolder)
         {
-            string jarfile = jarfileFolder + Constants.JavaBridgeJarFileName;
+            string jarfile = jarfileFolder + JavaBridgeJarFileName;
             List<string> files = new List<string>();
             files.Add(DriverConfigGenerator.HttpServerConfigFile);
             files.Add(DriverConfigGenerator.JobDriverConfigFile);


### PR DESCRIPTION
This change:
 * marks several constants (unused or used in obsolete methods only) as obsolete
 * moves JavaBridgeJarFileName to DriverConfigGenerator.cs
 * updates change_version.py to include DriverConfigGenerator.cs as well

JIRA:
  [REEF-212](https://issues.apache.org/jira/browse/REEF-212)

Pull request:
  This closes #