### PR TITLE
[REEF-1172] Correct deprecation of ContextConfiguration for RootContext

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextManager.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextManager.cs
@@ -51,8 +51,9 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
             {
                 _heartBeatManager = heartBeatManager;
                 _serializer = serializer;
+
                 _rootContextLauncher = new RootContextLauncher(
-                    evaluatorSettings.RootContextConfig.Id,
+                    evaluatorSettings.RootContextId,
                     evaluatorSettings.RootContextConfig,
                     evaluatorSettings.RootServiceConfiguration,
                     evaluatorSettings.RootTaskConfiguration);
@@ -283,16 +284,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
                     Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
                 }
 
-                IConfiguration contextConfiguration;
-                try
-                {
-                    contextConfiguration = _serializer.FromString(addContextProto.context_configuration);
-                }
-                catch (Exception)
-                {
-                    // TODO[JIRA REEF-1167]: Remove the catch.
-                    contextConfiguration = new ContextConfiguration(addContextProto.context_configuration);
-                }
+                var contextConfiguration = _serializer.FromString(addContextProto.context_configuration);
 
                 ContextRuntime newTopContext;
                 if (addContextProto.service_configuration != null)

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/RootContextLauncher.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/RootContextLauncher.cs
@@ -56,8 +56,17 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
         {
             if (_rootContext == null)
             {
-                // TODO[JIRA REEF-1167]: Remove use of this constructor.
-                _rootContext = new ContextRuntime(Id, _rootServiceInjector, _rootContextConfiguration);
+                // TODO[JIRA REEF-1167]: Remove use of deprecated ContextRuntime constructor and deprecatedContextConfiguration
+                var deprecatedContextConfiguration = _rootContextConfiguration as ContextConfiguration;
+                if (deprecatedContextConfiguration != null)
+                {
+                    LOGGER.Log(Level.Info, "Using deprecated ContextConfiguration.");
+                    _rootContext = new ContextRuntime(Id, _rootServiceInjector, _rootContextConfiguration);
+                }
+                else
+                {
+                    _rootContext = new ContextRuntime(_rootServiceInjector, _rootContextConfiguration, Optional<ContextRuntime>.Empty());
+                }
             }
             return _rootContext;
         }
@@ -76,9 +85,9 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
                 }
                 catch (Exception e)
                 {
-                    Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Caught(e, Level.Error, "Failed to instantiate service.", LOGGER);
+                    Utilities.Diagnostics.Exceptions.Caught(e, Level.Error, "Failed to instantiate service.", LOGGER);
                     InvalidOperationException ex = new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Failed to inject service: encoutned error {1} with message [{0}] and stack trace:[{1}]", e, e.Message, e.StackTrace));
-                    Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
+                    Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
                 }
                 LOGGER.Log(Level.Info, string.Format(CultureInfo.InvariantCulture, "injected {0} service(s)", services.Services.Count));
             }


### PR DESCRIPTION
This addressed the issue by
  * Support RootContext backward compatibility.
  * Remove backward compatibility support for context stacking.

JIRA:
  [REEF-1172](https://issues.apache.org/jira/browse/REEF-1172)