### PR TITLE
[REEF-1113] Update IllegalInstantiation checkstyle check

### DIFF
--- a/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
@@ -238,6 +238,10 @@
             <property name="illegalClassNames" value="Throwable, RuntimeException, Error" />
         </module>
 
+        <module name="IllegalInstantiation">
+            <property name="classes" value="java.lang.Throwable, java.lang.Error"/>
+        </module>
+
     </module>
 
 </module>

--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -240,6 +240,10 @@
             <property name="illegalClassNames" value="Throwable, RuntimeException, Error" />
         </module>
 
+        <module name="IllegalInstantiation">
+            <property name="classes" value="java.lang.Throwable, java.lang.Error"/>
+        </module>
+
     </module>
 
 </module>

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/StackBindLocation.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/StackBindLocation.java
@@ -22,6 +22,7 @@ import org.apache.reef.tang.BindLocation;
 
 import java.util.Arrays;
 
+@SuppressWarnings("checkstyle:illegalinstantiation")
 public class StackBindLocation implements BindLocation {
   private final StackTraceElement[] stack;
 


### PR DESCRIPTION
This patch:
 * Adds the IllegalInstantiation check to checkstyle.xml and checkstyle-strict.xml
 * Fixes the violation of the check in the REEF Java codebase

JIRA:
 [REEF-1113] (https://issues.apache.org/jira/browse/REEF-1113)