### PR TITLE
[REEF-1195] YARNClientConfiguration is broken for on-cluster YARN sub…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNClientConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNClientConfiguration.cs
@@ -37,6 +37,7 @@ namespace Org.Apache.REEF.Client.Yarn
 
         public static ConfigurationModule ConfigurationModule = new YARNClientConfiguration()
             .BindImplementation(GenericType<IREEFClient>.Class, GenericType<YarnREEFClient>.Class)
+            .BindImplementation(GenericType<IYarnRestClientCredential>.Class, YarnRestClientCredential)
             .BindNamedParameter(GenericType<JobSubmissionDirectoryPrefixParameter>.Class, JobSubmissionFolderPrefix)
             .BindNamedParameter(GenericType<SecurityTokenKindParameter>.Class, SecurityTokenKind)
             .BindNamedParameter(GenericType<SecurityTokenServiceParameter>.Class, SecurityTokenService)


### PR DESCRIPTION
…mission

This addressed the issue by
  * Bind IYarnRestClientCredential in ConfigurationModule.

JIRA:
  [REEF-1195](https://issues.apache.org/jira/browse/REEF-1195)