### PR TITLE
[REEF-1134] Wake Codec creation pattern is not consistent

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkServiceConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkServiceConfiguration.cs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Tang.Formats;
@@ -25,6 +26,7 @@ using Org.Apache.REEF.Wake.Remote;
 
 namespace Org.Apache.REEF.Network.NetworkService
 {
+    [Obsolete("Deprecated in 0.14.")]
     public class NetworkServiceConfiguration : ConfigurationModuleBuilder
     {
         [SuppressMessage("Microsoft.Security", "CA2104:Do not declare read only mutable reference types", Justification = "not applicable")] 

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/ICodec.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/ICodec.cs
@@ -17,8 +17,11 @@
  * under the License.
  */
 
+using System;
+
 namespace Org.Apache.REEF.Wake.Remote
 {
+    [Obsolete("Deprecated in 0.14, please use ICodec<T> instead.")]
     public interface ICodec
     {
     }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/ICodecFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/ICodecFactory.cs
@@ -17,11 +17,13 @@
  * under the License.
  */
 
+using System;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Wake.Remote.Impl;
 
 namespace Org.Apache.REEF.Wake.Remote
 {
+    [Obsolete("Deprecated in 0.14, please inject the ICodec directly or use its constructor instead.")]
     [DefaultImplementation(typeof(ByteCodecFactory))]
     public interface ICodecFactory
     {

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/IDecoder.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/IDecoder.cs
@@ -17,8 +17,11 @@
  * under the License.
  */
 
+using System;
+
 namespace Org.Apache.REEF.Wake.Remote
 {
+    [Obsolete("Deprecated in 0.14, please use ICodec<T> instead.")]
     public interface IDecoder
     {
     }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/IEncoder.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/IEncoder.cs
@@ -17,8 +17,11 @@
  * under the License.
  */
 
+using System;
+
 namespace Org.Apache.REEF.Wake.Remote
 {
+    [Obsolete("Deprecated in 0.14, please use IEncoder<T> instead.")]
     public interface IEncoder
     {
     }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/ByteCodecFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/ByteCodecFactory.cs
@@ -17,10 +17,12 @@
  * under the License.
  */
 
+using System;
 using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.Wake.Remote.Impl
 {
+    [Obsolete("Deprecated in 0.14, please inject or call ByteCodec's constructor instead.")]
     public sealed class ByteCodecFactory : ICodecFactory
     {
         [Inject]

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/MultiCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/MultiCodec.cs
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+using Org.Apache.REEF.Tang.Annotations;
+
 namespace Org.Apache.REEF.Wake.Remote.Impl
 {
     /// <summary>
@@ -31,6 +33,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// <summary>
         /// Constructs a new MultiCodec object.
         /// </summary>
+        [Inject]
         public MultiCodec()
         {
             _encoder = new MultiEncoder<T>();


### PR DESCRIPTION
This addressed the issue by
  * Deprecating superfluous classes and related Configuration.
  * Deprecating ICodecFactory.

JIRA:
  [REEF-1134](https://issues.apache.org/jira/browse/REEF-1134)