### PR TITLE
[REEF-1129] Driver side VortexAggregate submission

### DIFF
--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFunction.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFunction.java
@@ -21,7 +21,7 @@ package org.apache.reef.vortex.api;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Public;
-import org.apache.reef.wake.remote.Codec;
+import org.apache.reef.io.serialization.Codec;
 
 import java.io.Serializable;
 import java.util.List;

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFuture.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFuture.java
@@ -23,8 +23,8 @@ import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.annotations.audience.Public;
+import org.apache.reef.io.serialization.Codec;
 import org.apache.reef.vortex.common.VortexFutureDelegate;
-import org.apache.reef.wake.remote.Codec;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.*;

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexThreadPool.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexThreadPool.java
@@ -23,6 +23,7 @@ import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.driver.VortexMaster;
 
 import javax.inject.Inject;
+import java.util.List;
 
 /**
  * Distributed thread pool.
@@ -60,5 +61,36 @@ public final class VortexThreadPool {
       submit(final VortexFunction<TInput, TOutput> function, final TInput input,
              final FutureCallback<TOutput> callback) {
     return vortexMaster.enqueueTasklet(function, input, Optional.of(callback));
+  }
+
+  /**
+   * @param aggregateFunction to run on VortexFunction outputs
+   * @param function to run on Vortex
+   * @param inputs of the function
+   * @param <TInput> input type
+   * @param <TOutput> output type
+   * @return VortexAggregationFuture for tracking execution progress of aggregate-able functions
+   */
+  public <TInput, TOutput> VortexAggregateFuture<TInput, TOutput>
+      submit(final VortexAggregateFunction<TOutput> aggregateFunction,
+             final VortexFunction<TInput, TOutput> function, final List<TInput> inputs) {
+    return vortexMaster.enqueueTasklets(
+        aggregateFunction, function, inputs, Optional.<FutureCallback<AggregateResult<TInput, TOutput>>>empty());
+  }
+
+  /**
+   * @param aggregateFunction to run on VortexFunction outputs
+   * @param function to run on Vortex
+   * @param inputs of the function
+   * @param callback of the aggregation
+   * @param <TInput> input type
+   * @param <TOutput> output type
+   * @return VortexAggregationFuture for tracking execution progress of aggregate-able functions
+   */
+  public <TInput, TOutput> VortexAggregateFuture<TInput, TOutput>
+      submit(final VortexAggregateFunction<TOutput> aggregateFunction,
+             final VortexFunction<TInput, TOutput> function, final List<TInput> inputs,
+             final FutureCallback<AggregateResult<TInput, TOutput>> callback) {
+    return vortexMaster.enqueueTasklets(aggregateFunction, function, inputs, Optional.of(callback));
   }
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/AggregateFunctionRepository.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/AggregateFunctionRepository.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.driver;
+
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.vortex.api.VortexAggregateFunction;
+
+import javax.annotation.concurrent.ThreadSafe;
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A repository for {@link VortexAggregateFunction}, used to pass functions between {@link VortexMaster} and
+ * {@link RunningWorkers}.
+ */
+@ThreadSafe
+@Unstable
+@Private
+public final class AggregateFunctionRepository {
+  private final Map<Integer, VortexAggregateFunction> aggregateFunctionIdMap = new ConcurrentHashMap<>();
+
+  @Inject
+  private AggregateFunctionRepository() {
+  }
+
+  VortexAggregateFunction put(final int aggregateFunctionId, final VortexAggregateFunction function) {
+    return aggregateFunctionIdMap.put(aggregateFunctionId, function);
+  }
+
+  VortexAggregateFunction get(final int aggregateFunctionId) {
+    return aggregateFunctionIdMap.get(aggregateFunctionId);
+  }
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/AggregateFunctionRepository.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/AggregateFunctionRepository.java
@@ -24,8 +24,8 @@ import org.apache.reef.vortex.api.VortexAggregateFunction;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * A repository for {@link VortexAggregateFunction}, used to pass functions between {@link VortexMaster} and
@@ -35,17 +35,17 @@ import java.util.concurrent.ConcurrentHashMap;
 @Unstable
 @Private
 public final class AggregateFunctionRepository {
-  private final Map<Integer, VortexAggregateFunction> aggregateFunctionIdMap = new ConcurrentHashMap<>();
+  private final ConcurrentMap<Integer, VortexAggregateFunction> aggregateFunctionMap = new ConcurrentHashMap<>();
 
   @Inject
   private AggregateFunctionRepository() {
   }
 
   VortexAggregateFunction put(final int aggregateFunctionId, final VortexAggregateFunction function) {
-    return aggregateFunctionIdMap.put(aggregateFunctionId, function);
+    return aggregateFunctionMap.put(aggregateFunctionId, function);
   }
 
   VortexAggregateFunction get(final int aggregateFunctionId) {
-    return aggregateFunctionIdMap.get(aggregateFunctionId);
+    return aggregateFunctionMap.get(aggregateFunctionId);
   }
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
@@ -105,8 +105,8 @@ final class DefaultVortexMaster implements VortexMaster {
 
     final VortexAggregateFuture<TInput, TOutput> vortexAggregateFuture =
         callback.isPresent() ?
-        new VortexAggregateFuture(executor, taskletIdInputMap, aggOutputCodec, callback.get()) :
-        new VortexAggregateFuture(executor, taskletIdInputMap, aggOutputCodec, null);
+        new VortexAggregateFuture<>(executor, taskletIdInputMap, aggOutputCodec, callback.get()) :
+        new VortexAggregateFuture<>(executor, taskletIdInputMap, aggOutputCodec, null);
 
     for (final Map.Entry<Integer, TInput> taskletIdInputEntry : taskletIdInputMap.entrySet()) {
       final Tasklet tasklet = new Tasklet<>(taskletIdInputEntry.getKey(), Optional.of(aggregateFunctionId),

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
@@ -23,9 +23,7 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.io.serialization.Codec;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.util.Optional;
-import org.apache.reef.vortex.api.FutureCallback;
-import org.apache.reef.vortex.api.VortexFunction;
-import org.apache.reef.vortex.api.VortexFuture;
+import org.apache.reef.vortex.api.*;
 import org.apache.reef.vortex.common.*;
 
 import javax.inject.Inject;
@@ -43,6 +41,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 final class DefaultVortexMaster implements VortexMaster {
   private final Map<Integer, VortexFutureDelegate> taskletFutureMap = new HashMap<>();
   private final AtomicInteger taskletIdCounter = new AtomicInteger();
+  private final AtomicInteger aggregateIdCounter = new AtomicInteger();
+  private final AggregateFunctionRepository aggregateFunctionRepository;
   private final RunningWorkers runningWorkers;
   private final PendingTasklets pendingTasklets;
   private final Executor executor;
@@ -53,10 +53,12 @@ final class DefaultVortexMaster implements VortexMaster {
   @Inject
   DefaultVortexMaster(final RunningWorkers runningWorkers,
                       final PendingTasklets pendingTasklets,
+                      final AggregateFunctionRepository aggregateFunctionRepository,
                       @Parameter(VortexMasterConf.CallbackThreadPoolSize.class) final int threadPoolSize) {
     this.executor = Executors.newFixedThreadPool(threadPoolSize);
     this.runningWorkers = runningWorkers;
     this.pendingTasklets = pendingTasklets;
+    this.aggregateFunctionRepository = aggregateFunctionRepository;
   }
 
   /**
@@ -76,11 +78,45 @@ final class DefaultVortexMaster implements VortexMaster {
       vortexFuture = new VortexFuture<>(executor, this, id, outputCodec);
     }
 
-    final Tasklet tasklet = new Tasklet<>(id, function, input, vortexFuture);
+    final Tasklet tasklet = new Tasklet<>(id, Optional.<Integer>empty(), function, input, vortexFuture);
     putDelegate(Collections.singletonList(tasklet), vortexFuture);
     this.pendingTasklets.addLast(tasklet);
 
     return vortexFuture;
+  }
+
+  /**
+   * Add aggregate-able Tasklets to pendingTasklets.
+   */
+  @Override
+  public <TInput, TOutput> VortexAggregateFuture<TInput, TOutput>
+      enqueueTasklets(final VortexAggregateFunction<TOutput> aggregateFunction,
+                      final VortexFunction<TInput, TOutput> vortexFunction, final List<TInput> inputs,
+                      final Optional<FutureCallback<AggregateResult<TInput, TOutput>>> callback) {
+    final int aggregateFunctionId = aggregateIdCounter.getAndIncrement();
+    aggregateFunctionRepository.put(aggregateFunctionId, aggregateFunction);
+    final Codec<TOutput> aggOutputCodec = aggregateFunction.getOutputCodec();
+    final List<Tasklet> tasklets = new ArrayList<>(inputs.size());
+    final Map<Integer, TInput> taskletIdInputMap = new HashMap<>(inputs.size());
+
+    for (int i = 0; i < inputs.size(); i++) {
+      taskletIdInputMap.put(taskletIdCounter.getAndIncrement(), inputs.get(i));
+    }
+
+    final VortexAggregateFuture vortexAggregateFuture =
+        callback.isPresent() ?
+        new VortexAggregateFuture(executor, taskletIdInputMap, aggOutputCodec, callback.get()) :
+        new VortexAggregateFuture(executor, taskletIdInputMap, aggOutputCodec, null);
+
+    for (final Map.Entry<Integer, TInput> taskletIdInputEntry : taskletIdInputMap.entrySet()) {
+      final Tasklet tasklet = new Tasklet<>(taskletIdInputEntry.getKey(), Optional.of(aggregateFunctionId),
+          vortexFunction, taskletIdInputEntry.getValue(), vortexAggregateFuture);
+      tasklets.add(tasklet);
+      pendingTasklets.addLast(tasklet);
+    }
+
+    putDelegate(tasklets, vortexAggregateFuture);
+    return vortexAggregateFuture;
   }
 
   /**

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
@@ -99,11 +99,11 @@ final class DefaultVortexMaster implements VortexMaster {
     final List<Tasklet> tasklets = new ArrayList<>(inputs.size());
     final Map<Integer, TInput> taskletIdInputMap = new HashMap<>(inputs.size());
 
-    for (int i = 0; i < inputs.size(); i++) {
-      taskletIdInputMap.put(taskletIdCounter.getAndIncrement(), inputs.get(i));
+    for (final TInput input : inputs) {
+      taskletIdInputMap.put(taskletIdCounter.getAndIncrement(), input);
     }
 
-    final VortexAggregateFuture vortexAggregateFuture =
+    final VortexAggregateFuture<TInput, TOutput> vortexAggregateFuture =
         callback.isPresent() ?
         new VortexAggregateFuture(executor, taskletIdInputMap, aggOutputCodec, callback.get()) :
         new VortexAggregateFuture(executor, taskletIdInputMap, aggOutputCodec, null);

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RunningWorkers.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RunningWorkers.java
@@ -20,6 +20,7 @@ package org.apache.reef.vortex.driver;
 
 import net.jcip.annotations.ThreadSafe;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.util.Optional;
 
@@ -57,12 +58,18 @@ final class RunningWorkers {
   // Scheduling policy
   private final SchedulingPolicy schedulingPolicy;
 
+  private final AggregateFunctionRepository aggregateFunctionRepository;
+
+  private final Map<String, Set<Integer>> workerAggregateFunctionMap = new HashMap<>();
+
   /**
    * RunningWorkers constructor.
    */
   @Inject
-  RunningWorkers(final SchedulingPolicy schedulingPolicy) {
+  RunningWorkers(final SchedulingPolicy schedulingPolicy,
+                 final AggregateFunctionRepository aggregateFunctionRepository) {
     this.schedulingPolicy = schedulingPolicy;
+    this.aggregateFunctionRepository = aggregateFunctionRepository;
   }
 
   /**
@@ -76,6 +83,7 @@ final class RunningWorkers {
         if (!removedBeforeAddedWorkers.contains(vortexWorkerManager.getId())) {
           this.runningWorkers.put(vortexWorkerManager.getId(), vortexWorkerManager);
           this.schedulingPolicy.workerAdded(vortexWorkerManager);
+          this.workerAggregateFunctionMap.put(vortexWorkerManager.getId(), new HashSet<Integer>());
 
           // Notify (possibly) waiting scheduler
           noWorkerOrResource.signal();
@@ -111,7 +119,11 @@ final class RunningWorkers {
         return Optional.empty();
       }
     } finally {
-      lock.unlock();
+      try {
+        workerAggregateFunctionMap.remove(id);
+      } finally {
+        lock.unlock();
+      }
     }
   }
 
@@ -146,6 +158,13 @@ final class RunningWorkers {
         }
 
         final VortexWorkerManager vortexWorkerManager = runningWorkers.get(workerId.get());
+        if (tasklet.getAggregateFunctionId().isPresent() &&
+            !workerAggregateFunctionMap.containsKey(tasklet.getAggregateFunctionId().get())) {
+          // TODO[JIRA REEF-1130]: fetch aggregate function from repo and send aggregate function to worker.
+          throw new NotImplementedException("Serialize aggregate function to worker if it doesn't have it. " +
+              "Complete in REEF-1130.");
+        }
+
         vortexWorkerManager.launchTasklet(tasklet);
         schedulingPolicy.taskletLaunched(vortexWorkerManager, tasklet);
       }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RunningWorkers.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RunningWorkers.java
@@ -157,9 +157,10 @@ final class RunningWorkers {
           return;
         }
 
+        final Optional<Integer> taskletAggFunctionId =  tasklet.getAggregateFunctionId();
         final VortexWorkerManager vortexWorkerManager = runningWorkers.get(workerId.get());
-        if (tasklet.getAggregateFunctionId().isPresent() &&
-            !workerAggregateFunctionMap.containsKey(tasklet.getAggregateFunctionId().get())) {
+        if (taskletAggFunctionId.isPresent() &&
+            !workerHasAggregateFunction(vortexWorkerManager.getId(), taskletAggFunctionId.get())) {
           // TODO[JIRA REEF-1130]: fetch aggregate function from repo and send aggregate function to worker.
           throw new NotImplementedException("Serialize aggregate function to worker if it doesn't have it. " +
               "Complete in REEF-1130.");
@@ -265,5 +266,18 @@ final class RunningWorkers {
    */
   boolean isWorkerRunning(final String workerId) {
     return runningWorkers.containsKey(workerId);
+  }
+
+  /**
+   * @return true if Vortex has sent the aggregation function to the worker specified by workerId
+   */
+  private boolean workerHasAggregateFunction(final String workerId, final int aggregateFunctionId) {
+    if (!workerAggregateFunctionMap.containsKey(workerId)) {
+      LOG.log(Level.WARNING, "Trying to look up a worker's aggregation function for a worker with an ID that has " +
+          "not yet been added.");
+      return false;
+    }
+
+    return workerAggregateFunctionMap.get(workerId).contains(aggregateFunctionId);
   }
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/Tasklet.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/Tasklet.java
@@ -19,6 +19,7 @@
 package org.apache.reef.vortex.driver;
 
 import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.api.VortexFunction;
 import org.apache.reef.vortex.common.VortexFutureDelegate;
 
@@ -29,13 +30,16 @@ import org.apache.reef.vortex.common.VortexFutureDelegate;
 class Tasklet<TInput, TOutput> {
   private final int taskletId;
   private final VortexFunction<TInput, TOutput> userTask;
+  private final Optional<Integer> aggregateFunctionId;
   private final TInput input;
   private final VortexFutureDelegate delegate;
 
   Tasklet(final int taskletId,
+          final Optional<Integer> aggregateFunctionId,
           final VortexFunction<TInput, TOutput> userTask,
           final TInput input,
           final VortexFutureDelegate delegate) {
+    this.aggregateFunctionId = aggregateFunctionId;
     this.taskletId = taskletId;
     this.userTask = userTask;
     this.input = input;
@@ -47,6 +51,13 @@ class Tasklet<TInput, TOutput> {
    */
   int getId() {
     return taskletId;
+  }
+
+  /**
+   * @return aggregate function id of the tasklet, not present if the tasklet is not aggregate-able
+   */
+  Optional<Integer> getAggregateFunctionId() {
+    return aggregateFunctionId;
   }
 
   /**

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMaster.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMaster.java
@@ -22,10 +22,10 @@ import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.util.Optional;
-import org.apache.reef.vortex.api.FutureCallback;
-import org.apache.reef.vortex.api.VortexFunction;
-import org.apache.reef.vortex.api.VortexFuture;
+import org.apache.reef.vortex.api.*;
 import org.apache.reef.vortex.common.WorkerReport;
+
+import java.util.List;
 
 /**
  * The heart of Vortex.
@@ -41,6 +41,15 @@ public interface VortexMaster {
   <TInput, TOutput> VortexFuture<TOutput>
       enqueueTasklet(final VortexFunction<TInput, TOutput> vortexFunction, final TInput input,
                      final Optional<FutureCallback<TOutput>> callback);
+
+  /**
+   * Submits aggregate-able Tasklets to be run sometime in the future, with an optional callback function on
+   * the aggregation progress.
+   */
+  <TInput, TOutput> VortexAggregateFuture<TInput, TOutput>
+      enqueueTasklets(final VortexAggregateFunction<TOutput> aggregateFunction,
+                      final VortexFunction<TInput, TOutput> vortexFunction, final List<TInput> inputs,
+                      final Optional<FutureCallback<AggregateResult<TInput, TOutput>>> callback);
 
   /**
    * Call this when a Tasklet is to be cancelled.

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
@@ -19,7 +19,6 @@
 package org.apache.reef.vortex.driver;
 
 import org.apache.reef.io.serialization.SerializableCodec;
-import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.api.FutureCallback;
@@ -55,10 +54,10 @@ public class DefaultVortexMasterTest {
     final VortexFunction vortexFunction = testUtil.newIntegerFunction();
     final VortexWorkerManager vortexWorkerManager1 = testUtil.newWorker();
     final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
-        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
+        testUtil.newAggregateFunctionRepository());
     final PendingTasklets pendingTasklets = new PendingTasklets();
     final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets,
-        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class), 5);
+        testUtil.newAggregateFunctionRepository(), 5);
 
     final AtomicBoolean callbackReceived = new AtomicBoolean(false);
     final CountDownLatch latch = new CountDownLatch(1);
@@ -101,10 +100,10 @@ public class DefaultVortexMasterTest {
     final VortexWorkerManager vortexWorkerManager1 = testUtil.newWorker();
     final VortexWorkerManager vortexWorkerManager2 = testUtil.newWorker();
     final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
-        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
+        testUtil.newAggregateFunctionRepository());
     final PendingTasklets pendingTasklets = new PendingTasklets();
     final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets,
-        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class), 5);
+        testUtil.newAggregateFunctionRepository(), 5);
 
     // Allocate worker & tasklet and schedule
     vortexMaster.workerAllocated(vortexWorkerManager1);
@@ -139,10 +138,10 @@ public class DefaultVortexMasterTest {
     // The tasklets that need to be executed
     final ArrayList<VortexFuture> vortexFutures = new ArrayList<>();
     final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
-        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
+        testUtil.newAggregateFunctionRepository());
     final PendingTasklets pendingTasklets = new PendingTasklets();
     final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets,
-        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class), 5);
+        testUtil.newAggregateFunctionRepository(), 5);
 
     // Allocate iniital evaluators (will all be preempted later...)
     final List<VortexWorkerManager> initialWorkers = new ArrayList<>();
@@ -194,10 +193,10 @@ public class DefaultVortexMasterTest {
     final VortexFunction vortexFunction = testUtil.newIntegerFunction();
     final VortexWorkerManager vortexWorkerManager1 = testUtil.newWorker();
     final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
-        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
+        testUtil.newAggregateFunctionRepository());
     final PendingTasklets pendingTasklets = new PendingTasklets();
     final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets,
-        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class), 5);
+        testUtil.newAggregateFunctionRepository(), 5);
 
     final AtomicBoolean callbackReceived = new AtomicBoolean(false);
     final CountDownLatch latch = new CountDownLatch(1);
@@ -238,7 +237,7 @@ public class DefaultVortexMasterTest {
   @Test(timeout = 10000)
   public void testSingleTaskletCancellation() throws Exception {
     final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
-        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
+        testUtil.newAggregateFunctionRepository());
     final PendingTasklets pendingTasklets = new PendingTasklets();
     final VortexFuture future = createTaskletCancellationFuture(runningWorkers, pendingTasklets);
     launchTasklets(runningWorkers, pendingTasklets, 1);
@@ -255,7 +254,7 @@ public class DefaultVortexMasterTest {
   public void testSingleTaskletCancellationBeforeLaunch() throws Exception {
 
     final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
-        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
+        testUtil.newAggregateFunctionRepository());
     final PendingTasklets pendingTasklets = new PendingTasklets();
     final VortexFuture future = createTaskletCancellationFuture(runningWorkers, pendingTasklets);
 
@@ -277,7 +276,7 @@ public class DefaultVortexMasterTest {
     final VortexFunction vortexFunction = testUtil.newInfiniteLoopFunction();
     final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(
         runningWorkers, pendingTasklets,
-        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class), 5);
+        testUtil.newAggregateFunctionRepository(), 5);
     final VortexWorkerManager vortexWorkerManager1 = testUtil.newWorker(vortexMaster);
 
 

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/DefaultVortexMasterTest.java
@@ -19,6 +19,8 @@
 package org.apache.reef.vortex.driver;
 
 import org.apache.reef.io.serialization.SerializableCodec;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.api.FutureCallback;
 import org.apache.reef.vortex.api.VortexFunction;
@@ -52,9 +54,11 @@ public class DefaultVortexMasterTest {
   public void testSingleTaskletNoFailure() throws Exception {
     final VortexFunction vortexFunction = testUtil.newIntegerFunction();
     final VortexWorkerManager vortexWorkerManager1 = testUtil.newWorker();
-    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
+    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
+        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
     final PendingTasklets pendingTasklets = new PendingTasklets();
-    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets, 5);
+    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets,
+        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class), 5);
 
     final AtomicBoolean callbackReceived = new AtomicBoolean(false);
     final CountDownLatch latch = new CountDownLatch(1);
@@ -96,9 +100,11 @@ public class DefaultVortexMasterTest {
     final VortexFunction vortexFunction = testUtil.newFunction();
     final VortexWorkerManager vortexWorkerManager1 = testUtil.newWorker();
     final VortexWorkerManager vortexWorkerManager2 = testUtil.newWorker();
-    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
+    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
+        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
     final PendingTasklets pendingTasklets = new PendingTasklets();
-    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets, 5);
+    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets,
+        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class), 5);
 
     // Allocate worker & tasklet and schedule
     vortexMaster.workerAllocated(vortexWorkerManager1);
@@ -132,9 +138,11 @@ public class DefaultVortexMasterTest {
   public void testMultipleTaskletsFailure() throws Exception {
     // The tasklets that need to be executed
     final ArrayList<VortexFuture> vortexFutures = new ArrayList<>();
-    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
+    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
+        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
     final PendingTasklets pendingTasklets = new PendingTasklets();
-    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets, 5);
+    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets,
+        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class), 5);
 
     // Allocate iniital evaluators (will all be preempted later...)
     final List<VortexWorkerManager> initialWorkers = new ArrayList<>();
@@ -185,9 +193,11 @@ public class DefaultVortexMasterTest {
   public void testTaskletThrowException() throws Exception {
     final VortexFunction vortexFunction = testUtil.newIntegerFunction();
     final VortexWorkerManager vortexWorkerManager1 = testUtil.newWorker();
-    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
+    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
+        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
     final PendingTasklets pendingTasklets = new PendingTasklets();
-    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets, 5);
+    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets,
+        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class), 5);
 
     final AtomicBoolean callbackReceived = new AtomicBoolean(false);
     final CountDownLatch latch = new CountDownLatch(1);
@@ -227,7 +237,8 @@ public class DefaultVortexMasterTest {
    */
   @Test(timeout = 10000)
   public void testSingleTaskletCancellation() throws Exception {
-    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
+    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
+        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
     final PendingTasklets pendingTasklets = new PendingTasklets();
     final VortexFuture future = createTaskletCancellationFuture(runningWorkers, pendingTasklets);
     launchTasklets(runningWorkers, pendingTasklets, 1);
@@ -243,7 +254,8 @@ public class DefaultVortexMasterTest {
   @Test(timeout = 10000)
   public void testSingleTaskletCancellationBeforeLaunch() throws Exception {
 
-    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
+    final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy(),
+        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
     final PendingTasklets pendingTasklets = new PendingTasklets();
     final VortexFuture future = createTaskletCancellationFuture(runningWorkers, pendingTasklets);
 
@@ -260,10 +272,12 @@ public class DefaultVortexMasterTest {
     assertTrue("The VortexFuture should be done", future.isDone());
   }
 
-  private VortexFuture createTaskletCancellationFuture(final RunningWorkers runningWorkers,
-                                                       final PendingTasklets pendingTasklets) {
+  private VortexFuture createTaskletCancellationFuture(
+      final RunningWorkers runningWorkers, final PendingTasklets pendingTasklets) throws InjectionException {
     final VortexFunction vortexFunction = testUtil.newInfiniteLoopFunction();
-    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(runningWorkers, pendingTasklets, 5);
+    final DefaultVortexMaster vortexMaster = new DefaultVortexMaster(
+        runningWorkers, pendingTasklets,
+        Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class), 5);
     final VortexWorkerManager vortexWorkerManager1 = testUtil.newWorker(vortexMaster);
 
 

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/RunningWorkersTest.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/RunningWorkersTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.reef.vortex.driver;
 
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -34,7 +36,12 @@ import static org.junit.Assert.assertTrue;
 public class RunningWorkersTest {
   private final TestUtil testUtil = new TestUtil();
   private final TestUtil.TestSchedulingPolicy schedulingPolicy = testUtil.newSchedulingPolicy();
-  private final RunningWorkers runningWorkers = new RunningWorkers(schedulingPolicy);
+  private final RunningWorkers runningWorkers;
+
+  public RunningWorkersTest() throws InjectionException {
+    runningWorkers = new RunningWorkers(
+        schedulingPolicy, Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class));
+  }
 
   /**
    * Test executor preemption -> executor allocation.

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/TestUtil.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/TestUtil.java
@@ -90,7 +90,7 @@ public final class TestUtil {
    */
   public Tasklet newTasklet() {
     final int id = taskletId.getAndIncrement();
-    return new Tasklet(id, null, null, new VortexFuture(executor, vortexMaster, id, VOID_CODEC));
+    return new Tasklet(id, Optional.empty(), null, null, new VortexFuture(executor, vortexMaster, id, VOID_CODEC));
   }
 
   /**

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/TestUtil.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/TestUtil.java
@@ -21,6 +21,8 @@ package org.apache.reef.vortex.driver;
 import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.io.serialization.Codec;
 import org.apache.reef.io.serialization.SerializableCodec;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.vortex.util.VoidCodec;
 import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.api.VortexFunction;
@@ -91,6 +93,13 @@ public final class TestUtil {
   public Tasklet newTasklet() {
     final int id = taskletId.getAndIncrement();
     return new Tasklet(id, Optional.empty(), null, null, new VortexFuture(executor, vortexMaster, id, VOID_CODEC));
+  }
+
+  /**
+   * @return a new {@link AggregateFunctionRepository}
+   */
+  public AggregateFunctionRepository newAggregateFunctionRepository() throws InjectionException {
+    return Tang.Factory.getTang().newInjector().getInstance(AggregateFunctionRepository.class);
   }
 
   /**


### PR DESCRIPTION
This addressed the issue by
  * Modified ThreadPool, VortexMaster, and RunningWorkers to support submission of aggregate-able VortexFunctions.
  * Added AggregateFunctionRepository to share aggregate functions between VortexMaster and RunningWorkers.
  * Modified tests.
  * Add TODO for REEF-1130 in passing VortexAggregateFunctions to Worker processes.

JIRA:
  [REEF-1129](https://issues.apache.org/jira/browse/REEF-1129)