### PR TITLE
[REEF-1032] Migrate Org.Apache.REEF.IO.Tests to xUnit

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystem.cs
@@ -18,7 +18,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
@@ -29,6 +28,7 @@ using Org.Apache.REEF.IO.FileSystem.AzureBlob.RetryPolicy;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.IO.Tests
 {
@@ -37,24 +37,23 @@ namespace Org.Apache.REEF.IO.Tests
     /// Some methods are currently not unit tested due to the complexity of "faking out"
     /// the methods. They are instead tested E2E in TestAzureBlockBlobFileSystemE2E
     /// </summary>
-    [TestClass]
     public sealed class TestAzureBlockBlobFileSystem
     {
         private readonly static Uri FakeUri = new Uri("http://fake.com");
 
-        [TestMethod, ExpectedException(typeof(NotSupportedException))]
+        [Fact]
         public void TestCreateNotSupported()
         {
-            new TestContext().GetAzureFileSystem().Create(FakeUri);
+            Assert.Throws<NotSupportedException>(() => new TestContext().GetAzureFileSystem().Create(FakeUri));
         }
 
-        [TestMethod, ExpectedException(typeof(NotSupportedException))]
+        [Fact]
         public void TestOpenNotSupported()
         {
-            new TestContext().GetAzureFileSystem().Open(FakeUri);
+            Assert.Throws<NotSupportedException>(() => new TestContext().GetAzureFileSystem().Open(FakeUri));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDelete()
         {
             var testContext = new TestContext();
@@ -62,7 +61,7 @@ namespace Org.Apache.REEF.IO.Tests
             testContext.TestCloudBlockBlob.Received(1).Delete();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestExists()
         {
             var testContext = new TestContext();
@@ -70,7 +69,7 @@ namespace Org.Apache.REEF.IO.Tests
             testContext.TestCloudBlockBlob.Received(1).Exists();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCopyToLocal()
         {
             var testContext = new TestContext();
@@ -78,7 +77,7 @@ namespace Org.Apache.REEF.IO.Tests
             testContext.TestCloudBlockBlob.Received(1).DownloadToFile("local", FileMode.CreateNew);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCopyFromLocal()
         {
             var testContext = new TestContext();
@@ -86,7 +85,7 @@ namespace Org.Apache.REEF.IO.Tests
             testContext.TestCloudBlockBlob.Received(1).UploadFromFile("local", FileMode.Open);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCreateDirectory()
         {
             var testContext = new TestContext();
@@ -94,13 +93,13 @@ namespace Org.Apache.REEF.IO.Tests
             testContext.TestCloudBlobClient.DidNotReceiveWithAnyArgs();
         }
 
-        [TestMethod, ExpectedException(typeof(StorageException))]
+        [Fact]
         public void TestDeleteDirectoryFails()
         {
-            new TestContext().GetAzureFileSystem().DeleteDirectory(FakeUri);
+            Assert.Throws<StorageException>(() => new TestContext().GetAzureFileSystem().DeleteDirectory(FakeUri));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDeleteDirectoryAtContainer()
         {
             var testContext = new TestContext();
@@ -109,7 +108,7 @@ namespace Org.Apache.REEF.IO.Tests
             testContext.TestCloudBlobContainer.Received(1).DeleteIfExists();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDeleteDirectoryRecursive()
         {
             var testContext = new TestContext();
@@ -122,12 +121,12 @@ namespace Org.Apache.REEF.IO.Tests
             testContext.TestCloudBlob.Received(5).DeleteIfExists();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCreateUriForPath()
         {
             var testContext = new TestContext();
             const string dirStructure = "container/directory";
-            Assert.AreEqual(new Uri(FakeUri, dirStructure), testContext.GetAzureFileSystem().CreateUriForPath(dirStructure));
+            Assert.Equal(new Uri(FakeUri, dirStructure), testContext.GetAzureFileSystem().CreateUriForPath(dirStructure));
         }
 
         private sealed class TestContext

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystemE2E.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystemE2E.cs
@@ -19,12 +19,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Org.Apache.REEF.IO.FileSystem;
 using Org.Apache.REEF.IO.FileSystem.AzureBlob;
 using Org.Apache.REEF.Tang.Implementations.Tang;
+using Xunit;
 
 namespace Org.Apache.REEF.IO.Tests
 {
@@ -32,15 +32,13 @@ namespace Org.Apache.REEF.IO.Tests
     /// E2E tests for AzureBlockBlobFileSystem.
     /// These tests require the person running the test to fill in credentials.
     /// </summary>
-    [TestClass, Ignore]
-    public sealed class TestAzureBlockBlobFileSystemE2E
+    public sealed class TestAzureBlockBlobFileSystemE2E : IDisposable
     {
         private const string HelloFile = "hello";
         private IFileSystem _fileSystem;
         private CloudBlobContainer _container;
 
-        [TestInitialize]
-        public void TestInitialize()
+        public TestAzureBlockBlobFileSystemE2E()
         {
             // Fill in before running test!
             const string connectionString = "DefaultEndpointsProtocol=http;AccountName=myAccount;AccountKey=myKey;";
@@ -54,8 +52,7 @@ namespace Org.Apache.REEF.IO.Tests
             _container.CreateIfNotExists();
         }
 
-        [TestCleanup]
-        public void TestCleanup()
+        public void Dispose()
         {
             if (_container != null)
             {
@@ -63,28 +60,28 @@ namespace Org.Apache.REEF.IO.Tests
             }
         }
 
-        [TestMethod]
+        [Fact(Skip = "Fill in credentials before running test")]
         public void TestDeleteE2E()
         {
             var blob = _container.GetBlockBlobReference(HelloFile);
             UploadFromString(blob, "hello");
-            Assert.IsTrue(blob.Exists());
+            Assert.True(blob.Exists());
             _fileSystem.Delete(PathToFile(HelloFile));
-            Assert.IsFalse(blob.Exists());
+            Assert.False(blob.Exists());
         }
 
-        [TestMethod]
+        [Fact(Skip = "Fill in credentials before running test")]
         public void TestExistsE2E()
         {
             var helloFilePath = PathToFile(HelloFile);
             var blob = _container.GetBlockBlobReference(HelloFile);
             UploadFromString(blob, "hello");
-            Assert.IsTrue(_fileSystem.Exists(helloFilePath));
+            Assert.True(_fileSystem.Exists(helloFilePath));
             blob.DeleteIfExists();
-            Assert.IsFalse(_fileSystem.Exists(helloFilePath));
+            Assert.False(_fileSystem.Exists(helloFilePath));
         }
 
-        [TestMethod]
+        [Fact(Skip = "Fill in credentials before running test")]
         public void TestCopyE2E()
         {
             const string srcFileName = "src";
@@ -93,18 +90,18 @@ namespace Org.Apache.REEF.IO.Tests
             var destFilePath = PathToFile(destFileName);
             ICloudBlob srcBlob = _container.GetBlockBlobReference(srcFileName);
             UploadFromString(srcBlob, "hello");
-            Assert.IsTrue(srcBlob.Exists());
+            Assert.True(srcBlob.Exists());
             ICloudBlob destBlob = _container.GetBlockBlobReference(destFileName);
-            Assert.IsFalse(destBlob.Exists());
+            Assert.False(destBlob.Exists());
             _fileSystem.Copy(srcFilePath, destFilePath);
             destBlob = _container.GetBlobReferenceFromServer(destFileName);
-            Assert.IsTrue(destBlob.Exists());
+            Assert.True(destBlob.Exists());
             srcBlob = _container.GetBlobReferenceFromServer(srcFileName);
-            Assert.IsTrue(srcBlob.Exists());
-            Assert.AreEqual(_container.GetBlockBlobReference(srcFileName).DownloadText(), _container.GetBlockBlobReference(destFileName).DownloadText());
+            Assert.True(srcBlob.Exists());
+            Assert.Equal(_container.GetBlockBlobReference(srcFileName).DownloadText(), _container.GetBlockBlobReference(destFileName).DownloadText());
         }
 
-        [TestMethod]
+        [Fact(Skip = "Fill in credentials before running test")]
         public void TestCopyToLocalE2E()
         {
             var helloFilePath = PathToFile(HelloFile);
@@ -115,8 +112,8 @@ namespace Org.Apache.REEF.IO.Tests
             {
                 UploadFromString(blob, text);
                 _fileSystem.CopyToLocal(helloFilePath, tempFilePath);
-                Assert.IsTrue(File.Exists(tempFilePath));
-                Assert.AreEqual(text, File.ReadAllText(tempFilePath));
+                Assert.True(File.Exists(tempFilePath));
+                Assert.Equal(text, File.ReadAllText(tempFilePath));
             }
             finally
             {
@@ -124,12 +121,12 @@ namespace Org.Apache.REEF.IO.Tests
             }
         }
 
-        [TestMethod]
+        [Fact(Skip = "Fill in credentials before running test")]
         public void TestCopyFromLocalE2E()
         {
             var helloFilePath = PathToFile(HelloFile);
             ICloudBlob blob = _container.GetBlockBlobReference(HelloFile);
-            Assert.IsFalse(blob.Exists());
+            Assert.False(blob.Exists());
             var tempFilePath = GetTempFilePath();
             const string text = "hello";
             try
@@ -137,7 +134,7 @@ namespace Org.Apache.REEF.IO.Tests
                 File.WriteAllText(tempFilePath, text);
                 _fileSystem.CopyFromLocal(tempFilePath, helloFilePath);
                 blob = _container.GetBlobReferenceFromServer(HelloFile);
-                Assert.IsTrue(blob.Exists());
+                Assert.True(blob.Exists());
                 using (var stream = new MemoryStream())
                 {
                     blob.DownloadToStream(stream);
@@ -146,7 +143,7 @@ namespace Org.Apache.REEF.IO.Tests
                     using (var sr = new StreamReader(stream))
                     {
                         var matchingText = sr.ReadToEnd();
-                        Assert.AreEqual(text, matchingText);
+                        Assert.Equal(text, matchingText);
                     }
                 }
             }
@@ -156,14 +153,14 @@ namespace Org.Apache.REEF.IO.Tests
             }
         }
 
-        [TestMethod]
+        [Fact(Skip = "Fill in credentials before running test")]
         public void TestDeleteDirectoryAtContainerE2E()
         {
             _fileSystem.DeleteDirectory(_container.Uri);
-            Assert.IsFalse(_container.Exists());
+            Assert.False(_container.Exists());
         }
 
-        [TestMethod]
+        [Fact(Skip = "Fill in credentials before running test")]
         public void TestDeleteDirectoryFirstLevelE2E()
         {
             const string directory = "dir";
@@ -174,7 +171,7 @@ namespace Org.Apache.REEF.IO.Tests
                 var filePath = directory + '/' + i;
                 var blockBlob = _container.GetBlockBlobReference(filePath);
                 UploadFromString(blockBlob, "hello");
-                Assert.IsTrue(blockBlob.Exists());
+                Assert.True(blockBlob.Exists());
                 blockBlobs.Add(blockBlob);
             }
 
@@ -182,13 +179,13 @@ namespace Org.Apache.REEF.IO.Tests
 
             foreach (var blockBlob in blockBlobs)
             {
-                Assert.IsFalse(blockBlob.Exists());
+                Assert.False(blockBlob.Exists());
             }
 
-            Assert.IsTrue(_container.Exists());
+            Assert.True(_container.Exists());
         }
 
-        [TestMethod]
+        [Fact(Skip = "Fill in credentials before running test")]
         public void TestDeleteDirectorySecondLevelE2E()
         {
             const string directory1 = "dir1";
@@ -204,8 +201,8 @@ namespace Org.Apache.REEF.IO.Tests
                 var blockBlob2 = _container.GetBlockBlobReference(filePath2);
                 UploadFromString(blockBlob1, "hello");
                 UploadFromString(blockBlob2, "hello");
-                Assert.IsTrue(blockBlob1.Exists());
-                Assert.IsTrue(blockBlob2.Exists());
+                Assert.True(blockBlob1.Exists());
+                Assert.True(blockBlob2.Exists());
                 blockBlobs1.Add(blockBlob1);
                 blockBlobs2.Add(blockBlob2);
             }
@@ -214,15 +211,15 @@ namespace Org.Apache.REEF.IO.Tests
 
             foreach (var blockBlob in blockBlobs2)
             {
-                Assert.IsFalse(blockBlob.Exists());
+                Assert.False(blockBlob.Exists());
             }
 
             foreach (var blockBlob in blockBlobs1)
             {
-                Assert.IsTrue(blockBlob.Exists());
+                Assert.True(blockBlob.Exists());
             }
 
-            Assert.IsTrue(_container.Exists());
+            Assert.True(_container.Exists());
         }
 
         private static string GetTempFilePath()

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
@@ -19,7 +19,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.IO.PartitionedData;
 using Org.Apache.REEF.IO.PartitionedData.FileSystem;
 using Org.Apache.REEF.IO.PartitionedData.FileSystem.Parameters;
@@ -29,13 +28,13 @@ using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.IO.Tests
 {
     /// <summary>
     /// Tests for Org.Apache.REEF.IO.PartitionedData.FileSystem.
     /// </summary>
-    [TestClass]
     public class TestFilePartitionInputDataSet
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(TestFilePartitionInputDataSet));
@@ -45,7 +44,7 @@ namespace Org.Apache.REEF.IO.Tests
         string sourceFilePath1 = Path.Combine(Path.GetTempPath(), tempFileName1);
         string sourceFilePath2 = Path.Combine(Path.GetTempPath(), tempFileName2);
 
-        [TestMethod]
+        [Fact]
         public void TestDataSetId()
         {
             string filePaths = string.Format(CultureInfo.CurrentCulture, "{0};{1};{2};{3}", "/tmp/abc", "tmp//cde.txt", "efg", "tmp\\hhh");
@@ -58,14 +57,14 @@ namespace Org.Apache.REEF.IO.Tests
                     .Build())
                 .GetInstance<IPartitionedInputDataSet>();
 
-            Assert.AreEqual(dataSet.Id, "FileSystemDataSet-hhh");
+            Assert.Equal(dataSet.Id, "FileSystemDataSet-hhh");
         }
 
         /// <remarks>
         /// This test creates IPartitionDataSet with FileSystemInputPartitionConfiguration module.
         /// It then instantiates each IInputPartition using the IConfiguration provided by the IPartitionDescriptor.
         /// </remarks>
-        [TestMethod]
+        [Fact]
         public void TestEvaluatorSideWithMultipleFilesOnePartition()
         {
             MakeLocalTestFile(sourceFilePath1, new byte[] { 111, 112, 113 });
@@ -80,7 +79,7 @@ namespace Org.Apache.REEF.IO.Tests
                     .Build())
                 .GetInstance<IPartitionedInputDataSet>();
 
-            Assert.AreEqual(dataSet.Count, 1);
+            Assert.Equal(dataSet.Count, 1);
 
             foreach (var partitionDescriptor in dataSet)
             {
@@ -91,8 +90,8 @@ namespace Org.Apache.REEF.IO.Tests
 
                 using (partition as IDisposable)
                 {
-                    Assert.IsNotNull(partition);
-                    Assert.IsNotNull(partition.Id);
+                    Assert.NotNull(partition);
+                    Assert.NotNull(partition.Id);
                     int count = 0;
                     var e = partition.GetPartitionHandle();
                     foreach (var v in e)
@@ -100,7 +99,7 @@ namespace Org.Apache.REEF.IO.Tests
                         Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Data read {0}: ", v));
                         count++;
                     }
-                    Assert.AreEqual(count, 7);
+                    Assert.Equal(count, 7);
                 }
             }
         }
@@ -109,7 +108,7 @@ namespace Org.Apache.REEF.IO.Tests
         /// This test creates IPartitionDataSet using the configuration build directly.
         /// It sets multiple files in each Partition
         /// </remarks>
-        [TestMethod]
+        [Fact]
         public void TestWithoutConfigurationModuleWithTwoPartitions()
         {
             MakeLocalTestFile(sourceFilePath1, new byte[] { 111, 112, 113 });
@@ -127,7 +126,7 @@ namespace Org.Apache.REEF.IO.Tests
                 .NewInjector(partitionConfig)
                 .GetInstance<IPartitionedInputDataSet>();
 
-            Assert.AreEqual(dataSet.Count, 2);
+            Assert.Equal(dataSet.Count, 2);
 
             foreach (var partitionDescriptor in dataSet)
             {
@@ -137,8 +136,8 @@ namespace Org.Apache.REEF.IO.Tests
                         .GetInstance<IInputPartition<IEnumerable<byte>>>();
                 using (partition as IDisposable)
                 {
-                    Assert.IsNotNull(partition);
-                    Assert.IsNotNull(partition.Id);
+                    Assert.NotNull(partition);
+                    Assert.NotNull(partition.Id);
                 }
             }
         }
@@ -146,7 +145,7 @@ namespace Org.Apache.REEF.IO.Tests
         /// <remarks>
         /// This test is to use a ByteSerializer.
         /// </remarks>
-        [TestMethod]
+        [Fact]
         public void TestWithByteDeserializer()
         {
             MakeLocalTestFile(sourceFilePath1, new byte[] { 111, 112, 113 });
@@ -180,13 +179,13 @@ namespace Org.Apache.REEF.IO.Tests
                     }
                 }
             }
-            Assert.AreEqual(count, 7);
+            Assert.Equal(count, 7);
         }
 
         /// <remarks>
         /// This test is to use a RowSerializer. Row is a class at client side. 
         /// </remarks>
-        [TestMethod]
+        [Fact]
         public void TestWithRowDeserializer()
         {
             MakeLocalTestFile(sourceFilePath1, new byte[] { 111, 112, 113 });
@@ -218,13 +217,13 @@ namespace Org.Apache.REEF.IO.Tests
                     }
                 }
             }
