### PR TITLE
[REEF-1029] Migrate O.A.R.Tests\Functional to xUnit

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
@@ -16,44 +16,38 @@
 // under the License.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Examples.AllHandlers;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Bridge
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public class TestBridgeClient : ReefFunctionalTest
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(TestBridgeClient));
 
-        [TestInitialize]
-        public void TestSetup()
+        public TestBridgeClient()
         {
             Init();
         }
 
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            Console.WriteLine("Post test check and clean up");
-        }
-
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Run CLR Bridge on local runtime")]
-        [DeploymentItem(@".")]
-        [Ignore] // this test needs to be run on Yarn environment with test framework installed.
+        [Fact(Skip = "Requires Yarn")]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Run CLR Bridge on Yarn")]
         public void CanRunClrBridgeExampleOnYarn()
         {
             string testRuntimeFolder = DefaultRuntimeFolder + TestNumber++;
             RunClrBridgeClient(true, testRuntimeFolder);
         }
 
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Run CLR Bridge on local runtime")]
-        [DeploymentItem(@".")]
-        [Timeout(180 * 1000)]
+        [Fact(Skip = "Test broken, ignoring to unblock xUnit migration. TODO[JIRA REEF-1185]")]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Run CLR Bridge on local runtime")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void CanRunClrBridgeExampleOnLocalRuntime()
         {
             string testRuntimeFolder = DefaultRuntimeFolder + TestNumber++;
@@ -68,7 +62,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
 
             var uri = driverHttpEndpoint.DriverUrl + "NRT/status?a=1&b=2";
             var strStatus = driverHttpEndpoint.GetUrlResult(uri);
-            Assert.IsTrue(strStatus.Equals("Byte array returned from HelloHttpHandler in CLR!!!\r\n"));
+            Assert.True(strStatus.Equals("Byte array returned from HelloHttpHandler in CLR!!!\r\n"));
 
             await((JobSubmissionResult)driverHttpEndpoint).TryUntilNoConnection(uri);
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
@@ -16,7 +16,6 @@
 // under the License.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
@@ -26,30 +25,25 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Bridge
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public sealed class TestFailedEvaluatorEventHandler : ReefFunctionalTest
     {
         private const string FailedEvaluatorMessage = "I have succeeded in seeing a failed evaluator.";
 
-        [TestInitialize]
-        public void TestSetup()
+        public TestFailedEvaluatorEventHandler()
         {
             Init();
         }
 
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            CleanUp();
-        }
-
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test invocation of FailedEvaluatorHandler")]
-        [DeploymentItem(@".")]
-        [Timeout(180 * 1000)]
+        [Fact]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Test invocation of FailedEvaluatorHandler")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestFailedEvaluatorEventHandlerOnLocalRuntime()
         {
             string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
@@ -16,7 +16,6 @@
 // under the License.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
@@ -27,30 +26,25 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Bridge
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public sealed class TestFailedTaskEventHandler : ReefFunctionalTest
     {
         private const string FailedTaskMessage = "I have successfully seen a failed task.";
 
-        [TestInitialize]
-        public void TestSetup()
+        public TestFailedTaskEventHandler()
         {
             Init();
         }
 
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            CleanUp();
-        }
-
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test invocation of FailedTaskHandler")]
-        [DeploymentItem(@".")]
-        [Timeout(180 * 1000)]
+        [Fact]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Test invocation of FailedTaskHandler")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestFailedTaskEventHandlerOnLocalRuntime()
         {
             string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleContext.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleContext.cs
@@ -16,7 +16,6 @@
 // under the License.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
@@ -31,10 +30,11 @@ using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
 using ContextConfiguration = Org.Apache.REEF.Common.Context.ContextConfiguration;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Bridge
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public sealed class TestSimpleContext : ReefFunctionalTest
     {
         private const string ContextId = "ContextId";
@@ -42,8 +42,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
 
         private static readonly Logger Logger = Logger.GetLogger(typeof(TestSimpleContext));
 
-        [TestInitialize]
-        public void TestSetup()
+        public TestSimpleContext()
         {
             Init();
         }
@@ -51,10 +50,11 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         /// <summary>
         /// Does a simple test of context submission.
         /// </summary>
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test Context ID submission on local runtime")]
-        [DeploymentItem(@".")]
-        [Timeout(180 * 1000)]
+        [Fact]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Test Context ID submission on local runtime")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestSimpleContextOnLocalRuntime()
         {
             TestContextOnLocalRuntime(ContextDriverConfiguration());
@@ -63,10 +63,11 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         /// <summary>
         /// Does a simple test of context submission with deprecated configurations.
         /// </summary>
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test deprecated Context ID submission on local runtime")]
-        [DeploymentItem(@".")]
-        [Timeout(180 * 1000)]
+        [Fact]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Test deprecated Context ID submission on local runtime")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestDeprecatedContextOnLocalRuntime()
         {
             TestContextOnLocalRuntime(DeprecatedContextDriverConfiguration());

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
@@ -18,7 +18,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Defaults;
 using Org.Apache.REEF.Examples.AllHandlers;
@@ -28,22 +27,23 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Bridge
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public class TestSimpleEventHandlers : ReefFunctionalTest
     {
-        [TestInitialize]
-        public void TestSetup()
+        public TestSimpleEventHandlers()
         {
             Init();
         }
 
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test Hello Handler on local runtime")]
-        [DeploymentItem(@".")]
-        [Timeout(180 * 1000)]
+        [Fact]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Test Hello Handler on local runtime")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void RunSimpleEventHandlerOnLocalRuntime()
         {
             string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Driver/TestDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Driver/TestDriver.cs
@@ -16,27 +16,20 @@
 // under the License.
 
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Defaults;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Driver
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public class TestDriver : ReefFunctionalTest
     {
-        [TestInitialize]
-        public void TestSetup()
-        {
-            CleanUp();
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
+        public TestDriver()
         {
             CleanUp();
         }
@@ -44,10 +37,11 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
         /// <summary>
         /// This is to test DriverTestStartHandler. No evaluator and tasks are involved.
         /// </summary>
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test DriverTestStartHandler. No evaluator and tasks are invoked")]
-        [DeploymentItem(@".")]
-        [Timeout(180 * 1000)]
+        [Fact]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Test DriverTestStartHandler. No evaluator and tasks are invoked")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestDriverStart()
         {
             string testFolder = DefaultRuntimeFolder + TestNumber++;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/BroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/BroadcastReduceTest.cs
@@ -16,7 +16,6 @@
 // under the License.
 
 using System.Globalization;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Network.Examples.GroupCommunication;
@@ -28,25 +27,19 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Group
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public class BroadcastReduceTest : ReefFunctionalTest
     {
-        [TestInitialize]
-        public void TestSetup()
+        public BroadcastReduceTest()
         {
             CleanUp();
         }
 
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            CleanUp();
-        }
-
-        [TestMethod]
+        [Fact]
         public void TestBroadcastAndReduceOnLocalRuntime()
         {
             int numTasks = 9;
@@ -56,8 +49,7 @@ namespace Org.Apache.REEF.Tests.Functional.Group
             ValidateSuccessForLocalRuntime(numTasks, testFolder: testFolder);
         }
 
-        [Ignore]
-        [TestMethod]
+        [Fact(Skip = "Requires Yarn")]
         public void TestBroadcastAndReduceOnYarn()
         {
             int numTasks = 9;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/PipelinedBroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/PipelinedBroadcastReduceTest.cs
@@ -16,7 +16,6 @@
 // under the License.
 
 using System.Globalization;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Network.Examples.GroupCommunication;
@@ -28,25 +27,19 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Group
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public class PipelinedBroadcastReduceTest : ReefFunctionalTest
     {
-        [TestInitialize]
-        public void TestSetup()
+        public PipelinedBroadcastReduceTest()
         {
             CleanUp();
         }
 
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            CleanUp();
-        }
-
-        [TestMethod]
+        [Fact]
         public void TestPipelinedBroadcastAndReduceOnLocalRuntime()
         {
             const int numTasks = 9;
@@ -56,8 +49,7 @@ namespace Org.Apache.REEF.Tests.Functional.Group
             ValidateSuccessForLocalRuntime(numTasks, testFolder: testFolder);
         }
 
-        [Ignore]
-        [TestMethod]
+        [Fact(Skip = "Requires Yarn")]
         public void TestPipelinedBroadcastAndReduceOnYarn()
         {
             const int numTasks = 9;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
@@ -16,7 +16,6 @@
 // under the License.
 
 using System.Globalization;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Network.Examples.GroupCommunication;
@@ -28,25 +27,19 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Group
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public class ScatterReduceTest : ReefFunctionalTest
     {
-        [TestInitialize]
-        public void TestSetup()
+        public ScatterReduceTest()
         {
             CleanUp();
         }
 
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            CleanUp();
-        }
-
-        [TestMethod]
+        [Fact]
         public void TestScatterAndReduceOnLocalRuntime()
         {
             int numTasks = 5;
@@ -56,8 +49,7 @@ namespace Org.Apache.REEF.Tests.Functional.Group
             ValidateSuccessForLocalRuntime(numTasks, testFolder: testFolder);
         }
 
-        [Ignore]
-        [TestMethod]
+        [Fact(Skip = "Requires Yarn")]
         public void TestScatterAndReduceOnYarn()
         {
             int numTasks = 5;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
@@ -19,7 +19,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Driver.Bridge;
@@ -32,10 +31,11 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public class TestKMeans : ReefFunctionalTest
     {
         private const int K = 3;
@@ -46,8 +46,7 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
         private readonly bool _useSmallDataSet = false;
         private string _dataFile = MouseDataFile;
 
-        [TestInitialize]
-        public void TestSetup()
+        public TestKMeans()
         {
             if (_useSmallDataSet)
             {
@@ -58,19 +57,11 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
             Init();
         }
 
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            Console.WriteLine("Post test check and clean up");
-            CleanUp();
-        }
-
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test KMeans clustering with things directly run without reef")]
-        [DeploymentItem(@".")]
-        [DeploymentItem(@"Data", ".")]
-        [Ignore]
-        [Timeout(180 * 1000)]
+        [Fact(Skip = "TODO[JIRA REEF-1183] Requires data files not present in enlistment")]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Test KMeans clustering with things directly run without reef")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestKMeansOnDirectRunViaFileSystem()
         {
             int iteration = 0;
@@ -116,12 +107,11 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
             }
         }
 
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test KMeans clustering on reef local runtime with group communications")]
-        [DeploymentItem(@".")]
-        [DeploymentItem(@"Data", ".")]
-        [Ignore]
-        [Timeout(180 * 1000)]
+        [Fact(Skip = "TODO[JIRA REEF-1183] Requires data files not present in enlistment")]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Test KMeans clustering on reef local runtime with group communications")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestKMeansOnLocalRuntimeWithGroupCommunications()
         {
             IsOnLocalRuntime = true;
@@ -131,17 +121,16 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
             ValidateSuccessForLocalRuntime(Partitions + 1, testFolder: testFolder);
         }
 
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test KMeans clustering on reef YARN runtime - one box")]
-        [DeploymentItem(@".")]
-        [DeploymentItem(@"Data", ".")]
-        [Timeout(180 * 1000)]
-        [Ignore]    // ignored by default
+        [Fact(Skip = "TODO[JIRA REEF-1183] Requires data files not present in enlistment")]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Test KMeans clustering on reef YARN runtime - one box")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestKMeansOnYarnOneBoxWithGroupCommunications()
         {
             string testFolder = DefaultRuntimeFolder + TestNumber++;
             TestRun(DriverConfiguration(), typeof(KMeansDriverHandlers), Partitions + 1, "KMeansDriverHandlers", "yarn", testFolder);
-            Assert.IsNotNull("BreakPointChecker");
+            Assert.NotNull("BreakPointChecker");
         }
 
         private IConfiguration DriverConfiguration()

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/TestTaskMessage.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/TestTaskMessage.cs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Defaults;
@@ -25,33 +24,28 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Messaging
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public class TestTaskMessage : ReefFunctionalTest
     {
-        [TestInitialize]
-        public void TestSetup()
+        public TestTaskMessage()
         {
             CleanUp();
             Init();
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            CleanUp();
         }
 
         /// <summary>
         /// This test is to test both task message and driver message. The messages are sent 
         /// from one side and received in the corresponding handlers and verified in the test 
         /// </summary>
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test task message and driver message")]
-        [DeploymentItem(@".")]
-        [Timeout(180 * 1000)]
+        [Fact]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Test task message and driver message")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestSendTaskMessage()
         {
             string testFolder = DefaultRuntimeFolder + TestNumber++;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -37,7 +37,7 @@ using Timer = System.Timers.Timer;
 
 namespace Org.Apache.REEF.Tests.Functional
 {
-    public class ReefFunctionalTest
+    public class ReefFunctionalTest : IDisposable
     {
         protected const string _stdout = "driver.stdout";
         protected const string _stderr = "driver.stderr";
@@ -131,6 +131,11 @@ namespace Org.Apache.REEF.Tests.Functional
             {
                 // do not fail if clean up is unsuccessful
             }   
+        }
+
+        public void Dispose() 
+        {
+            CleanUp();
         }
 
         protected void ValidateSuccessForLocalRuntime(int numberOfEvaluatorsToClose, int numberOfTasksToFail = 0, int numberOfEvaluatorsToFail = 0, string testFolder = DefaultRuntimeFolder)

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTest.cs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Defaults;
@@ -26,20 +25,14 @@ using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Tests.Functional.Messaging;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Driver
 {
-    [TestClass]
+    [Collection("FunctionalTests")]
     public class RuntimeNameTest : ReefFunctionalTest
     {
-        [TestInitialize]
-        public void TestSetup()
-        {
-            CleanUp();
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
+        public RuntimeNameTest()
         {
             CleanUp();
         }
@@ -47,10 +40,11 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
         /// <summary>
         /// This is to test DriverTestStartHandler. No evaluator and tasks are involved.
         /// </summary>
-        [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test TestRuntimeName. Validates that runtime name is propagated to c#")]
-        [DeploymentItem(@".")]
-        [Timeout(180 * 1000)]
+        [Fact]
+        [Trait("Priority", "1")]
+        [Trait("Category", "FunctionalGated")]
+        [Trait("Description", "Test TestRuntimeName. Validates that runtime name is propagated to c#")]
+        //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestRuntimeName()
         {
             string testFolder = DefaultRuntimeFolder + TestNumber++;


### PR DESCRIPTION
This change:
 * migrates O.A.R.Tests\Functional to xUnit
 * configures failing CanRunClrBridgeExampleOnLocalRuntime
   test to be ignored (see REEF-1185)

JIRA:
  [REEF-1029](https://issues.apache.org/jira/browse/REEF-1029)

Pull request:
  This closes #