### PR TITLE
[REEF-1105] Enable IllegalThrows checkstyle check

### DIFF
--- a/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
@@ -227,6 +227,12 @@
             <property name="commentFormat" value="This is expected"/>
             <property name="exceptionVariableName" value="expected|ignored"/>
         </module>
+
+        <!-- IllegalThrows is suppressed for files with the word "Test" in the filename -->
+        <module name="IllegalThrows">
+            <property name="illegalClassNames" value="Throwable, Error, RuntimeException, NullPointerException"/>
+        </module>
+
     </module>
 
 </module>

--- a/lang/java/reef-common/src/main/resources/checkstyle-suppress.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle-suppress.xml
@@ -21,4 +21,5 @@
 -->
 <suppressions>
     <suppress checks=".*" files=".*\\target\\generated-sources\\.*" />
+    <suppress checks="IllegalThrows" files=".*Test.*" />
 </suppressions>

--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -230,6 +230,11 @@
             <property name="exceptionVariableName" value="expected|ignored"/>
         </module>
 
+        <!-- IllegalThrows is suppressed for files with the word "Test" in the filename -->
+        <module name="IllegalThrows">
+            <property name="illegalClassNames" value="Throwable, Error, RuntimeException, NullPointerException"/>
+        </module>
+
     </module>
 
 </module>

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/Optional.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/Optional.java
@@ -52,11 +52,11 @@ public final class Optional<T> implements Serializable {
 
   /**
    * @return An Optional with the given value.
-   * @throws NullPointerException if the value is null
+   * @throws IllegalArgumentException if the value is null
    */
-  public static <T> Optional<T> of(final T value) throws NullPointerException {
+  public static <T> Optional<T> of(final T value) throws IllegalArgumentException {
     if (null == value) {
-      throw new NullPointerException("Passed a null value. Use ofNullable() instead");
+      throw new IllegalArgumentException("Passed a null value. Use ofNullable() instead");
     }
     return new Optional<>(value);
   }

--- a/lang/java/reef-utils/src/test/java/org/apache/reef/util/OptionalTest.java
+++ b/lang/java/reef-utils/src/test/java/org/apache/reef/util/OptionalTest.java
@@ -40,7 +40,7 @@ public class OptionalTest {
         Optional.of(2).isPresent());
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testOfNull() {
     final Optional<Integer> o = Optional.of(null);
   }


### PR DESCRIPTION
This patch:
 * Adds the IllegalThrows check to checkstyle.xml and checkstyle-strict.xml
 * Suppresses the check for files with the word "Test" in the filename
 * Fixes the violations of the check in the REEF Java codebase

JIRA:
 [REEF-1105] (https://issues.apache.org/jira/browse/REEF-1105)