### PR TITLE
[REEF-1175] Add support for network credential to O.A.R.Client.YarnCl…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client.Tests/HDInsightYarnClientTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/HDInsightYarnClientTests.cs
@@ -1,0 +1,168 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Org.Apache.REEF.Client.Yarn.RestClient;
+using Org.Apache.REEF.Client.YARN.RestClient;
+using Org.Apache.REEF.Client.YARN.RestClient.DataModel;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Util;
+using Xunit;
+
+namespace Org.Apache.REEF.Client.Tests
+{
+    public class HDInsightYarnClientTests
+    {
+        [Trait("Category", "Functional")]
+        [Fact(Skip = @"Requires HDInsight Cred")]
+        public async Task TestGetClusterInfo()
+        {
+            var injector = TangFactory.GetTang().NewInjector();
+            var cred = new HDInsightTestCredential();
+            var urlProvider = new HDInsightRMUrlProvider();
+            injector.BindVolatileInstance(GenericType<IYarnRestClientCredential>.Class, cred);
+            injector.BindVolatileInstance(GenericType<IUrlProvider>.Class, urlProvider);
+            var client = injector.GetInstance<IYarnRMClient>();
+
+            var clusterInfo = await client.GetClusterInfoAsync();
+
+            Assert.NotNull(clusterInfo);
+            Assert.Equal(ClusterState.STARTED, clusterInfo.State);
+            Assert.True(clusterInfo.StartedOn > 0);
+        }
+
+        [Trait("Category", "Functional")]
+        [Fact(Skip = @"Requires HDInsight Cred")]
+        public async Task TestGetClusterMetrics()
+        {
+            var injector = TangFactory.GetTang().NewInjector();
+            var cred = new HDInsightTestCredential();
+            var urlProvider = new HDInsightRMUrlProvider();
+            injector.BindVolatileInstance(GenericType<IYarnRestClientCredential>.Class, cred);
+            injector.BindVolatileInstance(GenericType<IUrlProvider>.Class, urlProvider);
+            var client = injector.GetInstance<IYarnRMClient>();
+
+            var clusterMetrics = await client.GetClusterMetricsAsync();
+
+            Assert.NotNull(clusterMetrics);
+            Assert.True(clusterMetrics.TotalMB > 0);
+            Assert.True(clusterMetrics.ActiveNodes > 0);
+        }
+
+        [Trait("Category", "Functional")]
+        [Fact(Skip = @"Requires HDInsight Cred")]
+        public async Task TestApplicationSubmissionAndQuery()
+        {
+            var injector = TangFactory.GetTang().NewInjector();
+            var cred = new HDInsightTestCredential();
+            var urlProvider = new HDInsightRMUrlProvider();
+            injector.BindVolatileInstance(GenericType<IYarnRestClientCredential>.Class, cred);
+            injector.BindVolatileInstance(GenericType<IUrlProvider>.Class, urlProvider);
+            var client = injector.GetInstance<IYarnRMClient>();
+
+            var newApplication = await client.CreateNewApplicationAsync();
+
+            Assert.NotNull(newApplication);
+            Assert.False(string.IsNullOrEmpty(newApplication.ApplicationId));
+            Assert.True(newApplication.MaximumResourceCapability.MemoryMB > 0);
+            Assert.True(newApplication.MaximumResourceCapability.VCores > 0);
+
+            string applicationName = "REEFTEST_APPLICATION_" + Guid.NewGuid();
+            Console.WriteLine(applicationName);
+
+            const string anyApplicationType = "REEFTest";
+            var submitApplicationRequest = new SubmitApplication
+            {
+                ApplicationId = newApplication.ApplicationId,
+                AmResource = new Resouce
+                {
+                    MemoryMB = 500,
+                    VCores = 1
+                },
+                ApplicationType = anyApplicationType,
+                ApplicationName = applicationName,
+                KeepContainersAcrossApplicationAttempts = false,
+                MaxAppAttempts = 1,
+                Priority = 1,
+                UnmanagedAM = false,
+                AmContainerSpec = new AmContainerSpec
+                {
+                    Commands = new Commands
+                    {
+                        Command = @"DONTCARE"
+                    },
+                    LocalResources = new LocalResources
+                    {
+                        Entries = new List<YARN.RestClient.DataModel.KeyValuePair<string, LocalResourcesValue>>
+                        {
+                            new YARN.RestClient.DataModel.KeyValuePair<string, LocalResourcesValue>
+                            {
+                                Key = "APPLICATIONWILLFAILBUTWEDONTCAREHERE",
+                                Value = new LocalResourcesValue
+                                {
+                                    Resource = "Foo",
+                                    Type = ResourceType.FILE,
+                                    Visibility = Visibility.APPLICATION
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var application = await client.SubmitApplicationAsync(submitApplicationRequest);
+
+            Assert.NotNull(application);
+            Assert.Equal(newApplication.ApplicationId, application.Id);
+            Assert.Equal(applicationName, application.Name);
+            Assert.Equal(anyApplicationType, application.ApplicationType);
+
+            var getApplicationResult = client.GetApplicationAsync(newApplication.ApplicationId).GetAwaiter().GetResult();
+
+            Assert.NotNull(getApplicationResult);
+            Assert.Equal(newApplication.ApplicationId, getApplicationResult.Id);
+            Assert.Equal(applicationName, getApplicationResult.Name);
+            Assert.Equal(anyApplicationType, getApplicationResult.ApplicationType);
+        }
+    }
+
+    public class HDInsightTestCredential : IYarnRestClientCredential
+    {
+        private const string UserName = @"foo";
+        private const string Password = @"bar"; // TODO: Do not checkin!!!
+        private readonly ICredentials _credentials = new NetworkCredential(UserName, Password);
+
+        public ICredentials Credentials
+        {
+            get { return _credentials; }
+        }
+    }
+
+    public class HDInsightRMUrlProvider : IUrlProvider
+    {
+        private const string HDInsightUrl = "https://baz.azurehdinsight.net/";
+
+        public Task<IEnumerable<Uri>> GetUrlAsync()
+        {
+            return Task.FromResult(Enumerable.Repeat(new Uri(HDInsightUrl), 1));
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client.Tests/Org.Apache.REEF.Client.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/Org.Apache.REEF.Client.Tests.csproj
@@ -62,6 +62,7 @@ under the License.
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HDInsightYarnClientTests.cs" />
     <Compile Include="JobResourceUploaderTests.cs" />
     <Compile Include="LegacyJobResourceUploaderTests.cs" />
     <Compile Include="MultipleRMUrlProviderTests.cs" />

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -103,7 +103,9 @@ under the License.
     <Compile Include="YARN\RestClient\IRequestFactory.cs" />
     <Compile Include="YARN\RestClient\IRestClient.cs" />
     <Compile Include="YARN\RestClient\ISerializer.cs" />
+    <Compile Include="YARN\RestClient\IYarnRestClientCredential.cs" />
     <Compile Include="YARN\RestClient\Method.cs" />
+    <Compile Include="YARN\RestClient\NullYarnRestClientCredential.cs" />
     <Compile Include="YARN\RestClient\RequestFactory.cs" />
     <Compile Include="YARN\RestClient\RestClient.cs" />
     <Compile Include="YARN\RestClient\RestJsonDeserializer.cs" />

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/HttpClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/HttpClient.cs
@@ -30,10 +30,10 @@ namespace Org.Apache.REEF.Client.YARN.RestClient
         private readonly System.Net.Http.HttpClient _httpClient;
 
         [Inject]
-        private HttpClient()
+        private HttpClient(IYarnRestClientCredential yarnRestClientCredential)
         {
             _httpClient = new System.Net.Http.HttpClient(
-                new HttpClientRetryHandler(new WebRequestHandler()),
+                new HttpClientRetryHandler(new WebRequestHandler { Credentials = yarnRestClientCredential.Credentials }),
                 disposeHandler: false);
         }
 

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/IYarnRestClientCredential.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/IYarnRestClientCredential.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,35 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Org.Apache.REEF.Client.YARN.RestClient;
+using System.Net;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Utilities.AsyncUtils;
 
-namespace Org.Apache.REEF.Client.Yarn.RestClient
+namespace Org.Apache.REEF.Client.YARN.RestClient
 {
     /// <summary>
-    /// Executes a REST request
+    /// Provides the credentials to be used by the REST client to 
+    /// connect to YARN RM.
     /// </summary>
-    [DefaultImplementation(typeof(RestRequestExecutor))]
-    internal interface IRestRequestExecutor
+    [DefaultImplementation(typeof(NullYarnRestClientCredential))]
+    public interface IYarnRestClientCredential
     {
         /// <summary>
-        /// Executes a REST request where a response is expected
+        /// .NET credentials to be used by REST client
         /// </summary>
-        Task<T> ExecuteAsync<T>(
-            RestRequest request,
-            Uri uri,
-            CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Executes a REST request where a response is NOT expected
-        /// </summary>
-        Task<RestResponse<VoidResult>> ExecuteAsync(
-            RestRequest request,
-            Uri uri,
-            CancellationToken cancellationToken);
+        ICredentials Credentials { get; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/NullYarnRestClientCredential.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/NullYarnRestClientCredential.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Net;
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.Client.YARN.RestClient
+{
+    internal class NullYarnRestClientCredential : IYarnRestClientCredential
+    {
+        [Inject]
+        private NullYarnRestClientCredential()
+        {
+        }
+
+        public ICredentials Credentials
+        {
+            get
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNClientConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNClientConfiguration.cs
@@ -18,6 +18,7 @@
 using Org.Apache.REEF.Client.API;
 using Org.Apache.REEF.Client.YARN;
 using Org.Apache.REEF.Client.YARN.Parameters;
+using Org.Apache.REEF.Client.YARN.RestClient;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Attributes;
@@ -32,6 +33,7 @@ namespace Org.Apache.REEF.Client.Yarn
         public static readonly OptionalParameter<string> JobSubmissionFolderPrefix = new OptionalParameter<string>();
         public static readonly OptionalParameter<string> SecurityTokenKind = new OptionalParameter<string>();
         public static readonly OptionalParameter<string> SecurityTokenService = new OptionalParameter<string>();
+        public static readonly OptionalImpl<IYarnRestClientCredential> YarnRestClientCredential = new OptionalImpl<IYarnRestClientCredential>();
 
         public static ConfigurationModule ConfigurationModule = new YARNClientConfiguration()
             .BindImplementation(GenericType<IREEFClient>.Class, GenericType<YarnREEFClient>.Class)
@@ -44,6 +46,7 @@ namespace Org.Apache.REEF.Client.Yarn
                   " and ConfigurationModuleYARNRest would be merged.")]
         public static ConfigurationModule ConfigurationModuleYARNRest = new YARNClientConfiguration()
             .BindImplementation(GenericType<IREEFClient>.Class, GenericType<YarnREEFDotNetClient>.Class)
+            .BindImplementation(GenericType<IYarnRestClientCredential>.Class, YarnRestClientCredential)
             .BindNamedParameter(GenericType<JobSubmissionDirectoryPrefixParameter>.Class, JobSubmissionFolderPrefix)
             .BindNamedParameter(GenericType<SecurityTokenKindParameter>.Class, SecurityTokenKind)
             .BindNamedParameter(GenericType<SecurityTokenServiceParameter>.Class, SecurityTokenService)


### PR DESCRIPTION
…ient

This addressed the issue by:
 * Adding NetworkCredential support to HttpClient which delegates to .NEt
 * HTTPClient
 * Add interface IYarnRestClientCredential which allows user to specify
 * mechanism to access their credential source

JIRA:
  [REEF-1175](https://issues.apache.org/jira/browse/REEF-1175)