### PR TITLE
[REEF-1179] Pass Mesos Integration Tests

### DIFF
--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosResourceLaunchHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosResourceLaunchHandler.java
@@ -21,8 +21,6 @@ package org.apache.reef.runtime.mesos.driver;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.evaluator.EvaluatorProcess;
-import org.apache.reef.io.TempFileCreator;
-import org.apache.reef.io.WorkingDirectoryTempFileCreator;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
 import org.apache.reef.runtime.common.files.ClasspathProvider;
@@ -85,7 +83,6 @@ final class MesosResourceLaunchHandler implements ResourceLaunchHandler {
 
       final Configuration evaluatorConfiguration = Tang.Factory.getTang()
           .newConfigurationBuilder(resourceLaunchEvent.getEvaluatorConf())
-          .bindImplementation(TempFileCreator.class, WorkingDirectoryTempFileCreator.class)
           .build();
 
       final File configurationFile = new File(

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFScheduler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFScheduler.java
@@ -395,6 +395,7 @@ final class REEFScheduler implements Scheduler {
         .setNodeId(taskStatus.getSlaveId().getValue())
         .setResourceMemory(resourceRequestProto.getMemorySize().get())
         .setVirtualCores(resourceRequestProto.getVirtualCores().get())
+        .setRuntimeName(RuntimeIdentifier.RUNTIME_NAME)
         .build();
     reefEventHandlers.onResourceAllocation(alloc);
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultRemoteManagerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultRemoteManagerFactory.java
@@ -19,6 +19,7 @@
 package org.apache.reef.wake.remote;
 
 import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.wake.EventHandler;
@@ -32,8 +33,6 @@ import javax.inject.Inject;
  * Default implementation of RemoteManagerFactory.
  */
 final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
-
-  private final Injector injector;
 
   private final Codec<?> codec;
   private final EventHandler<Throwable> errorHandler;
@@ -53,9 +52,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
       @Parameter(RemoteConfiguration.RetryTimeout.class) final int retryTimeout,
       final LocalAddressProvider localAddressProvider,
       final TransportFactory tpFactory,
-      final TcpPortProvider tcpPortProvider,
-      final Injector injector) {
-    this.injector = injector.forkInjector();
+      final TcpPortProvider tcpPortProvider) {
     this.codec = codec;
     this.errorHandler = errorHandler;
     this.orderingGuarantee = orderingGuarantee;
@@ -69,7 +66,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
   @Override
   public RemoteManager getInstance(final String name) {
     try {
-      final Injector newInjector = injector.forkInjector();
+      final Injector newInjector = Tang.Factory.getTang().newInjector();
       newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
       newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, this.codec);
       newInjector.bindVolatileParameter(RemoteConfiguration.ErrorHandler.class, this.errorHandler);
@@ -98,7 +95,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
                                        final LocalAddressProvider localAddressProvider,
                                        final TcpPortProvider tcpPortProvider) {
     try {
-      final Injector newInjector = injector.forkInjector();
+      final Injector newInjector = Tang.Factory.getTang().newInjector();
       newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
       newInjector.bindVolatileParameter(RemoteConfiguration.HostAddress.class, hostAddress);
       newInjector.bindVolatileParameter(RemoteConfiguration.Port.class, listeningPort);
@@ -127,7 +124,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
                                        final int numberOfTries,
                                        final int retryTimeout) {
     try {
-      final Injector newInjector = injector.forkInjector();
+      final Injector newInjector = Tang.Factory.getTang().newInjector();
       newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
       newInjector.bindVolatileParameter(RemoteConfiguration.HostAddress.class, hostAddress);
       newInjector.bindVolatileParameter(RemoteConfiguration.Port.class, listeningPort);
@@ -150,7 +147,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
   public <T> RemoteManager getInstance(
       final String name, final Codec<T> codec, final EventHandler<Throwable> errorHandler) {
     try {
-      final Injector newInjector = injector.forkInjector();
+      final Injector newInjector = Tang.Factory.getTang().newInjector();
       newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
       newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, codec);
       newInjector.bindVolatileParameter(RemoteConfiguration.ErrorHandler.class, errorHandler);
@@ -173,7 +170,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
                                        final Codec<T> codec,
                                        final EventHandler<Throwable> errorHandler) {
     try {
-      final Injector newInjector = injector.forkInjector();
+      final Injector newInjector = Tang.Factory.getTang().newInjector();
       newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
       newInjector.bindVolatileParameter(RemoteConfiguration.Port.class, listeningPort);
       newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, codec);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultRemoteManagerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultRemoteManagerFactory.java
@@ -34,6 +34,8 @@ import javax.inject.Inject;
  */
 final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
 
+  private final Injector injector;
+
   private final Codec<?> codec;
   private final EventHandler<Throwable> errorHandler;
   private final boolean orderingGuarantee;
@@ -53,6 +55,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
       final LocalAddressProvider localAddressProvider,
       final TransportFactory tpFactory,
       final TcpPortProvider tcpPortProvider) {
+    this.injector = Tang.Factory.getTang().newInjector();
     this.codec = codec;
     this.errorHandler = errorHandler;
     this.orderingGuarantee = orderingGuarantee;
@@ -66,7 +69,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
   @Override
   public RemoteManager getInstance(final String name) {
     try {
-      final Injector newInjector = Tang.Factory.getTang().newInjector();
+      final Injector newInjector = injector.forkInjector();
       newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
       newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, this.codec);
       newInjector.bindVolatileParameter(RemoteConfiguration.ErrorHandler.class, this.errorHandler);
@@ -95,7 +98,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
                                        final LocalAddressProvider localAddressProvider,
                                        final TcpPortProvider tcpPortProvider) {
     try {
-      final Injector newInjector = Tang.Factory.getTang().newInjector();
+      final Injector newInjector = injector.forkInjector();
       newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
       newInjector.bindVolatileParameter(RemoteConfiguration.HostAddress.class, hostAddress);
       newInjector.bindVolatileParameter(RemoteConfiguration.Port.class, listeningPort);
@@ -124,7 +127,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
                                        final int numberOfTries,
                                        final int retryTimeout) {
     try {
-      final Injector newInjector = Tang.Factory.getTang().newInjector();
+      final Injector newInjector = injector.forkInjector();
       newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
       newInjector.bindVolatileParameter(RemoteConfiguration.HostAddress.class, hostAddress);
       newInjector.bindVolatileParameter(RemoteConfiguration.Port.class, listeningPort);
@@ -147,7 +150,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
   public <T> RemoteManager getInstance(
       final String name, final Codec<T> codec, final EventHandler<Throwable> errorHandler) {
     try {
-      final Injector newInjector = Tang.Factory.getTang().newInjector();
+      final Injector newInjector = injector.forkInjector();
       newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
       newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, codec);
       newInjector.bindVolatileParameter(RemoteConfiguration.ErrorHandler.class, errorHandler);
@@ -170,7 +173,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
                                        final Codec<T> codec,
                                        final EventHandler<Throwable> errorHandler) {
     try {
-      final Injector newInjector = Tang.Factory.getTang().newInjector();
+      final Injector newInjector = injector.forkInjector();
       newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
       newInjector.bindVolatileParameter(RemoteConfiguration.Port.class, listeningPort);
       newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, codec);


### PR DESCRIPTION
This fixes the following missing parts from the previous commits:
  * Mesos needs to replace RemoteConfiguration.ManagerName.
    Do not use the given injector having `REEF_LAUNCHER`.
    - [REEF-991] Remove deprecated RangeTcpPortProvider.Default
      and DefaultRemoteManagerImplementation constructor
  * Adds Runtime Identifier to Mesos Runtime.
    - [REEF-983] Add Runtime Identifier to the EvaluatorDescriptor
  * Removes TempFileCreator binding.
    - [REEF-1013] C# Evaluator does not work on HDInsight