-            Assert.AreEqual(count, 5);
+            Assert.Equal(count, 5);
         }
 
         /// <remarks>
         /// This test is to test injected IPartition with TempFileFolerParameter
         /// </remarks>
-        [TestMethod]
+        [Fact]
         public void TestTempFileFolderWithRowDeserializer()
         {
             MakeLocalTestFile(sourceFilePath1, new byte[] { 111, 112, 113 });
@@ -263,7 +262,7 @@ namespace Org.Apache.REEF.IO.Tests
                     }
                 }
             }
-            Assert.AreEqual(count, 5);
+            Assert.Equal(count, 5);
         }
 
         private void MakeLocalTestFile(string filePath, byte[] bytes)

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
@@ -18,12 +18,12 @@
 using System;
 using System.IO;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.IO.FileSystem;
 using Org.Apache.REEF.IO.FileSystem.Hadoop;
 using Org.Apache.REEF.IO.FileSystem.Hadoop.Parameters;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
+using Xunit;
 
 namespace Org.Apache.REEF.IO.Tests
 {
@@ -31,8 +31,6 @@ namespace Org.Apache.REEF.IO.Tests
     /// Tests for HadoopFileSystem.
     /// </summary>
     /// <see cref="HadoopFileSystem" />    
-    [TestClass]
-    [Ignore] // These tests need to be run in an environment with HDFS installed.
     public sealed class TestHadoopFileSystem
     {
         private HadoopFileSystem _fileSystem;
@@ -47,8 +45,7 @@ namespace Org.Apache.REEF.IO.Tests
         /// <summary>
         /// Sets up the file system instance to be used for the tests.
         /// </summary>
-        [TestInitialize]
-        public void SetupFileSystem()
+        public TestHadoopFileSystem()
         {
             _fileSystem =
                 TangFactory.GetTang()
@@ -59,7 +56,7 @@ namespace Org.Apache.REEF.IO.Tests
         /// <summary>
         /// Creates a temp file locally, uploads it to HDFS and downloads it again.
         /// </summary>
-        [TestMethod]
+        [Fact(Skip = "These tests need to be run in an environment with HDFS installed.")]
         public void TestCopyFromLocalAndBack()
         {
             var localFile = FileSystemTestUtilities.MakeLocalTempFile();
@@ -69,10 +66,8 @@ namespace Org.Apache.REEF.IO.Tests
             _fileSystem.CopyFromLocal(localFile, remoteUri);
             _fileSystem.CopyToLocal(remoteUri, localFileDownloaded);
 
-            Assert.IsTrue(message: "A file up and downloaded should exist on the local file system.",
-                condition: File.Exists(localFileDownloaded));
-            Assert.IsTrue(message: "A file up and downloaded should not have changed content.",
-                condition: FileSystemTestUtilities.HaveSameContent(localFile, localFileDownloaded));
+            Assert.True(File.Exists(localFileDownloaded), "A file up and downloaded should exist on the local file system.");
+            Assert.True(FileSystemTestUtilities.HaveSameContent(localFile, localFileDownloaded), "A file up and downloaded should not have changed content.");
 
             _fileSystem.Delete(remoteUri);
             File.Delete(localFile);
@@ -82,23 +77,23 @@ namespace Org.Apache.REEF.IO.Tests
         /// <summary>
         /// Tests whether .Exists() works.
         /// </summary>
-        [TestMethod]
+        [Fact(Skip = "These tests need to be run in an environment with HDFS installed.")]
         public void TestExists()
         {
             var remoteUri = GetTempUri();
-            Assert.IsFalse(message: "The file should not exist yet", condition: _fileSystem.Exists(remoteUri));
+            Assert.False(_fileSystem.Exists(remoteUri), "The file should not exist yet");
             var localFile = FileSystemTestUtilities.MakeLocalTempFile();
             _fileSystem.CopyFromLocal(localFile, remoteUri);
-            Assert.IsTrue(message: "The file should now exist", condition: _fileSystem.Exists(remoteUri));
+            Assert.True(_fileSystem.Exists(remoteUri), "The file should now exist");
             _fileSystem.Delete(remoteUri);
-            Assert.IsFalse(message: "The file should no longer exist", condition: _fileSystem.Exists(remoteUri));
+            Assert.False(_fileSystem.Exists(remoteUri), "The file should no longer exist");
             File.Delete(localFile);
         }
 
         /// <summary>
         /// Tests for .GetChildren().
         /// </summary>
-        [TestMethod]
+        [Fact(Skip = "These tests need to be run in an environment with HDFS installed.")]
         public void TestGetChildren()
         {
             // Make a directory
@@ -106,8 +101,7 @@ namespace Org.Apache.REEF.IO.Tests
             _fileSystem.CreateDirectory(remoteDirectory);
 
             // Check that it is empty
-            Assert.AreEqual(message: "The directory should be empty.", expected: 0,
-                actual: _fileSystem.GetChildren(remoteDirectory).Count());
+            Assert.True(_fileSystem.GetChildren(remoteDirectory).Count() == 0, "The directory should be empty.");
 
             // Upload some localfile there
             var localTempFile = FileSystemTestUtilities.MakeLocalTempFile();
@@ -116,7 +110,7 @@ namespace Org.Apache.REEF.IO.Tests
 
             // Check that it is on the listing
             var uriInResult = _fileSystem.GetChildren(remoteUri).First();
-            Assert.AreEqual(remoteUri, uriInResult);
+            Assert.Equal(remoteUri, uriInResult);
 
             // Download the file and make sure it is the same as before
             var downloadedFileName = localTempFile + ".downloaded";
@@ -129,39 +123,36 @@ namespace Org.Apache.REEF.IO.Tests
             _fileSystem.Delete(remoteUri);
 
             // Check that the folder is empty again
-            Assert.AreEqual(message: "The directory should be empty.", expected: 0,
-                actual: _fileSystem.GetChildren(remoteDirectory).Count());
+            Assert.True(_fileSystem.GetChildren(remoteDirectory).Count() == 0, "The directory should be empty.");
 
             // Delete the folder
             _fileSystem.DeleteDirectory(remoteDirectory);
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(NotImplementedException),
-            "Open() is not supported by HadoopFileSystem. Use CopyToLocal and open the local file instead.")]
+        [Fact(Skip = "These tests need to be run in an environment with HDFS installed.")]
         public void TestOpen()
         {
-            _fileSystem.Open(GetTempUri());
+            // Open() is not supported by HadoopFileSystem. Use CopyToLocal and open the local file instead.
+            Assert.Throws<NotImplementedException>(() => _fileSystem.Open(GetTempUri()));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(NotImplementedException),
-            "Create() is not supported by HadoopFileSystem. Create a local file and use CopyFromLocal instead.")]
+        [Fact(Skip = "These tests need to be run in an environment with HDFS installed.")]
         public void TestCreate()
         {
-            _fileSystem.Create(GetTempUri());
+            // Create() is not supported by HadoopFileSystem. Create a local file and use CopyFromLocal instead.
+            Assert.Throws<NotImplementedException>(() => _fileSystem.Create(GetTempUri()));
         }
 
         /// <summary>
         /// This test is to make sure with the HadoopFileSystemConfiguration, HadoopFileSystem can be injected.
         /// </summary>
-        [TestMethod]
+        [Fact(Skip = "These tests need to be run in an environment with HDFS installed.")]
         public void TestHadoopFileSystemConfiguration()
         {
             var fileSystemTest = TangFactory.GetTang().NewInjector(HadoopFileSystemConfiguration.ConfigurationModule
                 .Build())
                 .GetInstance<FileSystemTest>();
-            Assert.IsTrue(fileSystemTest.FileSystem is HadoopFileSystem);
+            Assert.True(fileSystemTest.FileSystem is HadoopFileSystem);
         }
     }
 

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestLocalFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestLocalFileSystem.cs
@@ -18,23 +18,22 @@
 using System;
 using System.IO;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.IO.FileSystem;
 using Org.Apache.REEF.IO.FileSystem.Local;
 using Org.Apache.REEF.Tang.Implementations.Tang;
+using Xunit;
 
 namespace Org.Apache.REEF.IO.Tests
 {
     /// <summary>
     /// Tests for Org.Apache.REEF.IO.FileSystem.Local.LocalFileSystem
     /// </summary>
-    [TestClass]
     public sealed class TestLocalFileSystem
     {
         private const string TempFileName = "REEF.TestLocalFileSystem.tmp";
         private const byte TestByte = 123;
 
-        [TestMethod]
+        [Fact]
         public void TestCreateAndOpenAndDelete()
         {
             var fs = GetFileSystem();
@@ -48,27 +47,27 @@ namespace Org.Apache.REEF.IO.Tests
                 s.WriteByte(TestByte);
             }
 
-            Assert.IsTrue(fs.Exists(tempFileUri));
-            Assert.IsTrue(File.Exists(tempFilePath));
+            Assert.True(fs.Exists(tempFileUri));
+            Assert.True(File.Exists(tempFilePath));
 
             // Make sure it was read correctly
             using (var s = fs.Open(tempFileUri))
             {
-                Assert.AreEqual(TestByte, s.ReadByte());
+                Assert.Equal(TestByte, s.ReadByte());
             }
             using (var s = File.Open(tempFilePath, FileMode.Open))
             {
-                Assert.AreEqual(TestByte, s.ReadByte());
+                Assert.Equal(TestByte, s.ReadByte());
             }
 
             // Delete it
             fs.Delete(tempFileUri);
 
-            Assert.IsFalse(fs.Exists(tempFileUri));
-            Assert.IsFalse(File.Exists(tempFilePath));
+            Assert.False(fs.Exists(tempFileUri));
+            Assert.False(File.Exists(tempFilePath));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCopyFromLocal()
         {
             var fs = GetFileSystem();
@@ -86,13 +85,13 @@ namespace Org.Apache.REEF.IO.Tests
             TestRemoteFile(fs, destinationUri);
 
             fs.Delete(destinationUri);
-            Assert.IsFalse(fs.Exists(destinationUri));
+            Assert.False(fs.Exists(destinationUri));
 
             File.Delete(sourceFilePath);
-            Assert.IsFalse(File.Exists(sourceFilePath));
+            Assert.False(File.Exists(sourceFilePath));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCopyToLocal()
         {
             var fs = GetFileSystem();
@@ -109,13 +108,13 @@ namespace Org.Apache.REEF.IO.Tests
             TestLocalFile(destinationFilePath);
 
             fs.Delete(sourceUri);
-            Assert.IsFalse(fs.Exists(sourceUri));
+            Assert.False(fs.Exists(sourceUri));
 
             File.Delete(destinationFilePath);
-            Assert.IsFalse(File.Exists(destinationFilePath));
+            Assert.False(File.Exists(destinationFilePath));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCopy()
         {
             var fs = GetFileSystem();
@@ -127,17 +126,17 @@ namespace Org.Apache.REEF.IO.Tests
             {
                 fs.Delete(destinationUri);
             }
-            Assert.IsFalse(fs.Exists(destinationUri));
+            Assert.False(fs.Exists(destinationUri));
             fs.Copy(sourceUri, destinationUri);
-            Assert.IsTrue(fs.Exists(destinationUri));
+            Assert.True(fs.Exists(destinationUri));
             TestRemoteFile(fs, destinationUri);
             fs.Delete(destinationUri);
-            Assert.IsFalse(fs.Exists(destinationUri));
+            Assert.False(fs.Exists(destinationUri));
             fs.Delete(sourceUri);
-            Assert.IsFalse(fs.Exists(sourceUri));
+            Assert.False(fs.Exists(sourceUri));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGetChildren()
         {
             var fs = GetFileSystem();
@@ -152,8 +151,8 @@ namespace Org.Apache.REEF.IO.Tests
                 TestRemoteFile(fs, uri);
             }
 
-            Assert.AreEqual(1, fileUris.Count);
-            Assert.AreEqual(fileUri, fileUris[0]);
+            Assert.Equal(1, fileUris.Count);
+            Assert.Equal(fileUri, fileUris[0]);
             fs.Delete(fileUri);
             fs.DeleteDirectory(directoryUri);
         }
@@ -193,7 +192,7 @@ namespace Org.Apache.REEF.IO.Tests
         {
             using (var s = fs.Open(path))
             {
-                Assert.AreEqual(TestByte, s.ReadByte());
+                Assert.Equal(TestByte, s.ReadByte());
             }
         }
 
@@ -201,7 +200,7 @@ namespace Org.Apache.REEF.IO.Tests
         {
             using (var s = File.Open(filePath, FileMode.Open))
             {
-                Assert.AreEqual(TestByte, s.ReadByte());
+                Assert.Equal(TestByte, s.ReadByte());
             }
         }
     }

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestRandomInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestRandomInputDataSet.cs
@@ -17,17 +17,16 @@
 
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.IO.PartitionedData;
 using Org.Apache.REEF.IO.PartitionedData.Random;
 using Org.Apache.REEF.Tang.Implementations.Tang;
+using Xunit;
 
 namespace Org.Apache.REEF.IO.Tests
 {
     /// <summary>
     /// Tests for Org.Apache.REEF.IO.PartitionedData.Random.
     /// </summary>
-    [TestClass]
     public sealed class TestRandomInputDataSet
     {
         /// <summary>
@@ -53,21 +52,21 @@ namespace Org.Apache.REEF.IO.Tests
         /// <summary>
         /// Test for the driver side APIs of RandomDataSet.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestDriverSide()
         {
             var dataSet = MakeRandomDataSet();
-            Assert.IsNotNull(dataSet);
-            Assert.IsNotNull(dataSet.Id);
-            Assert.IsNotNull(dataSet.GetEnumerator());
-            Assert.AreEqual(NumberOfPartitions, dataSet.Count);
+            Assert.NotNull(dataSet);
+            Assert.NotNull(dataSet.Id);
+            Assert.NotNull(dataSet.GetEnumerator());
+            Assert.Equal(NumberOfPartitions, dataSet.Count);
 
             IEnumerator<IPartitionDescriptor> desriptors = dataSet.GetEnumerator();
             while (desriptors.MoveNext())
             {
                 var descriptor1 = desriptors.Current;
                 var descriptor2 = dataSet.GetPartitionDescriptorForId(descriptor1.Id);
-                Assert.AreEqual(descriptor1, descriptor2);
+                Assert.Equal(descriptor1, descriptor2);
             }
         }
 
@@ -77,7 +76,7 @@ namespace Org.Apache.REEF.IO.Tests
         /// <remarks>
         /// This instantiates each IInputPartition using the IConfiguration provided by the IPartitionDescriptor.
         /// </remarks>
-        [TestMethod]
+        [Fact]
         public void TestEvaluatorSide()
         {
             var dataSet = MakeRandomDataSet();
@@ -87,15 +86,15 @@ namespace Org.Apache.REEF.IO.Tests
                     TangFactory.GetTang()
                         .NewInjector(partitionDescriptor.GetPartitionConfiguration())
                         .GetInstance<IInputPartition<Stream>>();
-                Assert.IsNotNull(partition);
-                Assert.IsNotNull(partition.Id);
+                Assert.NotNull(partition);
+                Assert.NotNull(partition.Id);
 
                 using (var partitionStream = partition.GetPartitionHandle())
                 {
-                    Assert.IsNotNull(partitionStream);
-                    Assert.IsTrue(partitionStream.CanRead);
-                    Assert.IsFalse(partitionStream.CanWrite);
-                    Assert.AreEqual(ExpectedNumberOfBytesPerPartition, partitionStream.Length);
+                    Assert.NotNull(partitionStream);
+                    Assert.True(partitionStream.CanRead);
+                    Assert.False(partitionStream.CanWrite);
+                    Assert.Equal(ExpectedNumberOfBytesPerPartition, partitionStream.Length);
                 }
             }
         }

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestTempFolderCreator.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestTempFolderCreator.cs
@@ -16,19 +16,18 @@
 // under the License.
 
 using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.IO.TempFileCreation;
 using Org.Apache.REEF.Tang.Implementations.Tang;
+using Xunit;
 
 namespace Org.Apache.REEF.IO.Tests
 {
-    [TestClass]
     public class TestTempFolderCreator
     {
         /// <summary>
         /// This is to test default TempFileFolder and ITempFileCreator
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestDefaultTempFolder()
         {
             var b = TempFileConfigurationModule.ConfigurationModule.Build();
@@ -37,13 +36,13 @@ namespace Org.Apache.REEF.IO.Tests
             var f1 = tempFileCreator.GetTempFileName();
             var f2 = (string)i.GetNamedInstance(typeof(TempFileFolder));
             var f = Path.GetFullPath(f2);
-            Assert.IsTrue(f1.StartsWith(f));
+            Assert.True(f1.StartsWith(f));
         }
 
         /// <summary>
         /// This is to test setting a value to TempFileFolder
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestTempFileFolerParameter()
         {
             var b = TempFileConfigurationModule.ConfigurationModule
@@ -54,13 +53,13 @@ namespace Org.Apache.REEF.IO.Tests
             var f1 = tempFileCreator.GetTempFileName();
             var f2 = (string)i.GetNamedInstance(typeof(TempFileFolder));
             var f = Path.GetFullPath(f2);
-            Assert.IsTrue(f1.StartsWith(f));
+            Assert.True(f1.StartsWith(f));
         }
 
         /// <summary>
         /// This is to test CreateTempDirectory() by providing a subfolder 
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestCreateTempFileFoler()
         {
             var b = TempFileConfigurationModule.ConfigurationModule
@@ -71,8 +70,8 @@ namespace Org.Apache.REEF.IO.Tests
             var f1 = tempFileCreator.CreateTempDirectory("ddd\\fff");
             var f3 = tempFileCreator.CreateTempDirectory("ddd\\fff", "bbb");
             var f2 = Path.GetFullPath(@"./test1/abc/" + "ddd\\fff");
-            Assert.IsTrue(f1.StartsWith(f2));
-            Assert.IsTrue(f3.EndsWith("bbb"));
+            Assert.True(f1.StartsWith(f2));
+            Assert.True(f3.EndsWith("bbb"));
         }
     }
 }


### PR DESCRIPTION
This change migrates O.A.R.IO.Tests to xUnit, preserving skipped tests.
Tests will be updated to be skipped programmatically in REEF-1170.

JIRA:
  [REEF-1032](https://issues.apache.org/jira/browse/REEF-1032)

Pull request:
  This closes #