### PR TITLE
[REEF-1079] Fix TestNamedParameterWithAliasRoundTrip test failures

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestAnonymousType.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestAnonymousType.cs
@@ -33,12 +33,6 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
     {
         const string ClassHierarchyBinFileName = "example.bin";
 
-        [ClassInitialize]
-        public static void ClassSetup(TestContext context)
-        {
-            TangImpl.Reset();
-        }
-
         [TestMethod]
         public void TestAnonymousTypeWithDictionary()
         {

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
@@ -40,7 +40,6 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         {
             if (ns == null)
             {
-                TangImpl.Reset();
                 ns = TangFactory.GetTang().GetClassHierarchy(new string[] { FileNames.Examples, FileNames.Common, FileNames.Tasks });
             }
         }

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestGeneric.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestGeneric.cs
@@ -27,11 +27,6 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
 {
     public class TestGeneric
     {
-        public TestGeneric()
-        {
-            TangImpl.Reset();
-        }
-
         [Fact]
         public void TestGenericClassWithT()
         {

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Configuration/TestConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Configuration/TestConfiguration.cs
@@ -53,19 +53,22 @@ namespace Org.Apache.REEF.Tang.Tests.Configuration
             var serializer = new AvroConfigurationSerializer();
             serializer.ToFile(conf1, "task.config");
 
+            ProtocolBufferClassHierarchy.Serialize("Task.bin", conf1.GetClassHierarchy());
+            IClassHierarchy ns1 = ProtocolBufferClassHierarchy.DeSerialize("Task.bin");
+
             ICsConfigurationBuilder cb2 = tang.NewConfigurationBuilder();
             cb2.BindNamedParameter<Timer.Seconds, int>(GenericType<Timer.Seconds>.Class, "2");
             IConfiguration conf2 = cb2.Build();
             serializer.ToFile(conf2, "timer.config");
 
-            ProtocolBufferClassHierarchy.Serialize("TaskTimer.bin", conf1.GetClassHierarchy());
-            IClassHierarchy ns = ProtocolBufferClassHierarchy.DeSerialize("TaskTimer.bin");
+            ProtocolBufferClassHierarchy.Serialize("Timer.bin", conf2.GetClassHierarchy());
+            IClassHierarchy ns2 = ProtocolBufferClassHierarchy.DeSerialize("Timer.bin");
 
             AvroConfiguration taskAvroconfiguration = serializer.AvroDeserializeFromFile("task.config");
-            IConfiguration taskConfiguration = serializer.FromAvro(taskAvroconfiguration, ns);
+            IConfiguration taskConfiguration = serializer.FromAvro(taskAvroconfiguration, ns1);
 
             AvroConfiguration timerAvroconfiguration = serializer.AvroDeserializeFromFile("timer.config");
-            IConfiguration timerConfiguration = serializer.FromAvro(timerAvroconfiguration, ns);
+            IConfiguration timerConfiguration = serializer.FromAvro(timerAvroconfiguration, ns2);
 
             IConfiguration merged = Configurations.MergeDeserializedConfs(taskConfiguration, timerConfiguration);
 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Injection/TestMultipleConstructors.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Injection/TestMultipleConstructors.cs
@@ -192,7 +192,6 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
         [Fact]
         public void TestMultiLayersWithMiddleLayerFirst()
         {
-            TangImpl.Reset();
             ICsConfigurationBuilder cb2 = TangFactory.GetTang().NewConfigurationBuilder();
             cb2.BindImplementation(typeof(IH), typeof(M));
             IInjector i2 = TangFactory.GetTang().NewInjector(cb2.Build());
@@ -209,7 +208,6 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
         [Fact]
         public void TestMultiLayersWithLowerLayerFirst()
         {
-            TangImpl.Reset(); 
             ICsConfigurationBuilder cb = TangFactory.GetTang().NewConfigurationBuilder();
             cb.BindImplementation(typeof(IH), typeof(L));
             IInjector i = TangFactory.GetTang().NewInjector(cb.Build());
@@ -226,8 +224,6 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
         [Fact]
         public void TestMultiLayersWithBindImpl()
         {
-            TangImpl.Reset(); 
-
             ICsConfigurationBuilder cb = TangFactory.GetTang().NewConfigurationBuilder();
             cb.BindImplementation(typeof(IH), typeof(L));
             IInjector i = TangFactory.GetTang().NewInjector(cb.Build());
@@ -245,8 +241,6 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
         [Fact]
         public void TestMultiLayersWithNoInjectableDefaultConstructor()
         {
-            TangImpl.Reset(); 
-
             ICsConfigurationBuilder cb = TangFactory.GetTang().NewConfigurationBuilder();
             cb.BindImplementation(typeof(IH), typeof(L1));
             IInjector i = TangFactory.GetTang().NewInjector(cb.Build());

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/Tang/TangImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/Tang/TangImpl.cs
@@ -34,9 +34,6 @@ namespace Org.Apache.REEF.Tang.Implementations.Tang
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(TangImpl));
 
-        private static IDictionary<SetValuedKey, ICsClassHierarchy> defaultClassHierarchy = new Dictionary<SetValuedKey, ICsClassHierarchy>();
-
-        private static object classHierarchyLock = new object();
         public IInjector NewInjector()
         {
             try
@@ -130,19 +127,7 @@ namespace Org.Apache.REEF.Tang.Implementations.Tang
 
         public ICsClassHierarchy GetDefaultClassHierarchy(string[] assemblies, Type[] parameterParsers)
         {
-            SetValuedKey key = new SetValuedKey(assemblies, parameterParsers);
-
-            ICsClassHierarchy ret = null;
-            lock (classHierarchyLock)
-            {
-                defaultClassHierarchy.TryGetValue(key, out ret);
-                if (ret == null)
-                {
-                    ret = new ClassHierarchyImpl(assemblies, parameterParsers);
-                    defaultClassHierarchy.Add(key, ret);
-                }
-            }
-            return ret;
+            return new ClassHierarchyImpl(assemblies, parameterParsers);
         }
 
         public ICsConfigurationBuilder NewConfigurationBuilder()
@@ -198,11 +183,6 @@ namespace Org.Apache.REEF.Tang.Implementations.Tang
         public ICsConfigurationBuilder NewConfigurationBuilder(params Type[] parameterParsers) 
         {
             return NewConfigurationBuilder(new string[0], new IConfiguration[0], parameterParsers);
-        }
-
-        public static void Reset() 
-        {
-            defaultClassHierarchy = new Dictionary<SetValuedKey, ICsClassHierarchy>(); 
         }
     }
 }


### PR DESCRIPTION
This change:
 * removes caching of default class hierarchy from TangImpl and related code.
   This fixes TestNamedParameterWithAliasRoundTrip failures, which were
   caused by multiple tests sharing the same class hierarchy object.
 * fixes TestDeserializedConfigMerge test which relied on caching behavior.

JIRA:
  [REEF-1079](https://issues.apache.org/jira/browse/REEF-1079)

Pull request:
  This closes #