### PR TITLE
[REEF-1166] Remove IContextMessageSource.Message.Set

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Context/IContextMessageSource.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Context/IContextMessageSource.cs
@@ -19,8 +19,12 @@ using Org.Apache.REEF.Utilities;
 
 namespace Org.Apache.REEF.Common.Context
 {
+    /// <summary>
+    ///     Implement (and bind) this interface to send messages from a context as part of a heartbeat from Evaluator to
+    ///     Driver.
+    /// </summary>
     public interface IContextMessageSource
     {
-        Optional<ContextMessage> Message { get; set; }
+        Optional<ContextMessage> Message { get; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Context/Defaults/DefaultContextMessageSource.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Context/Defaults/DefaultContextMessageSource.cs
@@ -31,10 +31,6 @@ namespace Org.Apache.REEF.Driver.Context.Defaults
             {
                 return Optional<Common.Context.ContextMessage>.Empty();
             }
-
-            set
-            {
-            }
         }
     }
 }


### PR DESCRIPTION
This removes `IContextMessageSource.Message.Set` and its implementation.

JIRA:
  [REEF-1166](https://issues.apache.org/jira/browse/REEF-1166)