### PR TITLE
[REEF-1174] Update Apache Dockerfile to use Hadoop 2.7.2

### DIFF
--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -15,7 +15,7 @@ Docker-based Test Cluster
 | YARN        | Ubuntu 12.04 | HDP 2.2.7  (Hadoop 2.6.0) | HDInsight 3.2 | hdi3.2    |
 | YARN        | Ubuntu 12.04 | HDP 2.2.8  (Hadoop 2.6.0) |               | hdp2.2    |
 | YARN        | Ubuntu 12.04 | HDP 2.3.2  (Hadoop 2.7.1) |               | hdp2.3    |
-| YARN        | Ubuntu 12.04 | Apache Hadoop 2.7.1       |               | apache2.7 |
+| YARN        | Ubuntu 12.04 | Apache Hadoop 2.7.2       |               | apache2.7 |
 | MESOS       | Ubuntu 12.04 | Apache Mesos 0.24.1       |               | mesos0.24 |
 | MESOS       | Ubuntu 12.04 | Apache Mesos 0.25.0       |               | mesos0.25 |
 
@@ -58,7 +58,7 @@ Test Apache REEF on a docker-based YARN cluster
 
 Among reefrt/hdi3.1, reefrt/hdi3.2, reefrt/hdp2.2, reefrt/hdp2.3, and reefrt/apache2.7,
 choose one and run it as described in section _Run a docker-based cluster_.
-If you want to test on Hadoop 2.7.1, choose reefrt/apache2.7.
+If you want to test on Hadoop 2.7.2, choose reefrt/apache2.7.
 To simulate HDInsight 3.2, choose reefrt/hdi3.2.
 After running a cluster, use the following commands.
 

--- a/dev/docker/ubuntu12.04-jdk7-apache2.7/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-apache2.7/Dockerfile
@@ -18,12 +18,12 @@
 FROM reefrt/ubuntu12.04-jdk7
 MAINTAINER Apache REEF <dev@reef.apache.org>
 
-# Apache Hadoop 2.7.1
+# Apache Hadoop 2.7.2
 RUN \
-  cd /usr/local && wget -q http://www.us.apache.org/dist/hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz && \
-  tar -xzf hadoop-2.7.1.tar.gz && \
-  ln -s ./hadoop-2.7.1 hadoop && \
-  rm hadoop-2.7.1.tar.gz
+  cd /usr/local && wget -q http://www.us.apache.org/dist/hadoop/common/hadoop-2.7.2/hadoop-2.7.2.tar.gz && \
+  tar -xzf hadoop-2.7.2.tar.gz && \
+  ln -s ./hadoop-2.7.2 hadoop && \
+  rm hadoop-2.7.2.tar.gz
 
 ENV HADOOP_PREFIX /usr/local/hadoop
 ENV YARN_CONF_DIR /usr/local/hadoop/etc/hadoop


### PR DESCRIPTION
Apache Hadoop 2.7.2 is release on 25 January.
This updates Hadoop version from 2.7.1 into 2.7.2.

JIRA:
  [REEF-1174](https://issues.apache.org/jira/browse/REEF-1174)

Pull request:
  This closes #