### PR TITLE
[REEF-1185] Fix CanRunClrBridgeExampleOnLocalRuntime test

### DIFF
--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/HelloTaskCompletedHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/HelloTaskCompletedHandler.cs
@@ -38,7 +38,10 @@ namespace Org.Apache.REEF.Examples.AllHandlers
         /// <param name="completedTask"></param>
         public void OnNext(ICompletedTask completedTask)
         {
-            Console.WriteLine("Received CompletedTask: {0}, with message [{1}].", completedTask.Id, ByteUtilities.ByteArraysToString(completedTask.Message));
+            Console.WriteLine("Received CompletedTask: {0}", completedTask.Id);
+            using (completedTask.ActiveContext)
+            {
+            }
         }
 
         public void OnError(Exception error)

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using System.Threading.Tasks;
 using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Examples.AllHandlers;
 using Org.Apache.REEF.Utilities.Logging;
@@ -37,27 +38,27 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         [Trait("Priority", "1")]
         [Trait("Category", "FunctionalGated")]
         [Trait("Description", "Run CLR Bridge on Yarn")]
-        public void CanRunClrBridgeExampleOnYarn()
+        public async Task CanRunClrBridgeExampleOnYarn()
         {
             string testRuntimeFolder = DefaultRuntimeFolder + TestNumber++;
-            RunClrBridgeClient(true, testRuntimeFolder);
+            await RunClrBridgeClient(true, testRuntimeFolder);
         }
 
-        [Fact(Skip = "Test broken, ignoring to unblock xUnit migration. TODO[JIRA REEF-1185]")]
+        [Fact]
         [Trait("Priority", "1")]
         [Trait("Category", "FunctionalGated")]
         [Trait("Description", "Run CLR Bridge on local runtime")]
         //// TODO[JIRA REEF-1184]: add timeout 180 sec
-        public void CanRunClrBridgeExampleOnLocalRuntime()
+        public async Task CanRunClrBridgeExampleOnLocalRuntime()
         {
             string testRuntimeFolder = DefaultRuntimeFolder + TestNumber++;
             CleanUp(testRuntimeFolder);
-            RunClrBridgeClient(false, testRuntimeFolder);
+            await RunClrBridgeClient(false, testRuntimeFolder);
         }
 
-        private async void RunClrBridgeClient(bool runOnYarn, string testRuntimeFolder)
+        private async Task RunClrBridgeClient(bool runOnYarn, string testRuntimeFolder)
         {
-            string[] a = new[] { runOnYarn ? "yarn" : "local", testRuntimeFolder };
+            string[] a = { runOnYarn ? "yarn" : "local", testRuntimeFolder };
             IJobSubmissionResult driverHttpEndpoint = AllHandlers.Run(a);
 
             var uri = driverHttpEndpoint.DriverUrl + "NRT/status?a=1&b=2";


### PR DESCRIPTION
This addressed the issue by
 * Fixing concurrency issues in TestBridgeClient
 * Fixing null reference in HelloTaskCompletedHandler
 * Disposing completed task's active context in HelloTaskCompletedHandler

JIRA:
  [REEF-1185](https://issues.apache.org/jira/browse/REEF-1185)