### PR TITLE
[REEF-1151] Remove illformed `String.format` usage in TestClassHierarchyRoundTrip

### DIFF
--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/avro/TestClassHierarchyRoundTrip.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/avro/TestClassHierarchyRoundTrip.java
@@ -45,7 +45,8 @@ public class TestClassHierarchyRoundTrip extends TestClassHierarchy {
       ns = serializer.fromFile(file);
       file.delete();
     } catch (final IOException e) {
-      Assert.fail(String.format("IOException when serialize/deserialize the ClassHierarchy", e));
+      e.printStackTrace();
+      Assert.fail("IOException when serialize/deserialize the ClassHierarchy");
     }
   }
 
@@ -58,7 +59,8 @@ public class TestClassHierarchyRoundTrip extends TestClassHierarchy {
       ns = serializer.fromTextFile(textFile);
       textFile.delete();
     } catch (final IOException e) {
-      Assert.fail(String.format("IOException when serialize/deserialize the ClassHierarchy", e));
+      e.printStackTrace();
+      Assert.fail("IOException when serialize/deserialize the ClassHierarchy");
     }
   }
 
@@ -68,7 +70,8 @@ public class TestClassHierarchyRoundTrip extends TestClassHierarchy {
     try {
       ns = serializer.fromByteArray(serializer.toByteArray(ns));
     } catch (final IOException e) {
-      Assert.fail(String.format("IOException when serialize/deserialize the ClassHierarchy", e));
+      e.printStackTrace();
+      Assert.fail("IOException when serialize/deserialize the ClassHierarchy");
     }
   }
 
@@ -78,7 +81,8 @@ public class TestClassHierarchyRoundTrip extends TestClassHierarchy {
     try {
       ns = serializer.fromString(serializer.toString(ns));
     } catch (final IOException e) {
-      Assert.fail(String.format("IOException when serialize/deserialize the ClassHierarchy", e));
+      e.printStackTrace();
+      Assert.fail("IOException when serialize/deserialize the ClassHierarchy");
     }
   }
 


### PR DESCRIPTION
JIRA:
  [REEF-1151](https://issues.apache.org/jira/browse/REEF-1151)

Pull Request:
  This closes #