### PR TITLE
[REEF-1132] Define VortexAggregateFuture and VortexAggregateFunction

### DIFF
--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/AggregateResult.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/AggregateResult.java
@@ -66,7 +66,9 @@ public final class AggregateResult<TInput, TOutput> {
   }
 
   /**
-   * @return the output of an aggregation, throws the Exception a Tasklet or an aggregation fails.
+   * @return the output of an aggregation, throws the Exception if a Tasklet or an aggregation fails.
+   * If an aggregation fails, {@link VortexAggregateException} will be thrown, otherwise
+   * the Exception that caused the Tasklet to fail will be thrown directly.
    * @throws Exception the Exception that caused the Tasklet or aggregation failure.
    */
   public TOutput getAggregateResult() throws Exception {
@@ -85,6 +87,8 @@ public final class AggregateResult<TInput, TOutput> {
   }
 
   /**
+   * If an aggregation fails, {@link VortexAggregateException} will be thrown, otherwise
+   * the Exception that caused the Tasklet to fail will be thrown directly.
    * @return the Exception that caused the Tasklet or aggregation failure, if any.
    */
   public Optional<Exception> getException() {

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/AggregateResult.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/AggregateResult.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.api;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.ClientSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.annotations.audience.Public;
+import org.apache.reef.util.Optional;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The result of an aggregate.
+ */
+@Public
+@ClientSide
+@Unstable
+public final class AggregateResult<TInput, TOutput> {
+
+  private final Optional<TOutput> aggregatedOutput;
+  private final List<Pair<TInput, VortexFunction<TInput, TOutput>>> aggregatedList;
+  private final boolean hasNext;
+  private final Optional<Exception> exception;
+
+  @Private
+  public AggregateResult(final Exception exception,
+                         final List<Pair<TInput, VortexFunction<TInput, TOutput>>> aggregatedList,
+                         final boolean hasNext) {
+    this(Optional.<TOutput>empty(), Optional.of(exception), aggregatedList, hasNext);
+  }
+
+  @Private
+  public AggregateResult(final TOutput aggregatedOutput,
+                         final List<Pair<TInput, VortexFunction<TInput, TOutput>>> aggregatedList,
+                         final boolean hasNext) {
+    this(Optional.of(aggregatedOutput), Optional.<Exception>empty(), aggregatedList, hasNext);
+  }
+
+  private AggregateResult(final Optional<TOutput> aggregatedOutput,
+                          final Optional<Exception> exception,
+                          final List<Pair<TInput, VortexFunction<TInput, TOutput>>> aggregatedList,
+                          final boolean hasNext) {
+    this.aggregatedOutput = aggregatedOutput;
+    this.aggregatedList = Collections.unmodifiableList(aggregatedList);
+    this.hasNext = hasNext;
+    this.exception = exception;
+  }
+
+  /**
+   * @return the output of an aggregation, throws the Exception a Tasklet or an aggregation fails.
+   * @throws Exception the Exception that caused the Tasklet or aggregation failure.
+   */
+  public TOutput getAggregateResult() throws Exception {
+    if (exception.isPresent()) {
+      throw exception.get();
+    }
+
+    return aggregatedOutput.get();
+  }
+
+  /**
+   * @return the associated input and VortexFunction of an aggregation.
+   */
+  public List<Pair<TInput, VortexFunction<TInput, TOutput>>> getAggregatedInputAndFunction() {
+    return aggregatedList;
+  }
+
+  /**
+   * @return the Exception that caused the Tasklet or aggregation failure, if any.
+   */
+  public Optional<Exception> getException() {
+    return exception;
+  }
+
+  /**
+   * @return true if more results will be available, false otherwise.
+   */
+  public boolean hasNext() {
+    return hasNext;
+  }
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/AggregateResult.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/AggregateResult.java
@@ -20,7 +20,6 @@ package org.apache.reef.vortex.api;
 
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.ClientSide;
-import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.util.Optional;
 
@@ -40,15 +39,13 @@ public final class AggregateResult<TInput, TOutput> {
   private final boolean hasNext;
   private final Optional<Exception> exception;
 
-  @Private
-  public AggregateResult(final Exception exception,
+  AggregateResult(final Exception exception,
                          final List<TInput> inputList,
                          final boolean hasNext) {
     this(Optional.<TOutput>empty(), Optional.of(exception), inputList, hasNext);
   }
 
-  @Private
-  public AggregateResult(final TOutput aggregatedOutput,
+  AggregateResult(final TOutput aggregatedOutput,
                          final List<TInput> inputList,
                          final boolean hasNext) {
     this(Optional.of(aggregatedOutput), Optional.<Exception>empty(), inputList, hasNext);

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/AggregateResult.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/AggregateResult.java
@@ -18,7 +18,6 @@
  */
 package org.apache.reef.vortex.api;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Private;
@@ -37,30 +36,30 @@ import java.util.List;
 public final class AggregateResult<TInput, TOutput> {
 
   private final Optional<TOutput> aggregatedOutput;
-  private final List<Pair<TInput, VortexFunction<TInput, TOutput>>> aggregatedList;
+  private final List<TInput> inputList;
   private final boolean hasNext;
   private final Optional<Exception> exception;
 
   @Private
   public AggregateResult(final Exception exception,
-                         final List<Pair<TInput, VortexFunction<TInput, TOutput>>> aggregatedList,
+                         final List<TInput> inputList,
                          final boolean hasNext) {
-    this(Optional.<TOutput>empty(), Optional.of(exception), aggregatedList, hasNext);
+    this(Optional.<TOutput>empty(), Optional.of(exception), inputList, hasNext);
   }
 
   @Private
   public AggregateResult(final TOutput aggregatedOutput,
-                         final List<Pair<TInput, VortexFunction<TInput, TOutput>>> aggregatedList,
+                         final List<TInput> inputList,
                          final boolean hasNext) {
-    this(Optional.of(aggregatedOutput), Optional.<Exception>empty(), aggregatedList, hasNext);
+    this(Optional.of(aggregatedOutput), Optional.<Exception>empty(), inputList, hasNext);
   }
 
   private AggregateResult(final Optional<TOutput> aggregatedOutput,
                           final Optional<Exception> exception,
-                          final List<Pair<TInput, VortexFunction<TInput, TOutput>>> aggregatedList,
+                          final List<TInput> inputList,
                           final boolean hasNext) {
     this.aggregatedOutput = aggregatedOutput;
-    this.aggregatedList = Collections.unmodifiableList(aggregatedList);
+    this.inputList = Collections.unmodifiableList(inputList);
     this.hasNext = hasNext;
     this.exception = exception;
   }
@@ -71,19 +70,19 @@ public final class AggregateResult<TInput, TOutput> {
    * the Exception that caused the Tasklet to fail will be thrown directly.
    * @throws Exception the Exception that caused the Tasklet or aggregation failure.
    */
-  public TOutput getAggregateResult() throws Exception {
+  public TOutput getAggregateResult() throws VortexAggregateException {
     if (exception.isPresent()) {
-      throw exception.get();
+      throw new VortexAggregateException(exception.get(), inputList);
     }
 
     return aggregatedOutput.get();
   }
 
   /**
-   * @return the associated input and VortexFunction of an aggregation.
+   * @return the associated inputs of an aggregation
    */
-  public List<Pair<TInput, VortexFunction<TInput, TOutput>>> getAggregatedInputAndFunction() {
-    return aggregatedList;
+  public List<TInput> getAggregatedInputs() {
+    return inputList;
   }
 
   /**

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateException.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.api;
+
+import org.apache.reef.annotations.Unstable;
+
+/**
+ * Exception thrown when an aggregate function fails.
+ * Call {@link Exception#getCause()} to find the cause of failure in aggregation.
+ */
+@Unstable
+public final class VortexAggregateException extends Exception {
+  public VortexAggregateException(final Throwable cause) {
+    super(cause);
+  }
+
+  public VortexAggregateException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateException.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateException.java
@@ -19,18 +19,40 @@
 package org.apache.reef.vortex.api;
 
 import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Exception thrown when an aggregate function fails.
  * Call {@link Exception#getCause()} to find the cause of failure in aggregation.
+ * Call {@link VortexAggregateException#getInputs()} to get the inputs that correlate
+ * with the failure.
  */
 @Unstable
 public final class VortexAggregateException extends Exception {
-  public VortexAggregateException(final Throwable cause) {
+  private final List<Object> inputList;
+
+  @Private
+  public VortexAggregateException(final Throwable cause, final List<?> inputList) {
     super(cause);
+    this.inputList = new ArrayList<>(inputList);
   }
 
-  public VortexAggregateException(final String message, final Throwable cause) {
+  @Private
+  public VortexAggregateException(final String message,
+                                  final Throwable cause,
+                                  final List<?> inputList) {
     super(message, cause);
+    this.inputList = new ArrayList<>(inputList);
+  }
+
+  /**
+   * @return Inputs that correlate with the aggregation failure.
+   */
+  public List<Object> getInputs() {
+    return Collections.unmodifiableList(inputList);
   }
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFunction.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFunction.java
@@ -36,7 +36,7 @@ import java.util.List;
 @Public
 @ClientSide
 @Unstable
-public interface VortexAggregateFunction<TOutput> extends Serializable{
+public interface VortexAggregateFunction<TOutput> extends Serializable {
 
   /**
    * Runs a custom local aggregation function on Tasklets assigned to a VortexWorker.

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFunction.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFunction.java
@@ -44,7 +44,7 @@ public interface VortexAggregateFunction<TOutput> extends Serializable{
    * @return the aggregated output of Tasklets.
    * @throws Exception
    */
-  TOutput call(final List<TOutput> taskletOutputs) throws Exception;
+  TOutput call(final List<TOutput> taskletOutputs) throws VortexAggregateException;
 
   /**
    * Users must define codec for the AggregationOutput.

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFunction.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFunction.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.api;
+
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.ClientSide;
+import org.apache.reef.annotations.audience.Public;
+import org.apache.reef.wake.remote.Codec;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Typed user function for Local Aggregation. Implement your functions using this interface.
+ * TODO[REEF-504]: Clean up Serializable in Vortex.
+ * TODO[REEF-1003]: Use reflection instead of serialization when launching VortexFunction.
+ *
+ * @param <TOutput> output type of the aggregation function and the functions to-be-aggregated.
+ */
+@Public
+@ClientSide
+@Unstable
+public interface VortexAggregateFunction<TOutput> extends Serializable{
+
+  /**
+   * Runs a custom local aggregation function on Tasklets assigned to a VortexWorker.
+   * @param taskletOutputs the list of outputs from Tasklets on a Worker.
+   * @return the aggregated output of Tasklets.
+   * @throws Exception
+   */
+  TOutput call(final List<TOutput> taskletOutputs) throws Exception;
+
+  /**
+   * Users must define codec for the AggregationOutput.
+   * {@link org.apache.reef.vortex.util.VoidCodec} can be used if the aggregation output is
+   * empty, and {@link org.apache.reef.io.serialization.SerializableCodec} can be used for ({@link Serializable}
+   * aggregation output.
+   * Custom aggregation output Codec can also be supplied.
+   * @return Codec used to serialize/deserialize the output.
+   */
+  Codec<TOutput> getOutputCodec();
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFuture.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFuture.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.api;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.ClientSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.annotations.audience.Public;
+import org.apache.reef.vortex.common.VortexFutureDelegate;
+import org.apache.reef.vortex.driver.VortexMaster;
+import org.apache.reef.wake.remote.Codec;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.logging.Logger;
+
+/**
+ * The interface between user code and aggregation Tasklets.
+ * Thread safety: This class is not meant to be used in a multi-threaded fashion.
+ * TODO[JIRA REEF-1131]: Create and run tests once functional.
+ */
+@Public
+@ClientSide
+@NotThreadSafe
+@Unstable
+public final class VortexAggregateFuture<TInput, TOutput> implements VortexFutureDelegate {
+  private static final Logger LOG = Logger.getLogger(VortexAggregateFuture.class.getName());
+
+  private final Executor executor;
+  private final VortexMaster vortexMaster;
+  private final Codec<TOutput> aggOutputCodec;
+  private final BlockingQueue<AggregateResult> resultQueue;
+  private final Map<Integer, Pair<TInput, VortexFunction<TInput, TOutput>>> taskletIdFunctionMap;
+  private final FutureCallback<AggregateResult<TInput, TOutput>> callbackHandler;
+
+  @Private
+  public VortexAggregateFuture(final Executor executor,
+                               final VortexMaster vortexMaster,
+                               final Map<Integer, Pair<TInput, VortexFunction<TInput, TOutput>>> taskletIdFunctionMap,
+                               final Codec<TOutput> aggOutputCodec,
+                               final FutureCallback<AggregateResult<TInput, TOutput>> callbackHandler) {
+    this.executor = executor;
+    this.taskletIdFunctionMap = new HashMap<>(taskletIdFunctionMap);
+    this.resultQueue = new ArrayBlockingQueue<>(taskletIdFunctionMap.size());
+    this.aggOutputCodec = aggOutputCodec;
+    this.callbackHandler = callbackHandler;
+
+    // TODO[JIRA REEF-1129]: Call back from VortexMaster.
+    this.vortexMaster = vortexMaster;
+  }
+
+  /**
+   * @return the next aggregation result for the future, null if no more results.
+   */
+  public synchronized AggregateResult get() throws InterruptedException {
+    if (taskletIdFunctionMap.isEmpty()) {
+      return null;
+    }
+
+    return resultQueue.take();
+  }
+
+  /**
+   * @param timeout the timeout for the operation.
+   * @param timeUnit the time unit of the timeout.
+   * @return the next aggregation result for the future, within the user specified timeout, null if no more results.
+   * @throws TimeoutException if time out hits.
+   */
+  public synchronized AggregateResult get(final long timeout,
+                                          final TimeUnit timeUnit) throws InterruptedException, TimeoutException {
+    if (taskletIdFunctionMap.isEmpty()) {
+      return null;
+    }
+
+    final AggregateResult result = resultQueue.poll(timeout, timeUnit);
+
+    if (result == null) {
+      throw new TimeoutException();
+    }
+
+    return result;
+  }
+
+  /**
+   * @return true if there are no more results to poll.
+   */
+  public synchronized boolean isDone() {
+    return taskletIdFunctionMap.size() == 0;
+  }
+
+  /**
+   * A Tasklet associated with the aggregation has completed.
+   */
+  @Private
+  @Override
+  public void completed(final int taskletId, final byte[] serializedResult) {
+    try {
+      final TOutput result = aggOutputCodec.decode(serializedResult);
+      removeCompletedTasklets(result, Collections.singletonList(taskletId));
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Aggregation has completed for a list of Tasklets, with an aggregated result.
+   */
+  @Private
+  @Override
+  public void aggregationCompleted(final List<Integer> pTaskletIds, final byte[] serializedResult) {
+    try {
+      // TODO[REEF-1113]: Handle serialization failure separately in Vortex
+      final TOutput result = aggOutputCodec.decode(serializedResult);
+      removeCompletedTasklets(result, pTaskletIds);
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * A Tasklet associated with the aggregation has failed.
+   */
+  @Private
+  @Override
+  public void threwException(final int taskletId, final Exception exception) {
+    try {
+      removeFailedTasklets(exception, Collections.singletonList(taskletId));
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * A list of Tasklets has failed during aggregation phase.
+   */
+  @Private
+  @Override
+  public void aggregationThrewException(final List<Integer> pTaskletIds, final Exception exception) {
+    try {
+      removeFailedTasklets(exception, pTaskletIds);
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Not implemented for local aggregation.
+   */
+  @Private
+  @Override
+  public void cancelled(final int taskletId) {
+    throw new NotImplementedException("Tasklet cancellation not supported in aggregations.");
+  }
+
+  /**
+   * Removes completed Tasklets from Tasklets that are expected and invoke callback.
+   */
+  private synchronized void removeCompletedTasklets(final TOutput output, final List<Integer> taskletIds)
+      throws InterruptedException {
+    final AggregateResult result =
+        new AggregateResult(output, getInputFunctions(taskletIds), taskletIdFunctionMap.size() > 0);
+
+    if (callbackHandler != null) {
+      executor.execute(new Runnable() {
+        @Override
+        public void run() {
+          callbackHandler.onSuccess(result);
+        }
+      });
+    }
+
+    resultQueue.put(result);
+  }
+
+  /**
+   * Removes failed Tasklets from Tasklets that are expected and invokes callback.
+   */
+  private synchronized void removeFailedTasklets(final Exception exception, final List<Integer> taskletIds)
+      throws InterruptedException {
+
+    final AggregateResult result =
+        new AggregateResult(exception, getInputFunctions(taskletIds), taskletIdFunctionMap.size() > 0);
+
+    if (callbackHandler != null) {
+      executor.execute(new Runnable() {
+        @Override
+        public void run() {
+          // Note that success is still called here
+          // User should be checking the Exception status in AggregateResult.
+          // TODO[JIRA REEF-1129]: Add documentation in VortexThreadPool.
+          callbackHandler.onSuccess(result);
+        }
+      });
+    }
+
+    resultQueue.put(result);
+  }
+
+  /**
+   * Gets the inputs and their respective {@link VortexFunction}s on Tasklet aggregation completion.
+   */
+  private synchronized List<Pair<TInput, VortexFunction<TInput, TOutput>>> getInputFunctions(
+      final List<Integer> taskletIds) {
+
+    final List<Pair<TInput, VortexFunction<TInput, TOutput>>> inputList = new ArrayList<>(taskletIds.size());
+
+    for(final int taskletId : taskletIds) {
+      inputList.add(taskletIdFunctionMap.remove(taskletId));
+    }
+
+    return inputList;
+  }
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFuture.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFuture.java
@@ -120,11 +120,11 @@ public final class VortexAggregateFuture<TInput, TOutput> implements VortexFutur
    */
   @Private
   @Override
-  public void aggregationCompleted(final List<Integer> pTaskletIds, final byte[] serializedResult) {
+  public void aggregationCompleted(final List<Integer> taskletIds, final byte[] serializedResult) {
     try {
       // TODO[REEF-1113]: Handle serialization failure separately in Vortex
       final TOutput result = aggOutputCodec.decode(serializedResult);
-      removeCompletedTasklets(result, pTaskletIds);
+      removeCompletedTasklets(result, taskletIds);
     } catch (final InterruptedException e) {
       throw new RuntimeException(e);
     }
@@ -148,9 +148,9 @@ public final class VortexAggregateFuture<TInput, TOutput> implements VortexFutur
    */
   @Private
   @Override
-  public void aggregationThrewException(final List<Integer> pTaskletIds, final Exception exception) {
+  public void aggregationThrewException(final List<Integer> taskletIds, final Exception exception) {
     try {
-      removeFailedTasklets(exception, pTaskletIds);
+      removeFailedTasklets(exception, taskletIds);
     } catch (final InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFuture.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFuture.java
@@ -191,15 +191,16 @@ public final class VortexAggregateFuture<TInput, TOutput> implements VortexFutur
   private synchronized void removeFailedTasklets(final Exception exception, final List<Integer> taskletIds)
       throws InterruptedException {
 
+    final List<TInput> inputs = getInputs(taskletIds);
     final AggregateResult failure =
-        new AggregateResult(exception, getInputs(taskletIds), taskletIdInputMap.size() > 0);
+        new AggregateResult(exception, inputs, taskletIdInputMap.size() > 0);
 
     if (callbackHandler != null) {
       executor.execute(new Runnable() {
         @Override
         public void run() {
           // TODO[JIRA REEF-1129]: Add documentation in VortexThreadPool.
-          callbackHandler.onFailure(new VortexAggregateException(exception, taskletIds));
+          callbackHandler.onFailure(new VortexAggregateException(exception, inputs));
         }
       });
     }


### PR DESCRIPTION
This addressed the issue by
  * Defines and outlines the basic functionalities of VortexAggregateFuture and VortexAggregateFunction.
  * Currently not used in other parts of the codebase. Will be tested as Driver and Worker code is completed, as marked by TODO comments.

JIRA:
  [REEF-1132](https://issues.apache.org/jira/browse/REEF-1132)