### PR TITLE
[REEF-1149] VortexAddOneCallbackTest uses the incorrect test start class

### DIFF
--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/addone/AddOneTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/addone/AddOneTest.java
@@ -85,7 +85,7 @@ public final class AddOneTest {
         .set(VortexMasterConf.WORKER_MEM, 64)
         .set(VortexMasterConf.WORKER_CORES, 4)
         .set(VortexMasterConf.WORKER_CAPACITY, 2000)
-        .set(VortexMasterConf.VORTEX_START, AddOneTestStart.class)
+        .set(VortexMasterConf.VORTEX_START, AddOneCallbackTestStart.class)
         .build();
 
     final VortexJobConf vortexJobConf = VortexJobConf.newBuilder()


### PR DESCRIPTION
This addressed the issue by
  * VortexAddOneCallbackTest to use AddOneCallbackTestStart instead of AddOneTestStart.

JIRA:
  [REEF-1149](https://issues.apache.org/jira/browse/REEF-1149)