### PR TITLE
[REEF-113] Integrate .NET API documentation with our website, part 1

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = "Apache REEF"
+PROJECT_NUMBER         = 0.14.0-SNAPSHOT
+PROJECT_BRIEF          = "Retainable Evaluator Execution Framework"
+OUTPUT_DIRECTORY       = target
+JAVADOC_AUTOBRIEF      = YES
+
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_PACKAGE        = NO
+EXTRACT_STATIC         = YES
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_ANON_NSPACES   = NO
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = NO
+HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_INCLUDE_FILES     = YES
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = YES
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = YES
+STRICT_PROTO_MATCHING  = NO
+GENERATE_TODOLIST      = NO
+GENERATE_TESTLIST      = NO
+GENERATE_BUGLIST       = NO
+GENERATE_DEPRECATEDLIST= YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+
+QUIET                  = YES
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+
+INPUT                  = lang/cs
+INPUT_ENCODING         = UTF-8
+FILE_PATTERNS          = *.cs
+RECURSIVE              = YES
+
+EXCLUDE                = lang/cs/Org.Apache.REEF.Client.Tests
+EXCLUDE               += lang/cs/Org.Apache.REEF.Common.Tests
+EXCLUDE               += lang/cs/Org.Apache.REEF.Evaluator.Tests
+EXCLUDE               += lang/cs/Org.Apache.REEF.Examples
+EXCLUDE               += lang/cs/Org.Apache.REEF.Examples.AllHandlers
+EXCLUDE               += lang/cs/Org.Apache.REEF.Examples.DriverRestart
+EXCLUDE               += lang/cs/Org.Apache.REEF.Examples.HelloREEF
+EXCLUDE               += lang/cs/Org.Apache.REEF.IMRU.Examples
+EXCLUDE               += lang/cs/Org.Apache.REEF.IMRU.Tests
+EXCLUDE               += lang/cs/Org.Apache.REEF.IO.Tests
+EXCLUDE               += lang/cs/Org.Apache.REEF.Network.Examples
+EXCLUDE               += lang/cs/Org.Apache.REEF.Network.Examples.Client
+EXCLUDE               += lang/cs/Org.Apache.REEF.Network.Tests
+EXCLUDE               += lang/cs/Org.Apache.REEF.Tang.Examples
+EXCLUDE               += lang/cs/Org.Apache.REEF.Tang.Tests
+EXCLUDE               += lang/cs/Org.Apache.REEF.Tests
+EXCLUDE               += lang/cs/Org.Apache.REEF.Wake.Tests
+
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+
+GENERATE_HTML          = YES
+HTML_OUTPUT            = apidoc_net
+HTML_FILE_EXTENSION    = .html
+
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+
+GENERATE_LATEX         = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+
+CLASS_DIAGRAMS         = NO

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Acls.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Acls.cs
@@ -25,8 +25,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class Acls
     {
@@ -36,8 +36,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 
     /// <summary>
     /// Enum generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal enum AclsType
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/AmContainerSpec.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/AmContainerSpec.cs
@@ -21,8 +21,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class AmContainerSpec
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Application.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Application.cs
@@ -21,8 +21,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class Application
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ApplicationFinalState.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ApplicationFinalState.cs
@@ -19,8 +19,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     /// valid values are members of the YarnApplicationState enum
     public enum FinalState

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ApplicationState.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ApplicationState.cs
@@ -19,8 +19,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     /// valid values are members of the YarnApplicationState enum
     internal enum State

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Applications.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Applications.cs
@@ -21,8 +21,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class Applications
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ClusterHaState.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ClusterHaState.cs
@@ -19,8 +19,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal enum ClusterHaState
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ClusterInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ClusterInfo.cs
@@ -21,8 +21,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class ClusterInfo
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ClusterMetrics.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ClusterMetrics.cs
@@ -21,8 +21,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class ClusterMetrics
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ClusterState.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ClusterState.cs
@@ -19,8 +19,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal enum ClusterState
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Credentials.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Credentials.cs
@@ -21,8 +21,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class Credentials
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Environment.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Environment.cs
@@ -22,8 +22,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class Environment
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Error.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Error.cs
@@ -19,8 +19,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class Error
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/LocalResources.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/LocalResources.cs
@@ -24,8 +24,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class LocalResources
     {
@@ -35,8 +35,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class LocalResourcesValue
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/NewApplication.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/NewApplication.cs
@@ -21,8 +21,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class NewApplication
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Resouce.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Resouce.cs
@@ -21,8 +21,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class Resouce
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Secrets.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Secrets.cs
@@ -22,8 +22,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class Secrets
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ServiceData.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ServiceData.cs
@@ -21,8 +21,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class ServiceData
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/SubmitApplication.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/SubmitApplication.cs
@@ -22,8 +22,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class SubmitApplication
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Tokens.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Tokens.cs
@@ -22,8 +22,8 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
     /// Class generated based on schema provided in
-    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
-    /// Hadoop RM REST API </see> documentation.
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
     internal sealed class Tokens
     {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/FileSystemJobResourceUploader.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/FileSystemJobResourceUploader.cs
@@ -27,7 +27,7 @@ namespace Org.Apache.REEF.Client.YARN.RestClient
 {
     /// <summary>
     /// Provides FileSystem agnostic job resource uploader.
-    /// User can provide custome implementation of 
+    /// User can provide custom implementation of
     /// <see cref="IFileSystem"/> for their choice of DFS.
     /// </summary>
     internal sealed class FileSystemJobResourceUploader : IJobResourceUploader

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrHandlerHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrHandlerHelper.cs
@@ -199,7 +199,7 @@ namespace Org.Apache.REEF.Driver.Bridge
         /// <summary>
         /// Creates a new local directory <see cref="Constants.DriverAppDirectory"/> 
         /// at the current directory and copies all .dll files as specified by 
-        /// the input parameter <see cref="dlls"/> from the current directrory into 
+        /// the input parameter <see cref="dlls"/> from the current directory into
         /// the new directory.
         /// </summary>
         /// <param name="dlls">The set of DLLs to copy from the current directory</param>

--- a/lang/cs/Org.Apache.REEF.Driver/Context/IActiveContext.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Context/IActiveContext.cs
@@ -28,7 +28,7 @@ namespace Org.Apache.REEF.Driver.Context
         /// Sends a context message to the Driver. Currently does not work due to the
         /// original .NET evaluator implementation not propagating ContextConfiguration
         /// properly via Tang. Work on the new Evaluator is being done in 
-        /// <see href="https://issues.apache.org/jira/browse/REEF-289">REEF-289</see>.
+        /// <a href="https://issues.apache.org/jira/browse/REEF-289">REEF-289</a>.
         /// </summary>
         /// <param name="message">Message to send</param>
         /// TODO[JIRA REEF-863]: Test after unblocked by REEF-289

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
@@ -33,7 +33,8 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
     /// Note that operations with this class are enormously slow. If you can, use a more native way to access the file system
     /// in question.
     /// </remarks>
-    /// <see cref="http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/FileSystemShell.html" />
+    /// <a href="http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/FileSystemShell.html">
+    /// FileSystemShell</a>
     internal sealed class HadoopFileSystem : IFileSystem
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(HadoopFileSystem));

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
@@ -60,6 +60,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         /// <param name="groupName">The communication group name</param>
         /// <param name="driverId">Identifier of the Reef driver</param>
         /// <param name="numTasks">The number of tasks each operator will use</param>
+        /// <param name="fanOut"></param>
         /// <param name="confSerializer">Used to serialize task configuration</param>
         public CommunicationGroupDriver(
             string groupName,

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/Codec/NsMessageStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/Codec/NsMessageStreamingCodec.cs
@@ -55,7 +55,7 @@ namespace Org.Apache.REEF.Network.NetworkService.Codec
         /// Instantiate the class from the reader.
         /// </summary>
         /// <param name="reader">The reader from which to read</param>
-        /// <returns>The instance of type NsMessage<T></T> read from the reader</returns>
+        /// <returns>The instance of type NsMessage<T> read from the reader</returns>
         public NsMessage<T> Read(IDataReader reader)
         {
             int metadataSize = reader.ReadInt32();
@@ -80,7 +80,7 @@ namespace Org.Apache.REEF.Network.NetworkService.Codec
         /// <summary>
         /// Writes the class fields to the writer.
         /// </summary>
-        /// <param name="obj">The object of type NsMessage<T></T> to be encoded</param>
+        /// <param name="obj">The object of type NsMessage<T> to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
         public void Write(NsMessage<T> obj, IDataWriter writer)
         {

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkService.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkService.cs
@@ -52,13 +52,11 @@ namespace Org.Apache.REEF.Network.NetworkService
         /// Create a new NetworkService.
         /// </summary>
         /// <param name="nsPort">The port that the NetworkService will listen on</param>
-        /// <param name="nameServerAddr">The address of the NameServer</param>
-        /// <param name="nameServerPort">The port of the NameServer</param>
         /// <param name="messageHandler">The observer to handle incoming messages</param>
         /// <param name="idFactory">The factory used to create IIdentifiers</param>
         /// <param name="codec">The codec used for serialization</param>
+        /// <param name="nameClient"></param>
         /// <param name="remoteManagerFactory">Used to instantiate remote manager instances.</param>
-        /// <param name="tcpPortProvider">Provides ports for tcp listeners.</param>
         [Inject]
         public NetworkService(
             [Parameter(typeof(NetworkServiceOptions.NetworkServicePort))] int nsPort,

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/SmokeTest/RootImplementation.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/SmokeTest/RootImplementation.cs
@@ -34,6 +34,15 @@ namespace Org.Apache.REEF.Tang.Tests.SmokeTest
         //// private readonly ListOfBaseTypes listOfBaseTypes;  // TODO: to recover once Avro NuGet support it
         private readonly CyclicDependency cyclicDependency;
 
+        /// <param name="requiredString">required string</param>
+        /// <param name="optionalString">optional string</param>
+        /// <param name="anInt">an int</param>
+        /// <param name="aDouble">a double</param>
+        /// <param name="anInterface">an interface</param>
+        /// <param name="injectableClass">an injectable class</param>
+        /// <param name="setOfImplementations">set of implementations</param>
+        /// <param name="setOfBaseTypes">set of base types</param>
+        /// <param name="cyclicDependency">cyclic dependency</param>
         [Inject]
         public RootImplementation([Parameter(typeof(TestConfigurationModuleBuilder.RequiredString))] string requiredString,
                                   [Parameter(typeof(TestConfigurationModuleBuilder.OptionalString))] string optionalString,
@@ -43,8 +52,7 @@ namespace Org.Apache.REEF.Tang.Tests.SmokeTest
                                   InjectableClass injectableClass,
                                   SetOfImplementations setOfImplementations,
                                   SetOfBaseTypes setOfBaseTypes,
-                                  //// ListOfBaseTypes listOfBaseTypes, // TODO: to recover once Avro NuGet support it
-                                  CyclicDependency cyclicDependency) 
+                                  CyclicDependency cyclicDependency)
         {
                                 this.requiredString = requiredString;
                                 this.optionalString = optionalString;

--- a/lang/cs/Org.Apache.REEF.Utilities/Diagnostics/Exceptions.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Diagnostics/Exceptions.cs
@@ -189,7 +189,7 @@ namespace Org.Apache.REEF.Utilities.Diagnostics
         }
 
         /// <summary>
-        /// Gets an exception message that includes the messages of the inner exceptions..
+        /// Gets an exception message that includes the messages of the inner exceptions.
         /// </summary>
         /// <param name="e">The exception.</param>
         /// <returns>The message</returns>

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TransportServer.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TransportServer.cs
@@ -51,8 +51,8 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// <param name="localEndpoint">Endpoint to listen on</param>
         /// <param name="remoteHandler">The handler to invoke when receiving incoming
         /// remote messages</param>
-        /// <param name="codec">The codec to encode/decode"</param>
-         /// <param name="tcpPortProvider">provides port numbers to listen</param>
+        /// <param name="codec">The codec to encode/decode</param>
+        /// <param name="tcpPortProvider">provides port numbers to listen</param>
         public TransportServer(IPEndPoint localEndpoint, 
                                IObserver<TransportEvent<T>> remoteHandler, 
                                ICodec<T> codec,


### PR DESCRIPTION
This change:
 * adds Doxygen config to our project
 * fixes warnings produced by documentation generation

To generate documentation using this configuration, install Doxygen and run (from REEF_HOME) command `doxygen doxygen.config`
The results will be at `\target\site\apidoc_net`, browsable starting from `index.html`.

Once the contents and the look of the apidoc is agreed upon, I'll generate apidoc for release 0.13 and commit it to the website. After that, part 2 of the change will actually update website to include the new link (and possibly modify the structure of the website).

JIRA:
  [REEF-113](https://issues.apache.org/jira/browse/REEF-113)
