### PR TITLE
[REEF-1031] Migrate the rest of O.A.R.Tang.Tests and O.A.R.Client.Tests to xUnit

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client.Tests/RestClientTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/RestClientTests.cs
@@ -21,15 +21,14 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using Org.Apache.REEF.Client.YARN.RestClient;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Client.Tests
 {
-    [TestClass]
     public class RestClientTests
     {
         private const string AnyResource = "anyResource";
@@ -47,7 +46,7 @@ namespace Org.Apache.REEF.Client.Tests
         private static readonly Uri AnyRequestUri = new Uri("http://any/request/uri");
         private static readonly Encoding Encoding = Encoding.UTF8;
 
-        [TestMethod]
+        [Fact]
         public async Task RestClientGetRequestReturnsResponse()
         {
             var tc = new TestContext();
@@ -68,14 +67,14 @@ namespace Org.Apache.REEF.Client.Tests
             var response =
                 await client.ExecuteRequestAsync<AnyResponse>(anyRequest, AnyRequestUri, CancellationToken.None);
 
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual(AnyStringField, response.Data.AnyStringField);
-            Assert.AreEqual(AnyIntField, response.Data.AnyIntField);
-            Assert.IsNull(response.Exception);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(AnyStringField, response.Data.AnyStringField);
+            Assert.Equal(AnyIntField, response.Data.AnyIntField);
+            Assert.Null(response.Exception);
             var unused = tc.HttpClient.Received(1).GetAsync(AnyRequestUri + anyRequest.Resource, CancellationToken.None);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RestClientPostRequestReturnsResponse()
         {
             var tc = new TestContext();
@@ -102,10 +101,10 @@ namespace Org.Apache.REEF.Client.Tests
             var response =
                 await client.ExecuteRequestAsync<AnyResponse>(anyRequest, AnyRequestUri, CancellationToken.None);
 
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual(AnyStringField, response.Data.AnyStringField);
-            Assert.AreEqual(AnyIntField, response.Data.AnyIntField);
-            Assert.IsNull(response.Exception);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(AnyStringField, response.Data.AnyStringField);
+            Assert.Equal(AnyIntField, response.Data.AnyIntField);
+            Assert.Null(response.Exception);
             var unused = tc.HttpClient.Received(1).PostAsync(AnyRequestUri + anyRequest.Resource,
                 Arg.Is<StringContent>(
                     stringContent =>
@@ -114,7 +113,7 @@ namespace Org.Apache.REEF.Client.Tests
                 CancellationToken.None);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RestClientRequestReturnsFailureResponse()
         {
             var tc = new TestContext();
@@ -135,10 +134,10 @@ namespace Org.Apache.REEF.Client.Tests
             var response =
                 await client.ExecuteRequestAsync<AnyResponse>(anyRequest, AnyRequestUri, CancellationToken.None);
 
-            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
-            Assert.IsNull(response.Data);
-            Assert.IsNotNull(response.Exception);
-            Assert.IsInstanceOfType(response.Exception, typeof(HttpRequestException));
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.Null(response.Data);
+            Assert.NotNull(response.Exception);
+            Assert.IsType(typeof(HttpRequestException), response.Exception);
             var unused = tc.HttpClient.Received(1).GetAsync(AnyRequestUri + anyRequest.Resource, CancellationToken.None);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestAnonymousType.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestAnonymousType.cs
@@ -18,20 +18,19 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Examples;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Protobuf;
+using Xunit;
 
 namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
 {
-    [TestClass]
     public class TestAnonymousType
     {
         const string ClassHierarchyBinFileName = "example.bin";
 
-        [TestMethod]
+        [Fact]
         public void TestAnonymousTypeWithDictionary()
         {
             List<string> appDlls = new List<string>();
@@ -42,7 +41,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             IConfiguration conf = TangFactory.GetTang().NewConfigurationBuilder(c).Build();
             IInjector injector = TangFactory.GetTang().NewInjector(conf);
             var obj = injector.GetInstance<AnonymousType>();
-            Assert.IsNotNull(obj);
+            Assert.NotNull(obj);
 
             var cd = Directory.GetCurrentDirectory();
             Console.WriteLine(cd);

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestSerilization.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestSerilization.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Examples.Tasks.HelloTask;
 using Org.Apache.REEF.Examples.Tasks.StreamingTasks;
@@ -28,44 +27,28 @@ using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Protobuf;
 using Org.Apache.REEF.Tang.Types;
 using Org.Apache.REEF.Tang.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
 {
-    [TestClass]
-    public class TestSerilization
+    public class TestSerialization
     {
         static Assembly asm = null;
 
-        [ClassInitialize]
-        public static void ClassSetup(TestContext context)
+        public TestSerialization()
         {
             asm = Assembly.Load(FileNames.Examples);
             Assembly.Load(FileNames.Examples);
         }
 
-        [ClassCleanup]
-        public static void ClassCleanup()
-        {
-        }
-
-        [TestInitialize]
-        public void TestSetup()
-        {
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-        }
-
-        [TestMethod]
+        [Fact]
         public void TestSerializeClassHierarchy()
         {            
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Timer).Assembly.GetName().Name });
             ProtocolBufferClassHierarchy.Serialize("node.bin", ns);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDeSerializeClassHierarchy()
         {
             Type timerType = typeof(Timer);
@@ -84,16 +67,16 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             INode secondNode2 = ch.GetNode(SecondType.AssemblyQualifiedName);
             IClassNode SimpleConstructorsClassNode2 = (IClassNode)ch.GetNode(simpleCOnstuctorType.AssemblyQualifiedName);
 
-            Assert.AreEqual(timerClassNode.GetFullName(), timerClassNode2.GetFullName());
-            Assert.AreEqual(secondNode.GetFullName(), secondNode2.GetFullName());
-            Assert.AreEqual(SimpleConstructorsClassNode.GetFullName(), SimpleConstructorsClassNode2.GetFullName());
+            Assert.Equal(timerClassNode.GetFullName(), timerClassNode2.GetFullName());
+            Assert.Equal(secondNode.GetFullName(), secondNode2.GetFullName());
+            Assert.Equal(SimpleConstructorsClassNode.GetFullName(), SimpleConstructorsClassNode2.GetFullName());
 
-            Assert.IsTrue(SimpleConstructorsClassNode2.GetChildren().Count == 0);
+            Assert.True(SimpleConstructorsClassNode2.GetChildren().Count == 0);
             IList<IConstructorDef> def = SimpleConstructorsClassNode2.GetInjectableConstructors();
-            Assert.AreEqual(3, def.Count);
+            Assert.Equal(3, def.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDeSerializeClassHierarchyForTask()
         {
             Type streamTask1Type = typeof(StreamTask1);
@@ -108,32 +91,31 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             IClassNode StreamTask1ClassNode2 = (IClassNode)ch.GetNode(streamTask1Type.AssemblyQualifiedName);
             IClassNode HelloTaskClassNode2 = (IClassNode)ch.GetNode(helloTaskType.AssemblyQualifiedName);
 
-            Assert.AreEqual(StreamTask1ClassNode.GetFullName(), StreamTask1ClassNode2.GetFullName());
-            Assert.AreEqual(HelloTaskClassNode.GetFullName(), HelloTaskClassNode2.GetFullName());
+            Assert.Equal(StreamTask1ClassNode.GetFullName(), StreamTask1ClassNode2.GetFullName());
+            Assert.Equal(HelloTaskClassNode.GetFullName(), HelloTaskClassNode2.GetFullName());
         }
 
-        [TestMethod]
-        [DeploymentItem(@".")]
+        [Fact]
         public void TestDeSerializeClassHierarchyFromJava()
         {
             // the file comes from Java TestClassHierarchyRoundTrip SetUp3 testSimpleConstructors
             IClassHierarchy ch = ProtocolBufferClassHierarchy.DeSerialize("simpleConstructorJavaProto.bin");
             IClassNode simpleConstructorNode = (IClassNode)ch.GetNode("org.apache.reef.tang.implementation.SimpleConstructors");
-            Assert.AreEqual(simpleConstructorNode.GetChildren().Count, 0);
-            Assert.AreEqual(simpleConstructorNode.GetInjectableConstructors().Count, 3);
+            Assert.Equal(simpleConstructorNode.GetChildren().Count, 0);
+            Assert.Equal(simpleConstructorNode.GetInjectableConstructors().Count, 3);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSerializeClassHierarchyForAvro()
         {
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Microsoft.Hadoop.Avro.AvroSerializer).Assembly.GetName().Name });
-            Assert.IsNotNull(ns);
+            Assert.NotNull(ns);
             ProtocolBufferClassHierarchy.Serialize("avro.bin", ns);
             IClassHierarchy ch = ProtocolBufferClassHierarchy.DeSerialize("avro.bin");
-            Assert.IsNotNull(ch);
+            Assert.NotNull(ch);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDeSerializeClassHierarchyAndBind()
         {
             Type streamTask1Type = typeof(StreamTask1);
@@ -148,8 +130,8 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             IClassNode StreamTask1ClassNode2 = (IClassNode)ch.GetNode(streamTask1Type.AssemblyQualifiedName);
             IClassNode HelloTaskClassNode2 = (IClassNode)ch.GetNode(helloTaskType.AssemblyQualifiedName);
 
-            Assert.AreEqual(StreamTask1ClassNode.GetName(), StreamTask1ClassNode2.GetName());
-            Assert.AreEqual(HelloTaskClassNode.GetName(), HelloTaskClassNode2.GetName());
+            Assert.Equal(StreamTask1ClassNode.GetName(), StreamTask1ClassNode2.GetName());
+            Assert.Equal(HelloTaskClassNode.GetName(), HelloTaskClassNode2.GetName());
 
             // have to use original class hierarchy for the merge. ClassHierarchy from ProtoBuffer doesn't support merge. 
             IConfigurationBuilder cb = TangFactory.GetTang()
@@ -161,10 +143,10 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
 
             IConfiguration taskConfiguration = cb.Build();
             StreamTask1 st = TangFactory.GetTang().NewInjector(taskConfiguration).GetInstance<StreamTask1>();
-            Assert.IsNotNull(st);
+            Assert.NotNull(st);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSerirializeInjectionPlanForTimer()
         {
             Type timerType = typeof(Timer);
@@ -177,10 +159,10 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             ProtocolBufferInjectionPlan.Serialize("timerplan.bin", ip);
             var ch = conf.GetClassHierarchy();
             var ip1 = ProtocolBufferInjectionPlan.DeSerialize("timerplan.bin", ch);
-            Assert.IsNotNull(ip1);
+            Assert.NotNull(ip1);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSerirializeInjectionPlanForSimpleConstructor()
         {
             Type simpleConstructorType = typeof(SimpleConstructors);
@@ -194,10 +176,10 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             ProtocolBufferInjectionPlan.Serialize("plan.bin", ip);
             var ch = conf.GetClassHierarchy();
             var ipRecovered = ProtocolBufferInjectionPlan.DeSerialize("plan.bin", ch);
-            Assert.IsNotNull(ipRecovered);
+            Assert.NotNull(ipRecovered);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGenericClass()
         {
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Timer).Assembly.GetName().Name });
@@ -207,10 +189,10 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             ProtocolBufferClassHierarchy.Serialize("event.bin", ns);
             IClassHierarchy ch = ProtocolBufferClassHierarchy.DeSerialize("event.bin");
             IClassNode EventClassNode1 = (IClassNode)ns.GetNode(t.AssemblyQualifiedName);
-            Assert.AreEqual(EventClassNode.GetName(), EventClassNode1.GetName());
+            Assert.Equal(EventClassNode.GetName(), EventClassNode1.GetName());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGenericArgument()
         {
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(ClassWithGenericArgument<>).Assembly.GetName().Name });
@@ -223,13 +205,13 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
                 var args = c.GetArgs();
                 foreach (var a in args)
                 {
-                    Assert.IsNotNull(a.GetName());
+                    Assert.NotNull(a.GetName());
                 }
             }
             ProtocolBufferClassHierarchy.Serialize("generic.bin", ns);
             IClassHierarchy ch = ProtocolBufferClassHierarchy.DeSerialize("generic.bin");
             IClassNode classNode1 = (IClassNode)ns.GetNode(t.AssemblyQualifiedName);
-            Assert.AreEqual(classNode.GetName(), classNode1.GetName());
+            Assert.Equal(classNode.GetName(), classNode1.GetName());
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Configuration/TestAvroSerializerRoundTrip.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Configuration/TestAvroSerializerRoundTrip.cs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Formats.AvroConfigurationDataContract;
 using Org.Apache.REEF.Tang.Interface;
@@ -23,9 +22,8 @@ using Org.Apache.REEF.Tang.Tests.SmokeTest;
 
 namespace Org.Apache.REEF.Tang.Tests.Configuration
 {
-    internal class TestAvroSerializerRoundTrip
+    public class TestAvroSerializerRoundTrip
     {
-        [TestClass]
         public class AvroConfigurationTest : RoundTripTest
         {
             public override IConfiguration RoundTrip(IConfiguration configuration)
@@ -35,7 +33,6 @@ namespace Org.Apache.REEF.Tang.Tests.Configuration
             }
         }
 
-        [TestClass]
         public class ByteArrayTest : RoundTripTest
         {
             public override IConfiguration RoundTrip(IConfiguration configuration)
@@ -46,7 +43,6 @@ namespace Org.Apache.REEF.Tang.Tests.Configuration
             }
         }
 
-        [TestClass]
         public class FileTest : RoundTripTest
         {
             public override IConfiguration RoundTrip(IConfiguration configuration)
@@ -57,7 +53,6 @@ namespace Org.Apache.REEF.Tang.Tests.Configuration
             }
         }
 
-        [TestClass]
         public class StringTest : RoundTripTest
         {
             public override IConfiguration RoundTrip(IConfiguration configuration)

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Injection/TestForkInjection.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Injection/TestForkInjection.cs
@@ -17,41 +17,24 @@
 
 using System;
 using System.Reflection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Examples;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Tang.Tests.Injection
 {
-    [TestClass]
     public class TestForkInjection
     {        
         static Assembly asm = null;
 
-        [ClassInitialize]
-        public static void ClassSetup(TestContext context)
+        public TestForkInjection()
         {
             asm = Assembly.Load(FileNames.Examples);
         }
 
-        [ClassCleanup]
-        public static void ClassCleanup()
-        {
-        }
-
-        [TestInitialize]
-        public void TestSetup()
-        {
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-        }
-
-        [TestMethod]
+        [Fact]
         public void TestForksInjectorInConstructor()
         {
             ICsConfigurationBuilder cb = TangFactory.GetTang().NewConfigurationBuilder(new string[] { FileNames.Examples });
@@ -59,7 +42,7 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             var o = i.GetInstance(typeof(ForksInjectorInConstructor));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestForkWorks()
         {
             Type checkChildIfaceType = typeof(CheckChildIface);
@@ -71,7 +54,7 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             CheckChildIface c1 = (CheckChildIface)i1.GetInstance(checkChildIfaceType);
             IInjector i2 = i.ForkInjector();
             CheckChildIface c2 = (CheckChildIface)i2.GetInstance(checkChildIfaceType);
-            Assert.AreNotEqual(c1, c2);
+            Assert.NotEqual(c1, c2);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Injection/TestInjection.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Injection/TestInjection.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Reflection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Examples.Tasks.HelloTask;
 using Org.Apache.REEF.Examples.Tasks.StreamingTasks;
@@ -27,6 +26,7 @@ using Org.Apache.REEF.Tang.Implementations.ClassHierarchy;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Tang.Tests.Injection
 {
@@ -35,33 +35,16 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
     {
     }
 
-    [TestClass]
     public class TestInjection
     {
         static Assembly asm = null;
 
-        [ClassInitialize]
-        public static void ClassSetup(TestContext context)
+        public TestInjection()
         {
             asm = Assembly.Load(FileNames.Examples);
         }
 
-        [ClassCleanup]
-        public static void ClassCleanup()
-        {
-        }
-
-        [TestInitialize]
-        public void TestSetup()
-        {
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-        }
-
-        [TestMethod]
+        [Fact]
         public void TestTimer()
         {
             Type timerType = typeof(Timer);
@@ -72,12 +55,12 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             IInjector injector = tang.NewInjector(conf);
             var timer = (Timer)injector.GetInstance(timerType);
 
-            Assert.IsNotNull(timer);
+            Assert.NotNull(timer);
 
             timer.sleep();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTimerWithClassHierarchy()
         {
             Type timerType = typeof(Timer);
@@ -93,12 +76,12 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             IInjector injector = tang.NewInjector(conf);
             var timer = (Timer)injector.GetInstance(timerType);
 
-            Assert.IsNotNull(timer);
+            Assert.NotNull(timer);
 
             timer.sleep();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDocumentLoadNamedParameter()
         {
             Type documentedLocalNamedParameterType = typeof(DocumentedLocalNamedParameter);
@@ -109,10 +92,10 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             IInjector injector = tang.NewInjector(conf);
             var doc = (DocumentedLocalNamedParameter)injector.GetInstance(documentedLocalNamedParameterType);
 
-            Assert.IsNotNull(doc);
+            Assert.NotNull(doc);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDocumentLoadNamedParameterWithDefaultValue()
         {
             ITang tang = TangFactory.GetTang();
@@ -120,10 +103,10 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             IInjector injector = tang.NewInjector(conf);
             var doc = (DocumentedLocalNamedParameter)injector.GetInstance(typeof(DocumentedLocalNamedParameter));
 
-            Assert.IsNotNull(doc);
+            Assert.NotNull(doc);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSimpleConstructor()
         {
             Type simpleConstructorType = typeof(SimpleConstructors);
@@ -133,10 +116,10 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             IConfiguration conf = cb.Build();
             IInjector injector = tang.NewInjector(conf);
             var simpleConstructor = (SimpleConstructors)injector.GetInstance(simpleConstructorType);
-            Assert.IsNotNull(simpleConstructor);
+            Assert.NotNull(simpleConstructor);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestActivity()
         {
             Type activityType = typeof(HelloTask);
@@ -146,10 +129,10 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             IConfiguration conf = cb.Build();
             IInjector injector = tang.NewInjector(conf);
             var activityRef = (ITask)injector.GetInstance(activityType);
-            Assert.IsNotNull(activityRef);
+            Assert.NotNull(activityRef);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestStreamActivity1()
         {
             Type activityType = typeof(StreamTask1);
@@ -159,10 +142,10 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             IConfiguration conf = cb.Build();
             IInjector injector = tang.NewInjector(conf);
             var activityRef = (ITask)injector.GetInstance(activityType);
-            Assert.IsNotNull(activityRef);
+            Assert.NotNull(activityRef);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestStreamActivity2()
         {
             Type activityType = typeof(StreamTask2);
@@ -172,10 +155,10 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             IConfiguration conf = cb.Build();
             IInjector injector = tang.NewInjector(conf);
             var activityRef = (ITask)injector.GetInstance(activityType);
-            Assert.IsNotNull(activityRef);
+            Assert.NotNull(activityRef);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMultipleAssemlies()
         {
             Type activityInterfaceType1 = typeof(ITask);
@@ -193,13 +176,13 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             var activityRef = (ITask)injector.GetInstance(activityInterfaceType1);
             var tweeter = (Tweeter)injector.GetInstance(tweeterType);
 
-            Assert.IsNotNull(activityRef);
-            Assert.IsNotNull(tweeter);
+            Assert.NotNull(activityRef);
+            Assert.NotNull(tweeter);
 
             tweeter.sendMessage();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestActivityWithBinding()
         {
             Type activityInterfaceType = typeof(ITask);
@@ -213,12 +196,12 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             IInjector injector = tang.NewInjector(conf);
             ITask activityRef1 = injector.GetInstance<ITask>();
             var activityRef2 = (ITask)injector.GetInstance(activityInterfaceType);
-            Assert.IsNotNull(activityRef2);
-            Assert.IsNotNull(activityRef1);
-            Assert.AreEqual(activityRef1, activityRef2);
+            Assert.NotNull(activityRef2);
+            Assert.NotNull(activityRef1);
+            Assert.Equal(activityRef1, activityRef2);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestHelloStreamingActivityWithBinding()
         {
             Type activityInterfaceType = typeof(ITask);
@@ -232,10 +215,10 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             IConfiguration conf = cb.Build();
             IInjector injector = tang.NewInjector(conf);
             var activityRef = (ITask)injector.GetInstance(activityInterfaceType);
-            Assert.IsNotNull(activityRef);
+            Assert.NotNull(activityRef);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTweetExample()
         {
             Type tweeterType = typeof(Tweeter);
@@ -252,26 +235,26 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
 
             var sms = (ISMS)injector.GetInstance(typeof(ISMS));
             var factory = (ITweetFactory)injector.GetInstance(typeof(ITweetFactory));
-            Assert.IsNotNull(sms);
-            Assert.IsNotNull(factory);
+            Assert.NotNull(sms);
+            Assert.NotNull(factory);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestReferenceType()
         {
             AReferenceClass o = (AReferenceClass)TangFactory.GetTang().NewInjector().GetInstance(typeof(IAInterface));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGeneric()
         {
             var o = (AGenericClass<int>)TangFactory.GetTang().NewInjector().GetInstance(typeof(AGenericClass<int>));
             var o2 = (AClassWithGenericArgument<int>)TangFactory.GetTang().NewInjector().GetInstance(typeof(AClassWithGenericArgument<int>));
-            Assert.IsNotNull(o);
-            Assert.IsNotNull(o2);
+            Assert.NotNull(o);
+            Assert.NotNull(o2);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNestedClass()
         {
             ITang tang = TangFactory.GetTang();
@@ -285,10 +268,10 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             IInjector injector = tang.NewInjector(conf);
             ClassHasNestedClass h = injector.GetInstance<ClassHasNestedClass>();
 
-            Assert.IsNotNull(h);
+            Assert.NotNull(h);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestExternalObject()
         {
             ITang tang = TangFactory.GetTang();
@@ -300,14 +283,14 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             injector.BindVolatileInstance(GenericType<ExternalClass>.Class, new ExternalClass());
             ClassWithExternalObject o = injector.GetInstance<ClassWithExternalObject>();
 
-            Assert.IsNotNull(o.ExternalObject is ExternalClass);
+            Assert.NotNull(o.ExternalObject is ExternalClass);
         }
 
         /// <summary>
         /// In this test, interface is a generic of T. Implementations have different generic arguments such as int and string. 
         /// When doing injection, we must specify the interface with a specified argument type
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestInjectionWithGenericArguments()
         {
             var c = TangFactory.GetTang().NewConfigurationBuilder()
@@ -322,16 +305,16 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
             var o2 = injector.GetInstance(typeof(IMyOperator<string>));
             var o3 = injector.GetInstance(typeof(MyOperatorTopology<int>));
 
-            Assert.IsTrue(o1 is MyOperatorImpl<int>);
-            Assert.IsTrue(o2 is MyOperatorImpl<string>);
-            Assert.IsTrue(o3 is MyOperatorTopology<int>);
+            Assert.True(o1 is MyOperatorImpl<int>);
+            Assert.True(o2 is MyOperatorImpl<string>);
+            Assert.True(o3 is MyOperatorTopology<int>);
         }
 
         /// <summary>
         /// In this test, interface argument type is set through Configuration. We can get the argument type and then 
         /// make the interface with the argument type on the fly so that to do the injection
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestInjectionWithGenericArgumentType()
         {
             var c = TangFactory.GetTang().NewConfigurationBuilder()
@@ -351,7 +334,7 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
 
             var o = injector.GetInstance(interfaceOfMessageType);
 
-            Assert.IsTrue(o is MyOperatorImpl<int[]>);
+            Assert.True(o is MyOperatorImpl<int[]>);
         }
     }
 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/SmokeTest/RoundTripTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/SmokeTest/RoundTripTest.cs
@@ -15,24 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
+using Xunit;
 
 namespace Org.Apache.REEF.Tang.Tests.SmokeTest
 {
-    [TestClass]
     public abstract class RoundTripTest
     {
         public abstract IConfiguration RoundTrip(IConfiguration configuration);
 
-        [TestMethod]
-        public void TestRoundTrip() 
+        [Fact]
+        public virtual void TestRoundTrip() 
         {
             IConfiguration conf = ObjectTreeTest.GetConfiguration();
             IRootInterface before = TangFactory.GetTang().NewInjector(conf).GetInstance<IRootInterface>();
             IRootInterface after = TangFactory.GetTang().NewInjector(RoundTrip(conf)).GetInstance<IRootInterface>();
-            Assert.AreEqual(before, after, "Configuration conversion to and from Avro datatypes failed.");
+            Assert.True(before.Equals(after), "Configuration conversion to and from Avro datatypes failed.");
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Tang/TestTang.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Tang/TestTang.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Reflection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Examples;
 using Org.Apache.REEF.Tang.Exceptions;
@@ -27,52 +26,36 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Types;
 using Org.Apache.REEF.Tang.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Tang.Tests.Tang
 {
-    [TestClass]
     public class TestTang
     {
         private static ITang tang;
 
         private static Assembly asm = null;
 
-        [ClassInitialize]
-        public static void ClassSetup(TestContext context)
+        public TestTang()
         {
             asm = Assembly.Load(FileNames.Examples);
-        }
-
-        [ClassCleanup]
-        public static void ClassCleanup()
-        {
-        }
-
-        [TestInitialize]
-        public void TestSetup()
-        {
             MustBeSingleton.alreadyInstantiated = false;
             tang = TangFactory.GetTang();
         }
 
-        [TestCleanup]
-        public void TestCleanup()
-        {
-        }
-
-        [TestMethod]
+        [Fact]
         public void TestSingleton()
         {
             IInjector injector = tang.NewInjector();
-            Assert.IsNotNull(injector.GetInstance(typeof(TwoSingletons)));
-            Assert.IsNotNull(injector.GetInstance(typeof(TwoSingletons)));
+            Assert.NotNull(injector.GetInstance(typeof(TwoSingletons)));
+            Assert.NotNull(injector.GetInstance(typeof(TwoSingletons)));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNotSingleton()
         {
             TwoSingletons obj = null;
-            Assert.IsNotNull(tang.NewInjector().GetInstance(typeof(TwoSingletons)));
+            Assert.NotNull(tang.NewInjector().GetInstance(typeof(TwoSingletons)));
             try
             {
                 obj = (TwoSingletons)tang.NewInjector().GetInstance(typeof(TwoSingletons));
@@ -80,10 +63,10 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             catch (InjectionException)
             {
             }
-            Assert.IsNull(obj);
+            Assert.Null(obj);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestRepeatedAmbiguousArgs()
         {
             INode node = null;
@@ -97,10 +80,10 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             catch (ClassHierarchyException)
             {
             }
-            Assert.IsNull(node);
+            Assert.Null(node);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestRepeatedOKArgs()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
@@ -112,7 +95,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
         }
 
         // NamedParameter A has no default_value, so this should throw.
-        [TestMethod]
+        [Fact]
         public void TestOneNamedFailArgs()
         {
             string msg = null;
@@ -125,20 +108,20 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             catch (Exception)
             {
             }
-            Assert.IsNull(msg);
+            Assert.Null(msg);
         }
 
         // NamedParameter A get's bound to a volatile, so this should succeed.
-        [TestMethod]
+        [Fact]
         public void TestOneNamedSingletonOKArgs()
         {
             IInjector i = tang.NewInjector();
             i.BindVolatileParameter(GenericType<OneNamedSingletonArgs.A>.Class, i.GetInstance<MustBeSingleton>());
             OneNamedSingletonArgs o = i.GetInstance<OneNamedSingletonArgs>();
-            Assert.IsNotNull(o);
+            Assert.NotNull(o);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestRepeatedNamedArgs()
         {
             IInjector i = tang.NewInjector();
@@ -149,7 +132,7 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             i.GetInstance(typeof(RepeatedNamedSingletonArgs));
         }
 
-        [TestMethod]
+        [Fact]
         public void testStraightforwardBuild()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
@@ -157,16 +140,16 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             tang.NewInjector(cb.Build()).GetInstance(typeof(Interf));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestOneNamedStringArgCantRebind()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
             OneNamedStringArg a =
                 (OneNamedStringArg)tang.NewInjector(cb.Build()).GetInstance(typeof(OneNamedStringArg));
-            Assert.AreEqual("default", a.s);
+            Assert.Equal("default", a.s);
             cb.BindNamedParameter<OneNamedStringArg.A, string>(GenericType<OneNamedStringArg.A>.Class, "not default");
             IInjector i = tang.NewInjector(cb.Build());
-            Assert.AreEqual("not default", ((OneNamedStringArg)i.GetInstance(typeof(OneNamedStringArg))).s);
+            Assert.Equal("not default", ((OneNamedStringArg)i.GetInstance(typeof(OneNamedStringArg))).s);
             string msg = null;
             try
             {
@@ -177,69 +160,69 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             catch (Exception)
             {
             }
-            Assert.IsNull(msg);
+            Assert.Null(msg);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestOneNamedStringArgBind()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
             OneNamedStringArg a = tang.NewInjector(cb.Build()).GetInstance<OneNamedStringArg>();
-            Assert.AreEqual("default", a.s);
+            Assert.Equal("default", a.s);
             cb.BindNamedParameter<OneNamedStringArg.A, string>(GenericType<OneNamedStringArg.A>.Class, "not default");
             IInjector i = tang.NewInjector(cb.Build());
-            Assert.AreEqual("not default", i.GetInstance<OneNamedStringArg>().s);
+            Assert.Equal("not default", i.GetInstance<OneNamedStringArg>().s);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestOneNamedStringArgVolatile()
         {
             OneNamedStringArg a = tang.NewInjector().GetInstance<OneNamedStringArg>();
-            Assert.AreEqual("default", a.s);
+            Assert.Equal("default", a.s);
             IInjector i = tang.NewInjector();
             i.BindVolatileParameter(GenericType<OneNamedStringArg.A>.Class, "volatile");
-            Assert.AreEqual("volatile", i.GetInstance<OneNamedStringArg>().s);
+            Assert.Equal("volatile", i.GetInstance<OneNamedStringArg>().s);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTwoNamedStringArgsBind()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
             TwoNamedStringArgs a = tang.NewInjector(cb.Build()).GetInstance<TwoNamedStringArgs>();
-            Assert.AreEqual("defaultA", a.a);
-            Assert.AreEqual("defaultB", a.b);
+            Assert.Equal("defaultA", a.a);
+            Assert.Equal("defaultB", a.b);
             cb.BindNamedParameter<TwoNamedStringArgs.A, string>(GenericType<TwoNamedStringArgs.A>.Class, "not defaultA");
             cb.BindNamedParameter<TwoNamedStringArgs.B, string>(GenericType<TwoNamedStringArgs.B>.Class, "not defaultB");
             IInjector i = tang.NewInjector(cb.Build());
-            Assert.AreEqual("not defaultA",
+            Assert.Equal("not defaultA",
                             i.GetInstance<TwoNamedStringArgs>().a);
-            Assert.AreEqual("not defaultB",
+            Assert.Equal("not defaultB",
                             i.GetInstance<TwoNamedStringArgs>().b);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTwoNamedStringArgsBindVolatile()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
             TwoNamedStringArgs a = tang.NewInjector(cb.Build()).GetInstance<TwoNamedStringArgs>();
-            Assert.AreEqual("defaultA", a.a);
-            Assert.AreEqual("defaultB", a.b);
+            Assert.Equal("defaultA", a.a);
+            Assert.Equal("defaultB", a.b);
             IInjector i = tang.NewInjector(cb.Build());
             i.BindVolatileParameter(GenericType<TwoNamedStringArgs.A>.Class, "not defaultA");
             i.BindVolatileParameter(GenericType<TwoNamedStringArgs.B>.Class, "not defaultB");
-            Assert.AreEqual("not defaultA",
+            Assert.Equal("not defaultA",
                             i.GetInstance<TwoNamedStringArgs>().a);
-            Assert.AreEqual("not defaultB",
+            Assert.Equal("not defaultB",
                             i.GetInstance<TwoNamedStringArgs>().b);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTwoNamedStringArgsReBindVolatileFail()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
             TwoNamedStringArgs a = tang.NewInjector(cb.Build()).GetInstance<TwoNamedStringArgs>();
-            Assert.AreEqual("defaultA", a.a);
-            Assert.AreEqual("defaultB", a.b);
+            Assert.Equal("defaultA", a.a);
+            Assert.Equal("defaultB", a.b);
             cb.BindNamedParameter<TwoNamedStringArgs.A, string>(GenericType<TwoNamedStringArgs.A>.Class, "not defaultA");
             cb.BindNamedParameter<TwoNamedStringArgs.B, string>(GenericType<TwoNamedStringArgs.B>.Class, "not defaultB");
             IInjector i = tang.NewInjector(cb.Build());
@@ -254,19 +237,19 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             catch (Exception)
             {
             }
-            Assert.IsNull(msg);
+            Assert.Null(msg);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestBextendsAinjectA()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
             cb.BindImplementation(GenericType<BextendsAinjectA.A>.Class, GenericType<BextendsAinjectA.A>.Class);
             BextendsAinjectA.A a = tang.NewInjector(cb.Build()).GetInstance<BextendsAinjectA.A>();
-            Assert.IsNotNull(a);
+            Assert.NotNull(a);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNamedImpl()
         {
             ICsConfigurationBuilder cb = TangFactory.GetTang().NewConfigurationBuilder(new string[] { FileNames.Examples });
@@ -278,41 +261,41 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             Aimpl a2 = (Aimpl)i.GetNamedInstance<AImplName, INamedImplA>(GenericType<AImplName>.Class);
             Bimpl b1 = (Bimpl)i.GetNamedInstance<BImplName, INamedImplA>(GenericType<BImplName>.Class);
             Bimpl b2 = (Bimpl)i.GetNamedInstance<BImplName, INamedImplA>(GenericType<BImplName>.Class);
-            Assert.AreSame(a1, a2);
-            Assert.AreSame(b1, b2);
+            Assert.Same(a1, a2);
+            Assert.Same(b1, b2);
         }
 
-        [TestMethod]
+        [Fact]
         public void testThreeConstructors() 
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
             cb.BindNamedParameter<ThreeConstructors.TCInt, int>(GenericType<ThreeConstructors.TCInt>.Class, "1");
             cb.BindNamedParameter<ThreeConstructors.TCString, string>(GenericType<ThreeConstructors.TCString>.Class, "s");
             ThreeConstructors tc = tang.NewInjector(cb.Build()).GetInstance<ThreeConstructors>();
-            Assert.AreEqual(1, tc.i);
-            Assert.AreEqual("s", tc.s);
+            Assert.Equal(1, tc.i);
+            Assert.Equal("s", tc.s);
     
             cb = tang.NewConfigurationBuilder();
             cb.BindNamedParameter<ThreeConstructors.TCInt, int>(GenericType<ThreeConstructors.TCInt>.Class, "1");
             tc = tang.NewInjector(cb.Build()).GetInstance<ThreeConstructors>();
-            Assert.AreEqual(1, tc.i);
-            Assert.AreEqual("default", tc.s);
+            Assert.Equal(1, tc.i);
+            Assert.Equal("default", tc.s);
 
             cb = tang.NewConfigurationBuilder();
             cb.BindNamedParameter<ThreeConstructors.TCString, string>(GenericType<ThreeConstructors.TCString>.Class, "s");
             tc = tang.NewInjector(cb.Build()).GetInstance<ThreeConstructors>();
-            Assert.AreEqual(-1, tc.i);
-            Assert.AreEqual("s", tc.s);
+            Assert.Equal(-1, tc.i);
+            Assert.Equal("s", tc.s);
 
             cb = tang.NewConfigurationBuilder();
             cb.BindNamedParameter<ThreeConstructors.TCFloat, float>(GenericType<ThreeConstructors.TCFloat>.Class, "2");
             tc = tang.NewInjector(cb.Build()).GetInstance<ThreeConstructors>();
-            Assert.AreEqual(-1, tc.i);
-            Assert.AreEqual("default", tc.s);
-            Assert.AreEqual(2.0f, tc.f, 1e-9);
+            Assert.Equal(-1, tc.i);
+            Assert.Equal("default", tc.s);
+            Assert.Equal(2.0f, tc.f, 9);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestThreeConstructorsAmbiguous()
         {
             string msg = null;
@@ -335,10 +318,10 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             {
                 System.Diagnostics.Debug.WriteLine(e);
             }
-            Assert.IsNull(msg);
+            Assert.Null(msg);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTwoConstructorsAmbiguous()
         {
             string msg = null;
@@ -357,10 +340,10 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             {
                 System.Diagnostics.Debug.WriteLine(e); 
             }
-            Assert.IsNull(msg);
+            Assert.Null(msg);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSingletonWithMultipleConstructors() 
         {
             ICsConfigurationBuilder cb = TangFactory.GetTang().NewConfigurationBuilder();
@@ -368,10 +351,10 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             cb.BindNamedParameter<SingletonMultiConst.A, string>(GenericType<SingletonMultiConst.A>.Class, "foo");
             IInjector i = TangFactory.GetTang().NewInjector(cb.Build());
             var o = i.GetInstance<SMC>();
-            Assert.IsNotNull(o);
+            Assert.NotNull(o);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSingletonWithMoreSpecificConstructors()
         {
             ICsConfigurationBuilder cb = TangFactory.GetTang().NewConfigurationBuilder();
@@ -380,19 +363,19 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             cb.BindNamedParameter<SingletonMultiConst.B, string>(GenericType<SingletonMultiConst.B>.Class, "bar");
             IInjector i = TangFactory.GetTang().NewInjector(cb.Build());
             var o = i.GetInstance<SMC>();
-            Assert.IsNotNull(o);
+            Assert.NotNull(o);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestInjectInjector()
         {
             IInjector i = TangFactory.GetTang().NewInjector();
             var ii = (InjectInjector)i.GetInstance(typeof(InjectInjector));
-            //// Assert.IsTrue(ii.i is IInjector);
-            Assert.AreNotSame(i, ii.i);
+            //// Assert.True(ii.i is IInjector);
+            Assert.NotSame(i, ii.i);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGenericEventHandlers()
         {
             ICsConfigurationBuilder cba = TangFactory.GetTang().NewConfigurationBuilder();
@@ -404,23 +387,23 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             TangFactory.GetTang().NewInjector(cbb.Build()).GetNamedInstance(typeof(ABCName.XName));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGenericEventHandlerDefaults() 
         {
             ICsConfigurationBuilder cba = TangFactory.GetTang().NewConfigurationBuilder();
             var xbb = TangFactory.GetTang().NewInjector(cba.Build()).GetNamedInstance(typeof(ABCName.XNameDB));
-            Assert.IsTrue(xbb is ABCName.XBB);
+            Assert.True(xbb is ABCName.XBB);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGenericEventHandlerDefaultsGoodTreeIndirection() 
         {
             ICsConfigurationBuilder cba = TangFactory.GetTang().NewConfigurationBuilder();
             var o = TangFactory.GetTang().NewInjector(cba.Build()).GetNamedInstance(typeof(ABCName.XNameDDAA));
-            Assert.IsTrue(o is ABCName.XXBB);
+            Assert.True(o is ABCName.XXBB);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGenericUnrelatedGenericTypeParameters() 
         {
             string msg = null;
@@ -435,26 +418,26 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             {
                 System.Diagnostics.Debug.WriteLine(e);
             }    
-            Assert.IsNull(msg);        
+            Assert.Null(msg);        
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGenericInterfaceUnboundTypeParametersName()
         {
             ICsConfigurationBuilder cba = TangFactory.GetTang().NewConfigurationBuilder();
             var o = TangFactory.GetTang().NewInjector(cba.Build()).GetNamedInstance(typeof(FooEventHandler));
-            Assert.IsTrue(o is MyEventHandler<Foo>);
+            Assert.True(o is MyEventHandler<Foo>);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGenericInterfaceUnboundTypeParametersNameIface()
         {
             ICsConfigurationBuilder cba = TangFactory.GetTang().NewConfigurationBuilder();
             var o = TangFactory.GetTang().NewInjector(cba.Build()).GetNamedInstance(typeof(IfaceEventHandler));
-            Assert.IsTrue(o is IEventHandler<SomeIface>);
+            Assert.True(o is IEventHandler<SomeIface>);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGenericInterfaceUnboundTypeParametersIface()
         {
             string msg = null;
@@ -469,29 +452,29 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             {
                 System.Diagnostics.Debug.WriteLine(e);
             }    
-            Assert.IsNull(msg);    
+            Assert.Null(msg);    
         }
 
-        [TestMethod]
+        [Fact]
         public void TestWantSomeHandlers() 
         {
             var o = TangFactory.GetTang().NewInjector().GetInstance<WantSomeHandlers>();
-            Assert.IsNotNull(o);
+            Assert.NotNull(o);
         }
         
-        [TestMethod]
+        [Fact]
         public void TestWantSomeHandlersBadOrder() 
         {
             IInjector i = TangFactory.GetTang().NewInjector();
             var o1 = i.GetInstance<IAHandler>();
             var o2 = i.GetInstance<IBHandler>();
             var o3 = i.GetInstance<WantSomeFutureHandlers>();
-            Assert.IsTrue(o1 is AHandlerImpl);            
-            Assert.IsTrue(o2 is BHandlerImpl);
-            Assert.IsNotNull(o3);
+            Assert.True(o1 is AHandlerImpl);            
+            Assert.True(o2 is BHandlerImpl);
+            Assert.NotNull(o3);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestWantSomeFutureHandlersAlreadyBoundVolatile() 
         {
             IInjector i = TangFactory.GetTang().NewInjector();
@@ -500,26 +483,26 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             i.GetInstance<WantSomeFutureHandlers>();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestWantSomeFutureHandlers() 
         {
             TangFactory.GetTang().NewInjector().GetInstance<WantSomeFutureHandlers>();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestWantSomeFutureHandlersName() 
         {
             TangFactory.GetTang().NewInjector().GetInstance<WantSomeFutureHandlersName>();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestReuseFailedInjector() 
         {
             IInjector i = TangFactory.GetTang().NewInjector();
             try 
             {
                 i.GetInstance<Fail>();
-                Assert.Fail("Injecting Fail should not have worked!");
+                Assert.True(false, "Injecting Fail should not have worked!");
             } 
             catch (InjectionException) 
             {
@@ -527,30 +510,30 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMultipleLayersFromAbstractClass()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
             cb.BindImplementation(GenericType<MultiLayer>.Class, GenericType<LowerLayer>.Class);
             MultiLayer o = tang.NewInjector(cb.Build()).GetInstance<MultiLayer>();
-            Assert.IsNotNull(o);
+            Assert.NotNull(o);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMultipleLayersFromInterface()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder();
             cb.BindImplementation(GenericType<IMultiLayer>.Class, GenericType<LowerLayerImpl>.Class);
             IMultiLayer o = tang.NewInjector(cb.Build()).GetInstance<IMultiLayer>();
-            Assert.IsNotNull(o);
+            Assert.NotNull(o);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestEmptyStringAsDefaultValue()
         {
             ICsConfigurationBuilder cb = tang.NewConfigurationBuilder(EmptyStringAsDefaultParamConf.ConfigurationModule.Build());
             var value = tang.NewInjector(cb.Build()).GetNamedInstance<EmptyStringAsDefaultParam, string>();
-            Assert.IsNotNull(value.Equals(string.Empty));
+            Assert.NotNull(value.Equals(string.Empty));
         }
     }
 
@@ -832,8 +815,8 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             [Inject]
             private ABtaker([Parameter(typeof(AImplName))] INamedImplA a, [Parameter(typeof(BImplName))] INamedImplA b)
             {
-                // Assert.IsTrue(a is Aimpl, "AImplName must be instance of Aimpl");
-                // Assert.IsTrue(b is Bimpl, "BImplName must be instance of Bimpl");
+                // Assert.True(a is Aimpl, "AImplName must be instance of Aimpl");
+                // Assert.True(b is Bimpl, "BImplName must be instance of Bimpl");
             }
         }
     }


### PR DESCRIPTION
This change:
 * migrates previously unmigrated O.A.R.Tang.Tests to xUnit
 * migrates O.A.R.Client.Tests which was introduced after REEF-1033 to xUnit

JIRA:
  [REEF-1031](https://issues.apache.org/jira/browse/REEF-1031)

Pull request:
  This closes #