### PR TITLE
[REEF-547] Mark RemoteManager.registerErrorHandler as deprecated

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
@@ -69,6 +69,10 @@ public class RemoteManager {
   }
 
   // TODO[JIRA REEF-547]: This method uses deprecated raw.registerErrorHandler.
+  /**
+   * @deprecated in 0.14, will be deleted in 0.15
+   */
+  @Deprecated
   public AutoCloseable registerErrorHandler(final EventHandler<Exception> theHandler) {
     return this.raw.registerErrorHandler(theHandler);
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManager.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManager.java
@@ -83,6 +83,7 @@ public interface RemoteManager extends Stage {
    *
    * @param theHandler the exception event handler
    * @return the subscription that can be used to unsubscribe later
+   * @deprecated before 0.14, will be deleted in 0.15
    */
   @Deprecated
   AutoCloseable registerErrorHandler(final EventHandler<Exception> theHandler);


### PR DESCRIPTION
This method is unused and wraps a deprecated method.
This change does NOT close REEF-547

JIRA:
  [REEF-547](https://issues.apache.org/jira/browse/REEF-547)

Pull request:
  This closes #