### PR TITLE
[REEF-1153] Fix typos in class/function names

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/CommonUtilities.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/CommonUtilities.cpp
@@ -32,7 +32,7 @@ namespace Org {
                             ManagedLog::LOGGER->LogStart("CommonUtilities::GetEvaluatorDescriptor");
                             JNIEnv *env = RetrieveEnv(jvm);
                             jclass jclassActiveContext = env->GetObjectClass(object);
-                            jmethodID jmidGetEvaluatorDescriptor = env->GetMethodID(jclassActiveContext, "getEvaluatorDescriptorSring", "()Ljava/lang/String;");
+                            jmethodID jmidGetEvaluatorDescriptor = env->GetMethodID(jclassActiveContext, "getEvaluatorDescriptorString", "()Ljava/lang/String;");
 
                             if (jmidGetEvaluatorDescriptor == NULL) {
                                 ManagedLog::LOGGER->Log("jmidGetEvaluatorDescriptor is NULL");

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
@@ -71,7 +71,7 @@ public final class ActiveContextBridge extends NativeBridge implements Identifia
     ((EvaluatorContext)jactiveContext).submitTask(taskConfigurationString);
   }
 
-  public String getEvaluatorDescriptorSring() {
+  public String getEvaluatorDescriptorString() {
     final String descriptorString = Utilities.getEvaluatorDescriptorString(jactiveContext.getEvaluatorDescriptor());
     LOG.log(Level.FINE, "active context - serialized evaluator descriptor: " + descriptorString);
     return descriptorString;

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridge.java
@@ -139,7 +139,7 @@ public final class AllocatedEvaluatorBridge extends NativeBridge implements Iden
    * Gets the serialized evaluator descriptor from the Java allocated evaluator.
    * @return the serialized evaluator descriptor.
    */
-  public String getEvaluatorDescriptorSring() {
+  public String getEvaluatorDescriptorString() {
     final String descriptorString =
         Utilities.getEvaluatorDescriptorString(jallocatedEvaluator.getEvaluatorDescriptor());
     LOG.log(Level.INFO, "allocated evaluator - serialized evaluator descriptor: " + descriptorString);

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ClosedContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ClosedContextBridge.java
@@ -78,7 +78,7 @@ public final class ClosedContextBridge extends NativeBridge implements ClosedCon
   public void close() throws Exception {
   }
 
-  public String getEvaluatorDescriptorSring() {
+  public String getEvaluatorDescriptorString() {
     final String descriptorString = Utilities.getEvaluatorDescriptorString(evaluatorDescriptor);
     LOG.log(Level.INFO, "Closed Context - serialized evaluator descriptor: " + descriptorString);
     return descriptorString;

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedContextBridge.java
@@ -94,7 +94,7 @@ public final class FailedContextBridge extends NativeBridge implements ContextBa
     return parentContext;
   }
 
-  public String getEvaluatorDescriptorSring() {
+  public String getEvaluatorDescriptorString() {
     final String descriptorString = Utilities.getEvaluatorDescriptorString(evaluatorDescriptor);
     LOG.log(Level.INFO, "Failed Context - serialized evaluator descriptor: " + descriptorString);
     return descriptorString;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/BGDControlParameters.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/BGDControlParameters.java
@@ -48,7 +48,7 @@ public final class BGDControlParameters {
       @Parameter(Lambda.class) final double lambda,
       @Parameter(Eps.class) final double eps,
       @Parameter(Eta.class) final double eta,
-      @Parameter(ProbabilityOfSuccesfulIteration.class) final double probOfSuccessfulIteration,
+      @Parameter(ProbabilityOfSuccessfulIteration.class) final double probOfSuccessfulIteration,
       @Parameter(Iterations.class) final int iters,
       @Parameter(EnableRampup.class) final boolean rampup,
       @Parameter(MinParts.class) final int minParts,
@@ -70,7 +70,7 @@ public final class BGDControlParameters {
         .bindNamedParameter(Lambda.class, Double.toString(this.lambda))
         .bindNamedParameter(Eps.class, Double.toString(this.eps))
         .bindNamedParameter(Eta.class, Double.toString(this.eta))
-        .bindNamedParameter(ProbabilityOfSuccesfulIteration.class, Double.toString(probOfSuccessfulIteration))
+        .bindNamedParameter(ProbabilityOfSuccessfulIteration.class, Double.toString(probOfSuccessfulIteration))
         .bindNamedParameter(Iterations.class, Integer.toString(this.iters))
         .bindNamedParameter(EnableRampup.class, Boolean.toString(this.rampup))
         .bindNamedParameter(MinParts.class, Integer.toString(this.minParts))
@@ -84,7 +84,7 @@ public final class BGDControlParameters {
         .registerShortNameOfClass(Lambda.class)
         .registerShortNameOfClass(Eps.class)
         .registerShortNameOfClass(Eta.class)
-        .registerShortNameOfClass(ProbabilityOfSuccesfulIteration.class)
+        .registerShortNameOfClass(ProbabilityOfSuccessfulIteration.class)
         .registerShortNameOfClass(Iterations.class)
         .registerShortNameOfClass(EnableRampup.class)
         .registerShortNameOfClass(MinParts.class)

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/ProbabilityOfSuccessfulIteration.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/ProbabilityOfSuccessfulIteration.java
@@ -26,5 +26,5 @@ import org.apache.reef.tang.annotations.NamedParameter;
  * two iterations is less than this, the optimization stops.
  */
 @NamedParameter(short_name = "psuccess", default_value = "0.5")
-public final class ProbabilityOfSuccesfulIteration implements Name<Double> {
+public final class ProbabilityOfSuccessfulIteration implements Name<Double> {
 }

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestBindSingleton.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestBindSingleton.java
@@ -97,7 +97,7 @@ public class TestBindSingleton {
   }
 
   @Test
-  public void testMultipleInjectorInstaceWithSingleton() throws BindException, InjectionException {
+  public void testMultipleInjectorInstanceWithSingleton() throws BindException, InjectionException {
     final JavaConfigurationBuilder cb = Tang.Factory.getTang().newConfigurationBuilder();
 
     final Injector i1 = Tang.Factory.getTang().newInjector(cb.build());

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/TestConfigurationModule.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/TestConfigurationModule.java
@@ -294,7 +294,7 @@ public class TestConfigurationModule {
   }
 
   @Test
-  public void immutablilityTest() throws BindException, InjectionException {
+  public void immutabilityTest() throws BindException, InjectionException {
     // builder methods return copies; the original module is immutable
     final ConfigurationModule builder1 = MyConfigurationModule.CONF
         .set(MyConfigurationModule.THE_FOO, FooImpl.class)


### PR DESCRIPTION
This fixes the followings:
  * Deprecates `getEvaluatorDescriptorSring` in reef-bridge-java,
    and add `getEvaluatorDescriptorString`.
  * Rename `ProbabilityOfSuccesfulIteration.java` with
    `ProbabilityOfSuccessfulIteration.java` and update related codes.
  * Fix typos in two unittest function names in reef-tang.

JIRA:
  [REEF-1153](https://issues.apache.org/jira/browse/REEF-1153)

Pull Request:
  This closes #