### PR TITLE
[REEF-1033] Migrate Org.Apache.REEF.Client.Tests to xUnit

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client.Tests/JobResourceUploaderTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/JobResourceUploaderTests.cs
@@ -16,7 +16,6 @@
 // under the License.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Client.Yarn;
@@ -24,10 +23,10 @@ using Org.Apache.REEF.Client.YARN.RestClient;
 using Org.Apache.REEF.IO.FileSystem;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Client.Tests
 {
-    [TestClass]
     public class JobResourceUploaderTests
     {
         private const string AnyDriverLocalFolderPath = @"Any\Local\Folder\Path\";
@@ -41,13 +40,13 @@ namespace Org.Apache.REEF.Client.Tests
         private const long AnyResourceSize = 53092;
         private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, 0);
 
-        [TestMethod]
+        [Fact]
         public void JobResourceUploaderCanInstantiateWithDefaultBindings()
         {
             TangFactory.GetTang().NewInjector().GetInstance<FileSystemJobResourceUploader>();
         }
 
-        [TestMethod]
+        [Fact]
         public void UploadJobResourceCreatesResourceArchive()
         {
             var testContext = new TestContext();
@@ -59,7 +58,7 @@ namespace Org.Apache.REEF.Client.Tests
             testContext.ResourceArchiveFileGenerator.Received(1).CreateArchiveToUpload(AnyDriverLocalFolderPath);
         }
 
-        [TestMethod]
+        [Fact]
         public void UploadJobResourceReturnsJobResourceDetails()
         {
             var testContext = new TestContext();
@@ -67,12 +66,12 @@ namespace Org.Apache.REEF.Client.Tests
 
             var jobResource = jobResourceUploader.UploadJobResource(AnyDriverLocalFolderPath, AnyDriverResourceUploadPath);
 
-            Assert.AreEqual(AnyModificationTime, jobResource.LastModificationUnixTimestamp);
-            Assert.AreEqual(AnyResourceSize, jobResource.ResourceSize);
-            Assert.AreEqual(AnyUploadedResourceAbsoluteUri, jobResource.RemoteUploadPath);
+            Assert.Equal(AnyModificationTime, jobResource.LastModificationUnixTimestamp);
+            Assert.Equal(AnyResourceSize, jobResource.ResourceSize);
+            Assert.Equal(AnyUploadedResourceAbsoluteUri, jobResource.RemoteUploadPath);
         }
 
-        [TestMethod]
+        [Fact]
         public void UploadJobResourceMakesCorrectFileSystemCalls()
         {
             var testContext = new TestContext();

--- a/lang/cs/Org.Apache.REEF.Client.Tests/LegacyJobResourceUploaderTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/LegacyJobResourceUploaderTests.cs
@@ -17,16 +17,15 @@
 
 using System;
 using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Client.Yarn;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Client.Tests
 {
-    [TestClass]
     public class LegacyJobResourceUploaderTests
     {
         private const string AnyDriverLocalFolderPath = @"Any\Local\Folder\Path";
@@ -35,7 +34,7 @@ namespace Org.Apache.REEF.Client.Tests
         private const long AnyModificationTime = 1446161745550;
         private const long AnyResourceSize = 53092;
 
-        [TestMethod]
+        [Fact]
         public void UploadJobResourceCreatesResourceArchive()
         {
             var testContext = new TestContext();
@@ -47,7 +46,7 @@ namespace Org.Apache.REEF.Client.Tests
             testContext.ResourceArchiveFileGenerator.Received(1).CreateArchiveToUpload(AnyDriverLocalFolderPath + @"\");
         }
 
-        [TestMethod]
+        [Fact]
         public void UploadJobResourceJavaLauncherCalledWithCorrectArguments()
         {
             var testContext = new TestContext();
@@ -71,18 +70,17 @@ namespace Org.Apache.REEF.Client.Tests
                             && Guid.TryParse(Path.GetFileName(outputFilePath), out notUsed)));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(FileNotFoundException))]
+        [Fact]
         public void UploadJobResourceNoFileCreatedByJavaCallThrowsException()
         {
             var testContext = new TestContext();
             var jobResourceUploader = testContext.GetJobResourceUploader(fileExistsReturnValue: false);
 
             // throws filenotfound exception
-            jobResourceUploader.UploadJobResource(AnyDriverLocalFolderPath, AnyDriverResourceUploadPath);
+            Assert.Throws<FileNotFoundException>(() => jobResourceUploader.UploadJobResource(AnyDriverLocalFolderPath, AnyDriverResourceUploadPath));
         }
 
-        [TestMethod]
+        [Fact]
         public void UploadJobResourceReturnsJobResourceDetails()
         {
             var testContext = new TestContext();
@@ -90,9 +88,9 @@ namespace Org.Apache.REEF.Client.Tests
 
             var jobResource = jobResourceUploader.UploadJobResource(AnyDriverLocalFolderPath, AnyDriverResourceUploadPath);
 
-            Assert.AreEqual(AnyModificationTime, jobResource.LastModificationUnixTimestamp);
-            Assert.AreEqual(AnyResourceSize, jobResource.ResourceSize);
-            Assert.AreEqual(AnyUploadedResourcePath, jobResource.RemoteUploadPath);
+            Assert.Equal(AnyModificationTime, jobResource.LastModificationUnixTimestamp);
+            Assert.Equal(AnyResourceSize, jobResource.ResourceSize);
+            Assert.Equal(AnyUploadedResourcePath, jobResource.RemoteUploadPath);
         }
 
         private class TestContext

--- a/lang/cs/Org.Apache.REEF.Client.Tests/MultipleRMUrlProviderTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/MultipleRMUrlProviderTests.cs
@@ -18,16 +18,16 @@
 using System;
 using System.Globalization;
 using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Client.Yarn.RestClient;
 using Org.Apache.REEF.Client.YARN.RestClient;
 using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Client.Tests
 {
-    [TestClass]
+    [Collection("UrlProviderTests")]
     public class MultipleRMUrlProviderTests
     {
         private const string HadoopConfDirEnvVariable = "HADOOP_CONF_DIR";
@@ -54,7 +54,7 @@ namespace Org.Apache.REEF.Client.Tests
   </property>
 </configuration>";
 
-        [TestMethod]
+        [Fact]
         public void UrlProviderReadsEnvVarConfiguredConfigFileAndParsesCorrectHttpUrl()
         {
             string tempFile = Path.GetTempFileName();
@@ -71,24 +71,24 @@ namespace Org.Apache.REEF.Client.Tests
                 foreach (var u in url)
                 {
                     i++;
-                    Assert.AreEqual("http", u.Scheme);
+                    Assert.Equal("http", u.Scheme);
                     if (i == 1)
                     {
-                        Assert.AreEqual(AnyHttpAddressConfig.Split(':')[0], u.Host);
-                        Assert.AreEqual(AnyHttpAddressConfig.Split(':')[1],
+                        Assert.Equal(AnyHttpAddressConfig.Split(':')[0], u.Host);
+                        Assert.Equal(AnyHttpAddressConfig.Split(':')[1],
                             u.Port.ToString(CultureInfo.InvariantCulture));
                     }
                     else
                     {
-                        Assert.AreEqual(AnyHttpAddressConfigUpdated.Split(':')[0], u.Host);
-                        Assert.AreEqual(AnyHttpAddressConfigUpdated.Split(':')[1],
+                        Assert.Equal(AnyHttpAddressConfigUpdated.Split(':')[0], u.Host);
+                        Assert.Equal(AnyHttpAddressConfigUpdated.Split(':')[1],
                             u.Port.ToString(CultureInfo.InvariantCulture));
                     }
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void CannotFindHadoopConfigDirThrowsArgumentException()
         {
             using (new YarnConfigurationUrlProviderTests.TemporaryOverrideEnvironmentVariable(HadoopConfDirEnvVariable, string.Empty))
@@ -96,11 +96,11 @@ namespace Org.Apache.REEF.Client.Tests
                 try
                 {
                     IUrlProvider urlProviderNotUsed = GetYarnConfigurationUrlProvider();
-                    Assert.Fail("Should throw exception");
+                    Assert.True(false, "Should throw exception");
                 }
                 catch (InjectionException injectionException)
                 {
-                    Assert.IsTrue(injectionException.GetBaseException() is ArgumentException);
+                    Assert.True(injectionException.GetBaseException() is ArgumentException);
                 }
             }
         }

--- a/lang/cs/Org.Apache.REEF.Client.Tests/WindowsHadoopEmulatorYarnClientTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/WindowsHadoopEmulatorYarnClientTests.cs
@@ -27,6 +27,9 @@ using Xunit;
 
 namespace Org.Apache.REEF.Client.Tests
 {
+    // placed in the same collection as *UrlProviderTests to avoid running in parallel with them
+    // as they rely on setting the same environment variable to different values
+    [Collection("UrlProviderTests")]
     public class WindowsHadoopEmulatorYarnClientTests
     {
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Client.Tests/WindowsYarnJobCommandProviderTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/WindowsYarnJobCommandProviderTests.cs
@@ -16,17 +16,16 @@
 // under the License.
 
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using Org.Apache.REEF.Client.Yarn;
 using Org.Apache.REEF.Client.YARN;
 using Org.Apache.REEF.Client.YARN.Parameters;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Client.Tests
 {
-    [TestClass]
     public class WindowsYarnJobCommandProviderTests
     {
         private static readonly List<string> AnyClassPathItems = new List<string>
@@ -53,13 +52,13 @@ namespace Org.Apache.REEF.Client.Tests
             "%HADOOP_HOME%/share/hadoop/mapreduce/lib/*"
         };
 
-        [TestMethod]
+        [Fact]
         public void YarnJobCommandBuilderIsDefaultImplementationOfIYarnJobCommandBuilder()
         {
-            Assert.IsInstanceOfType(TangFactory.GetTang().NewInjector().GetInstance<IYarnJobCommandProvider>(), typeof(WindowsYarnJobCommandProvider));
+            Assert.IsType(typeof(WindowsYarnJobCommandProvider), TangFactory.GetTang().NewInjector().GetInstance<IYarnJobCommandProvider>());
         }
 
-        [TestMethod]
+        [Fact]
         public void GetJobSubmissionCommandGeneratesCorrectCommand()
         {
             var testContext = new TestContext();
@@ -79,10 +78,10 @@ namespace Org.Apache.REEF.Client.Tests
 
             var commandBuilder = testContext.GetCommandBuilder();
             var jobSubmissionCommand = commandBuilder.GetJobSubmissionCommand();
-            Assert.AreEqual(expectedCommand, jobSubmissionCommand);
+            Assert.Equal(expectedCommand, jobSubmissionCommand);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetJobSubmissionCommandLoggingEnabledGeneratesCorrectCommand()
         {
             var testContext = new TestContext();
@@ -102,10 +101,10 @@ namespace Org.Apache.REEF.Client.Tests
                                            "ion-params.json 1> <LOG_DIR>/driver.stdout 2> <LOG_DIR>/driver.stderr";
             var commandBuilder = testContext.GetCommandBuilder(true);
             var jobSubmissionCommand = commandBuilder.GetJobSubmissionCommand();
-            Assert.AreEqual(expectedCommand, jobSubmissionCommand);
+            Assert.Equal(expectedCommand, jobSubmissionCommand);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetJobSubmissionCommandSetsCorrectDriverMemoryAllocationSize()
         {
             var testContext = new TestContext();
@@ -126,10 +125,10 @@ namespace Org.Apache.REEF.Client.Tests
             string expectedCommand = string.Format(expectedCommandFormat, sizeMB);
             var commandBuilder = testContext.GetCommandBuilder(maxMemAllocPoolSize: sizeMB);
             var jobSubmissionCommand = commandBuilder.GetJobSubmissionCommand();
-            Assert.AreEqual(expectedCommand, jobSubmissionCommand);
+            Assert.Equal(expectedCommand, jobSubmissionCommand);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetJobSubmissionCommandSetsCorrectMaxPermSize()
         {
             var testContext = new TestContext();
@@ -152,7 +151,7 @@ namespace Org.Apache.REEF.Client.Tests
             var commandBuilder = testContext.GetCommandBuilder(maxPermSize: sizeMB);
             var jobSubmissionCommand = commandBuilder.GetJobSubmissionCommand();
             
-            Assert.AreEqual(expectedCommand, jobSubmissionCommand);
+            Assert.Equal(expectedCommand, jobSubmissionCommand);
         }
 
         private class TestContext

--- a/lang/cs/Org.Apache.REEF.Client.Tests/YarnClientTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/YarnClientTests.cs
@@ -21,7 +21,6 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using Org.Apache.REEF.Client.Yarn.RestClient;
 using Org.Apache.REEF.Client.YARN.RestClient;
@@ -29,13 +28,13 @@ using Org.Apache.REEF.Client.YARN.RestClient.DataModel;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Util;
 using RestSharp;
+using Xunit;
 
 namespace Org.Apache.REEF.Client.Tests
 {
-    [TestClass]
     public class YarnClientTests
     {
-        [TestMethod]
+        [Fact]
         public async Task TestGetClusterInfo()
         {
             // arrange
@@ -63,11 +62,11 @@ namespace Org.Apache.REEF.Client.Tests
             ClusterInfo actualClusterInfo = await yarnClient.GetClusterInfoAsync();
 
             // assert
-            Assert.AreEqual(anyClusterInfo, actualClusterInfo);
+            Assert.Equal(anyClusterInfo, actualClusterInfo);
             var unused = urlProvider.Received(1).GetUrlAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestGetClusterMetrics()
         {
             var ctx = new TestContext();
@@ -93,11 +92,11 @@ namespace Org.Apache.REEF.Client.Tests
             var yarnClient = ctx.GetClient();
             ClusterMetrics actualClusterMetrics = await yarnClient.GetClusterMetricsAsync();
 
-            Assert.AreEqual(anyClusterMetrics, actualClusterMetrics);
+            Assert.Equal(anyClusterMetrics, actualClusterMetrics);
             var unused = urlProvider.Received(1).GetUrlAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestGetApplication()
         {
             var ctx = new TestContext();
@@ -128,11 +127,11 @@ namespace Org.Apache.REEF.Client.Tests
             var yarnClient = ctx.GetClient();
             Application actualApplication = await yarnClient.GetApplicationAsync(applicationId);
 
-            Assert.AreEqual(anyApplication, actualApplication);
+            Assert.Equal(anyApplication, actualApplication);
             var unused = urlProvider.Received(1).GetUrlAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestGetApplicationFinalStatus()
         {
             var ctx = new TestContext();
@@ -165,10 +164,10 @@ namespace Org.Apache.REEF.Client.Tests
 
             Application actualApplication = await yarnClient.GetApplicationAsync(applicationId);
 
-            Assert.AreEqual(actualApplication.FinalStatus, FinalState.SUCCEEDED);
+            Assert.Equal(actualApplication.FinalStatus, FinalState.SUCCEEDED);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestCreateNewApplication()
         {
             var ctx = new TestContext();
@@ -192,11 +191,11 @@ namespace Org.Apache.REEF.Client.Tests
             var yarnClient = ctx.GetClient();
             NewApplication actualNewApplication = await yarnClient.CreateNewApplicationAsync();
 
-            Assert.AreEqual(anyNewApplication, actualNewApplication);
+            Assert.Equal(anyNewApplication, actualNewApplication);
             var unused = urlProvider.Received(1).GetUrlAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestSubmitNewApplication()
         {
             var ctx = new TestContext();
@@ -333,7 +332,7 @@ namespace Org.Apache.REEF.Client.Tests
             var yarnClient = ctx.GetClient();
             Application actualApplication = await yarnClient.SubmitApplicationAsync(anySubmitApplication);
 
-            Assert.AreEqual(thisApplication, actualApplication);
+            Assert.Equal(thisApplication, actualApplication);
             var unused = urlProvider.Received(2).GetUrlAsync();
         }
 

--- a/lang/cs/Org.Apache.REEF.Client.Tests/YarnConfigurationUrlProviderTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/YarnConfigurationUrlProviderTests.cs
@@ -21,15 +21,15 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Client.Yarn.RestClient;
 using Org.Apache.REEF.Client.YARN.RestClient;
 using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Tang.Implementations.Tang;
+using Xunit;
 
 namespace Org.Apache.REEF.Client.Tests
 {
-    [TestClass]
+    [Collection("UrlProviderTests")]
     public class YarnConfigurationUrlProviderTests
     {
         private const string HadoopConfDirEnvVariable = "HADOOP_CONF_DIR";
@@ -74,7 +74,7 @@ namespace Org.Apache.REEF.Client.Tests
   </property>
 </configuration>";
 
-        [TestMethod]
+        [Fact]
         public void UrlProviderReadsEnvVarConfiguredConfigFileAndParsesCorrectHttpUrl()
         {
             string tempFile = Path.GetTempFileName();
@@ -87,13 +87,13 @@ namespace Org.Apache.REEF.Client.Tests
                 YarnConfigurationUrlProvider urlProvider = GetYarnConfigurationUrlProvider();
                 var url = urlProvider.GetUrlAsync().GetAwaiter().GetResult();
 
-                Assert.AreEqual("http", url.First().Scheme);
-                Assert.AreEqual(AnyHttpAddressConfig.Split(':')[0], url.First().Host);
-                Assert.AreEqual(AnyHttpAddressConfig.Split(':')[1], url.First().Port.ToString(CultureInfo.InvariantCulture));
+                Assert.Equal("http", url.First().Scheme);
+                Assert.Equal(AnyHttpAddressConfig.Split(':')[0], url.First().Host);
+                Assert.Equal(AnyHttpAddressConfig.Split(':')[1], url.First().Port.ToString(CultureInfo.InvariantCulture));
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void UrlProviderReadsEnvVarConfiguredConfigFileAndParsesCorrectHttpsUrl()
         {
             string tempFile = Path.GetTempFileName();
@@ -106,13 +106,13 @@ namespace Org.Apache.REEF.Client.Tests
                 YarnConfigurationUrlProvider urlProvider = GetYarnConfigurationUrlProvider(useHttps: true);
                 IEnumerable<Uri> url = urlProvider.GetUrlAsync().GetAwaiter().GetResult();
 
-                Assert.AreEqual("https", url.First().Scheme);
-                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[0], url.First().Host);
-                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[1], url.First().Port.ToString(CultureInfo.InvariantCulture));
+                Assert.Equal("https", url.First().Scheme);
+                Assert.Equal(AnyHttpsAddressConfig.Split(':')[0], url.First().Host);
+                Assert.Equal(AnyHttpsAddressConfig.Split(':')[1], url.First().Port.ToString(CultureInfo.InvariantCulture));
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void UrlProviderReadsUserProvidedConfigFileAndParsesCorrectHttpsUrl()
         {
             string tempFile = Path.GetTempFileName();
@@ -126,13 +126,13 @@ namespace Org.Apache.REEF.Client.Tests
                     useHttps: true);
                 var url = urlProvider.GetUrlAsync().GetAwaiter().GetResult();
 
-                Assert.AreEqual("https", url.First().Scheme);
-                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[0], url.First().Host);
-                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[1], url.First().Port.ToString(CultureInfo.InvariantCulture));
+                Assert.Equal("https", url.First().Scheme);
+                Assert.Equal(AnyHttpsAddressConfig.Split(':')[0], url.First().Host);
+                Assert.Equal(AnyHttpsAddressConfig.Split(':')[1], url.First().Port.ToString(CultureInfo.InvariantCulture));
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void CannotFindHadoopConfigDirThrowsArgumentException()
         {
             using (new TemporaryOverrideEnvironmentVariable(HadoopConfDirEnvVariable, string.Empty))
@@ -140,11 +140,11 @@ namespace Org.Apache.REEF.Client.Tests
                 try
                 {
                     YarnConfigurationUrlProvider urlProviderNotUsed = GetYarnConfigurationUrlProvider();
-                    Assert.Fail("Should throw exception");
+                    Assert.True(false, "Should throw exception");
                 }
                 catch (InjectionException injectionException)
                 {
-                    Assert.IsTrue(injectionException.GetBaseException() is ArgumentException);
+                    Assert.True(injectionException.GetBaseException() is ArgumentException);
                 }
             }
         }


### PR DESCRIPTION
This change:
 * creates attribute which checks whether Hadoop services are
   available on the machine and skips the test if they are not
 * migrates O.A.R.Client.Tests to xUnit

JIRA:
  [REEF-1033](https://issues.apache.org/jira/browse/REEF-1033)

Pull request:
  This closes #