### PR TITLE
[REEF-1125] Enable TestClassLoaders (mvn clean test)

### DIFF
--- a/lang/java/reef-tang/tang-test-jarA/pom.xml
+++ b/lang/java/reef-tang/tang-test-jarA/pom.xml
@@ -28,4 +28,21 @@ under the License.
 
     <artifactId>tang-test-jarA</artifactId>
     <name>Tang Test Jar A</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/lang/java/reef-tang/tang-test-jarAB/pom.xml
+++ b/lang/java/reef-tang/tang-test-jarAB/pom.xml
@@ -29,6 +29,23 @@ under the License.
     <artifactId>tang-test-jarAB</artifactId>
     <name>Tang Test Jar AB</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/lang/java/reef-tang/tang-test-jarB-conflictA/pom.xml
+++ b/lang/java/reef-tang/tang-test-jarB-conflictA/pom.xml
@@ -28,4 +28,21 @@ under the License.
 
     <artifactId>tang-test-jarB-conflictA</artifactId>
     <name>Tang Test Jar B conflict A</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/lang/java/reef-tang/tang-test-jarB/pom.xml
+++ b/lang/java/reef-tang/tang-test-jarB/pom.xml
@@ -29,6 +29,23 @@ under the License.
     <artifactId>tang-test-jarB</artifactId>
     <name>Tang Test Jar B</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
This changes pom.xml files to make jar files during `test` phases
in order to support `mvn clean test` seamlessly.

JIRA:
  [REEF-1125](https://issues.apache.org/jira/browse/REEF-1125)

Pull request:
  This closes #