### PR TITLE
[REEF-113] Integrate .NET API documentation with our website

### DIFF
--- a/dev/change_version.py
+++ b/dev/change_version.py
@@ -48,7 +48,7 @@ import argparse
 Get list of path for every file in a directory
 """
 def get_filepaths(directory):
-    file_paths = []  
+    file_paths = []
 
     for root, directories, files in os.walk(directory):
         for filename in files:
@@ -216,6 +216,31 @@ def change_shaded_jar_name(file, new_version):
     f.close()
 
 """
+Change the version in Doxyfile
+"""
+def change_project_number_Doxyfile(file, new_version):
+    changed_str = ""
+
+    f = open(file, 'r')
+    while True:
+        line = f.readline()
+        if not line:
+            break
+
+        if "PROJECT_NUMBER         = " in line:
+            r = re.compile('= (.*?)$')
+            m = r.search(line)
+            old_version = m.group(1)
+            changed_str += line.replace(old_version, new_version)
+        else:
+            changed_str += line
+
+    f = open(file, 'w')
+    f.write(changed_str)
+    f.close()
+
+
+"""
 Change version of every pom.xml, every AsssemblyInfo.cs, 
 Constants.cs, AssemblyInfo.cpp, run.cmd and Resources.xml
 """
@@ -253,10 +278,12 @@ def change_version(reef_home, new_version, pom_only):
         change_shaded_jar_name(reef_home + "/lang/cs/Org.Apache.REEF.Client/run.cmd", new_version)
         print reef_home + "/lang/cs/Org.Apache.REEF.Client/run.cmd"
 
+        change_project_number_Doxyfile(reef_home + "/Doxyfile", new_version)
+        print reef_home + "/Doxyfile"
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Script for changing version of every pom.xml, " \
-        + "every AssemblyInfo.cs, Constants.cs, and AssemblyInfo.cpp")    
+        + "every AssemblyInfo.cs, Constants.cs, and AssemblyInfo.cpp")
     parser.add_argument("reef_home", type=str, help="REEF home")
     parser.add_argument("reef_version", type=str, help="REEF version")
     parser.add_argument("-s", "--isSnapshot", type=str, metavar="<true or false>", help="Change 'IsSnapshot' to true or false", required=True)

--- a/website/src/site/markdown/downloads.md
+++ b/website/src/site/markdown/downloads.md
@@ -51,6 +51,12 @@ Choose a release version:
     <li>
         <a id="releaseNotesLink" href="http://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315820&amp;version=12332972">Release notes</a>
     </li>
+    <li>
+        <a id="javaApiLink" href="apidocs/0.13.0-incubating/index.html">Java API</a>
+    </li>
+    <li>
+        <span id="dotnetApiLink">.NET API available since release 0.14.0</span>
+    </li>
 </ul>
 
 ##Development and Maintenance Branches

--- a/website/src/site/resources/js/release.js
+++ b/website/src/site/resources/js/release.js
@@ -44,11 +44,20 @@ var releaseNotes = {
     "0.13.0-incubating": "https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315820&version=12332972"
 };
 
+var javaApi = {
+    "0.10.0-incubating": "apidocs/0.10.0-incubating/index.html",
+    "0.11.0-incubating": "apidocs/0.11.0-incubating/index.html",
+    "0.12.0-incubating": "apidocs/0.12.0-incubating/index.html",
+    "0.13.0-incubating": "apidocs/0.13.0-incubating/index.html"
+};
+
+var dotnetApi = {
+};
+
 function setReleaseLink() {
     var releaseVersion = this.document.getElementById("selectRelease").value;
     if (releaseDirect[releaseVersion] == undefined) {
         this.document.getElementById("listRelease").style.display= "none";
-        
     } else {
         this.document.getElementById("listRelease").style.display = "block";
 
@@ -63,6 +72,14 @@ function setReleaseLink() {
             directReleaseStrSplit[directReleaseStrSplit.length - 1];
         this.document.getElementById("verificationLink").setAttribute("href",
             releaseDirectStr.slice(0, (0 - directReleaseStrSplit[directReleaseStrSplit.length - 1].length)));
+
+        this.document.getElementById("javaApiLink").setAttribute("href", javaApi[releaseVersion]);
+        if (dotnetApi[releaseVersion] == undefined) {
+            // special case: for versions 0.13.0 and earlier .NET API documentation is not available
+            this.document.getElementById("dotnetApiLink").innerHTML = ".NET API available since release 0.14.0";
+        } else {
+            this.document.getElementById("dotnetApiLink").innerHTML = "<a href=" + dotnetApi[releaseVersion] + ">.NET API</a>";
+        }
     }
 
 }

--- a/website/src/site/site.xml
+++ b/website/src/site/site.xml
@@ -83,7 +83,7 @@ under the License.
             <item name="Overview" href="index.html"/>
             <item name="FAQ" href="faq.html"/>
             <item name="License" href="license.html"/>
-            <item name="Downloads" href="downloads.html"/>
+            <item name="Downloads &amp; APIs" href="downloads.html"/>
             <item name="Privacy Policy" href="privacy-policy.html"/>
         </menu>
 
@@ -94,10 +94,6 @@ under the License.
             <item name="Glossary" href="glossary.html"/>
             <item name="Tang" href="tang.html"/>
             <item name="Wake" href="wake.html"/>
-            <item name="0.10.0-incubating API" href="apidocs/0.10.0-incubating/index.html"/>
-            <item name="0.11.0-incubating API" href="apidocs/0.11.0-incubating/index.html"/>
-            <item name="0.12.0-incubating API" href="apidocs/0.12.0-incubating/index.html"/>
-            <item name="0.13.0-incubating API" href="apidocs/0.13.0-incubating/index.html"/>
         </menu>
         <menu name="Contribution">
             <item name="Contributing" href="https://cwiki.apache.org/confluence/display/REEF/Contributing"/>


### PR DESCRIPTION
This change:
 * moves Java API documentation from sidebar to "Downloads" page
   of corresponding release
 * adds logic for displaying .NET API documentation
 * includes Doxygen file in list of files updated with change_version.py

There is no actual .NET documentation on the website yet;
it will be added as part of release 0.14.

This closes REEF-113

JIRA:
  [REEF-113](https://issues.apache.org/jira/browse/REEF-113)

Pull request:
  This closes #