### PR TITLE
[REEF-1204] Interface separation between Job and Application Parameters

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client.Tests/YarnREEFParamSerializerTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/YarnREEFParamSerializerTests.cs
@@ -62,10 +62,10 @@ namespace Org.Apache.REEF.Client.Tests
             var injector = TangFactory.GetTang().NewInjector(tcpConf, driverConf);
 
             var serializer = injector.GetInstance<YarnREEFDotNetParamSerializer>();
-            var jobSubmission = injector.GetInstance<JobSubmissionBuilderFactory>()
-                .GetJobSubmissionBuilder().Build();
+            var jobRequest = injector.GetInstance<JobRequestBuilder>().Build();
 
-            var serializedBytes = serializer.SerializeAppArgsToBytes(jobSubmission, injector, AnyString);
+            var serializedBytes = serializer.SerializeAppArgsToBytes(
+                jobRequest.AppParameters, injector, AnyString);
             var expectedString = Encoding.UTF8.GetString(serializedBytes);
             var jsonObject = JObject.Parse(expectedString);
             var expectedJsonObject = JObject.Parse(expectedJson);
@@ -90,10 +90,9 @@ namespace Org.Apache.REEF.Client.Tests
             var injector = TangFactory.GetTang().NewInjector();
 
             var serializer = injector.GetInstance<YarnREEFDotNetParamSerializer>();
-            var jobSubmission = injector.GetInstance<JobSubmissionBuilderFactory>()
-                .GetJobSubmissionBuilder().SetJobIdentifier(AnyString).Build();
+            var jobRequest = injector.GetInstance<JobRequestBuilder>().SetJobIdentifier(AnyString).Build();
 
-            var serializedBytes = serializer.SerializeJobArgsToBytes(jobSubmission, AnyString, AnyString);
+            var serializedBytes = serializer.SerializeJobArgsToBytes(jobRequest.JobParameters, AnyString, AnyString);
             var expectedString = Encoding.UTF8.GetString(serializedBytes);
             var jsonObject = JObject.Parse(expectedString);
             var expectedJsonObject = JObject.Parse(expectedJson);
@@ -127,13 +126,12 @@ namespace Org.Apache.REEF.Client.Tests
             var injector = TangFactory.GetTang().NewInjector(tcpConf, driverConf);
 
             var serializer = injector.GetInstance<YarnREEFParamSerializer>();
-            var jobSubmission = injector.GetInstance<JobSubmissionBuilderFactory>()
-                .GetJobSubmissionBuilder()
+            var jobRequest = injector.GetInstance<JobRequestBuilder>()
                 .SetDriverMemory(AnyInt)
                 .SetMaxApplicationSubmissions(AnyInt)
                 .Build();
 
-            var serializedBytes = serializer.SerializeAppArgsToBytes(jobSubmission, injector);
+            var serializedBytes = serializer.SerializeAppArgsToBytes(jobRequest.AppParameters, injector);
             var expectedString = Encoding.UTF8.GetString(serializedBytes);
             var jsonObject = JObject.Parse(expectedString);
             var expectedJsonObject = JObject.Parse(expectedJson);
@@ -171,14 +169,13 @@ namespace Org.Apache.REEF.Client.Tests
             var injector = TangFactory.GetTang().NewInjector(conf);
 
             var serializer = injector.GetInstance<YarnREEFParamSerializer>();
-            var jobSubmission = injector.GetInstance<JobSubmissionBuilderFactory>()
-                .GetJobSubmissionBuilder()
+            var jobRequest = injector.GetInstance<JobRequestBuilder>()
                 .SetJobIdentifier(AnyString)
                 .SetMaxApplicationSubmissions(AnyInt)
                 .SetDriverMemory(AnyInt)
                 .Build();
 
-            var serializedBytes = serializer.SerializeJobArgsToBytes(jobSubmission, injector, AnyString);
+            var serializedBytes = serializer.SerializeJobArgsToBytes(jobRequest.JobParameters, injector, AnyString);
             var expectedString = Encoding.UTF8.GetString(serializedBytes);
             var jsonObject = JObject.Parse(expectedString);
             var expectedJsonObject = JObject.Parse(expectedJson);

--- a/lang/cs/Org.Apache.REEF.Client/API/AppParameters.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/AppParameters.cs
@@ -15,93 +15,94 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
 using System.Collections.Generic;
 using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.Client.API
 {
     /// <summary>
-    /// Captures a submission of a REEF Job to a cluster.
+    /// The parameters for a REEF application, used to specify application parameters for each REEF application.
+    /// For job parameters which is specified each time for job submissions of the same
+    /// REEF application, see <see cref="JobParameters"/>.
     /// </summary>
-    internal sealed class JobSubmission : IJobSubmission
+    public sealed class AppParameters
     {
         private readonly ISet<IConfiguration> _driverConfigurations;
         private readonly ISet<string> _globalAssemblies;
         private readonly ISet<string> _globalFiles;
         private readonly ISet<string> _localAssemblies;
         private readonly ISet<string> _localFiles;
-        private readonly int _driverMemory;
-        private readonly int _maxAppSubmissions;
-        private readonly string _jobIdentifier;
         private readonly string _driverConfigurationFileContents;
 
-        internal JobSubmission(JobRequest jobRequest)
+        internal AppParameters(
+            ISet<IConfiguration> driverConfigurations,
+            ISet<string> globalAssemblies,
+            ISet<string> globalFiles,
+            ISet<string> localAssemblies,
+            ISet<string> localFiles,
+            string driverConfigurationFileContents)
         {
-            _driverConfigurations = jobRequest.DriverConfigurations;
-            _globalAssemblies = jobRequest.GlobalAssemblies;
-            _globalFiles = jobRequest.GlobalFiles;
-            _localAssemblies = jobRequest.LocalAssemblies;
-            _localFiles = jobRequest.LocalFiles;
-            _driverMemory = jobRequest.DriverMemory;
-            _jobIdentifier = jobRequest.JobIdentifier;
-            _driverConfigurationFileContents = jobRequest.DriverConfigurationFileContents;
-            _maxAppSubmissions = jobRequest.MaxApplicationSubmissions;
+            _driverConfigurations = driverConfigurations;
+            _globalAssemblies = globalAssemblies;
+            _globalFiles = globalFiles;
+            _localAssemblies = localAssemblies;
+            _localFiles = localFiles;
+            _driverConfigurationFileContents = driverConfigurationFileContents;
+        }
+
+        [Obsolete("Introduced to bridge deprecation of IJobSubmission.")]
+        internal static AppParameters FromJobSubmission(IJobSubmission jobSubmission)
+        {
+            return new AppParameters(jobSubmission.DriverConfigurations, jobSubmission.GlobalAssemblies, jobSubmission.GlobalFiles, 
+                jobSubmission.LocalAssemblies, jobSubmission.LocalFiles, jobSubmission.DriverConfigurationFileContents);
         }
 
         /// <summary>
         /// The assemblies to be made available to all containers.
         /// </summary>
-        ISet<string> IJobSubmission.GlobalAssemblies
+        public ISet<string> GlobalAssemblies
         {
             get { return _globalAssemblies; }
         }
 
         /// <summary>
-        /// The driver configurations
+        /// The driver configurations.
         /// </summary>
-        ISet<IConfiguration> IJobSubmission.DriverConfigurations
+        public ISet<IConfiguration> DriverConfigurations
         {
             get { return _driverConfigurations; }
         }
 
-        ISet<string> IJobSubmission.GlobalFiles
+        /// <summary>
+        /// The global files to be made available to all containers.
+        /// </summary>
+        public ISet<string> GlobalFiles
         {
             get { return _globalFiles; }
         }
 
-        ISet<string> IJobSubmission.LocalAssemblies
+        /// <summary>
+        /// The assemblies to be made available only to the local container.
+        /// </summary>
+        public ISet<string> LocalAssemblies
         {
             get { return _localAssemblies; }
         }
 
-        ISet<string> IJobSubmission.LocalFiles
+        /// <summary>
+        /// The files to be made available only to the local container.
+        /// </summary>
+        public ISet<string> LocalFiles
         {
             get { return _localFiles; }
-        }
-
-        int IJobSubmission.DriverMemory
-        {
-            get { return _driverMemory; }
-        }
-
-        int IJobSubmission.MaxApplicationSubmissions
-        {
-            get { return _maxAppSubmissions; }
-        }
-
-        /// <summary>
-        /// The Job's identifier
-        /// </summary>
-        string IJobSubmission.JobIdentifier 
-        {
-            get { return _jobIdentifier; }
         }
 
         /// <summary>
         /// Driver config file contents (Org.Apache.REEF.Bridge.exe.config)
         /// Can be use to redirect assembly versions
         /// </summary>
-        string IJobSubmission.DriverConfigurationFileContents
+        public string DriverConfigurationFileContents
         {
             get { return _driverConfigurationFileContents; }
         }

--- a/lang/cs/Org.Apache.REEF.Client/API/AppParametersBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/AppParametersBuilder.cs
@@ -1,0 +1,161 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Org.Apache.REEF.Tang.Interface;
+
+namespace Org.Apache.REEF.Client.API
+{
+    /// <summary>
+    /// A builder for <see cref="AppParameters"/>.
+    /// </summary>
+    public sealed class AppParametersBuilder
+    {
+        private readonly ISet<IConfiguration> _driverConfigurations = new HashSet<IConfiguration>();
+        private readonly ISet<string> _globalAssemblies = new HashSet<string>();
+        private readonly ISet<string> _globalFiles = new HashSet<string>();
+        private readonly ISet<string> _localAssemblies = new HashSet<string>();
+        private readonly ISet<string> _localFiles = new HashSet<string>();
+        private readonly ISet<IConfigurationProvider> _configurationProviders = new HashSet<IConfigurationProvider>();
+
+        private string _driverConfigurationFileContents;
+
+        private AppParametersBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="AppParametersBuilder"/>.
+        /// </summary>
+        public static AppParametersBuilder NewBuilder()
+        {
+            return new AppParametersBuilder();
+        }
+
+        /// <summary>
+        /// Add a file to be made available in all containers.
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        public AppParametersBuilder AddGlobalFile(string fileName)
+        {
+            _globalFiles.Add(fileName);
+            return this;
+        }
+
+        /// <summary>
+        /// Add a file to be made available only on the driver.
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        public AppParametersBuilder AddLocalFile(string fileName)
+        {
+            _localFiles.Add(fileName);
+            return this;
+        }
+
+        /// <summary>
+        /// Add an assembly to be made available on all containers.
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        public AppParametersBuilder AddGlobalAssembly(string fileName)
+        {
+            _globalAssemblies.Add(fileName);
+            return this;
+        }
+
+        /// <summary>
+        /// Add an assembly to the driver only.
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        public AppParametersBuilder AddLocalAssembly(string fileName)
+        {
+            _localAssemblies.Add(fileName);
+            return this;
+        }
+
+        /// <summary>
+        /// Add a Configuration to the Driver.
+        /// </summary>
+        public AppParametersBuilder AddDriverConfiguration(IConfiguration configuration)
+        {
+            _driverConfigurations.Add(configuration);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a driver configuration provider for configurations of the Driver.
+        /// </summary>
+        public AppParametersBuilder AddDriverConfigurationProviders(
+            IEnumerable<IConfigurationProvider> configurationProviders)
+        {
+            _configurationProviders.UnionWith(configurationProviders);
+            return this;
+        }
+
+        /// <summary>
+        /// Add the assembly needed for the given Type to the driver.
+        /// </summary>
+        public AppParametersBuilder AddLocalAssemblyForType(Type type)
+        {
+            AddLocalAssembly(GetAssemblyPathForType(type));
+            return this;
+        }
+
+        /// <summary>
+        /// Add the assembly needed for the given Type to all containers.
+        /// </summary>
+        public AppParametersBuilder AddGlobalAssemblyForType(Type type)
+        {
+            AddGlobalAssembly(GetAssemblyPathForType(type));
+            return this;
+        }
+
+        /// <summary>
+        /// Driver config file contents (Org.Apache.REEF.Bridge.exe.config) contents
+        /// Can be use to redirect assembly versions
+        /// </summary>
+        /// <param name="driverConfigurationFileContents">Driver configuration file contents.</param>
+        public AppParametersBuilder SetDriverConfigurationFileContents(string driverConfigurationFileContents)
+        {
+            _driverConfigurationFileContents = driverConfigurationFileContents;
+            return this;
+        }
+
+        /// <summary>
+        /// Finds the path to the assembly the given Type was loaded from.
+        /// </summary>
+        private static string GetAssemblyPathForType(Type type)
+        {
+            var path = Uri.UnescapeDataString(new UriBuilder(type.Assembly.CodeBase).Path);
+            return Path.GetFullPath(path);
+        }
+
+        /// <summary>
+        /// Builds the application parameters.
+        /// </summary>
+        public AppParameters Build()
+        {
+            return new AppParameters(_driverConfigurations, _globalAssemblies, _globalFiles, _localAssemblies,
+                _localFiles, _driverConfigurationFileContents);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/API/IJobSubmission.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/IJobSubmission.cs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
 using System.Collections.Generic;
 using Org.Apache.REEF.Tang.Interface;
 
@@ -24,6 +25,7 @@ namespace Org.Apache.REEF.Client.API
     /// This interfaces provides all the information that is needed for 
     /// a job submission
     /// </summary>
+    [Obsolete("Deprecated in 0.14. Please use JobRequest.")]
     public interface IJobSubmission
     {
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Client/API/IJobSubmissionBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/IJobSubmissionBuilder.cs
@@ -23,6 +23,7 @@ namespace Org.Apache.REEF.Client.API
     /// <summary>
     /// Facilitates building of job submissions
     /// </summary>
+    [Obsolete("Deprecated in 0.14, please use JobRequestBuilder.")]
     public interface IJobSubmissionBuilder
     {
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Client/API/IREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/IREEFClient.cs
@@ -30,19 +30,26 @@ namespace Org.Apache.REEF.Client.API
     public interface IREEFClient
     {
         /// <summary>
-        /// Submit the job described in jobSubmission to the cluster.
+        /// Submit the job described in jobRequest to the cluster.
         /// </summary>
         /// <param name="jobSubmission"></param>
+        [Obsolete("Deprecated in 0.14. Please use Submit(JobRequest)")]
         void Submit(IJobSubmission jobSubmission);
 
         /// <summary>
-        /// Submit the job described in jobSubmission to the cluster.
+        /// Submit the job described in jobRequest to the cluster.
+        /// </summary>
+        /// <param name="jobRequest"></param>
+        void Submit(JobRequest jobRequest);
+
+        /// <summary>
+        /// Submit the job described in jobRequest to the cluster.
         /// Expect IJobSubmissionResult returned after the call.
         /// </summary>
-        /// <param name="jobSubmission"></param>
+        /// <param name="jobRequest"></param>
         /// <returns>IJobSubmissionResult</returns>
         [Unstable("0.13", "Working in progress for what to return after submit")]
-        IJobSubmissionResult SubmitAndGetJobStatus(IJobSubmission jobSubmission);
+        IJobSubmissionResult SubmitAndGetJobStatus(JobRequest jobRequest);
 
         /// <summary>
         /// Returns the application status in running the job

--- a/lang/cs/Org.Apache.REEF.Client/API/JobParameters.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/JobParameters.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+
+namespace Org.Apache.REEF.Client.API
+{
+    /// <summary>
+    /// The parameters for a REEF job, used to specify job parameters on each REEF submission.
+    /// For application parameters which is specified only once for all job submissions of the same
+    /// REEF application, see <see cref="AppParameters"/>.
+    /// </summary>
+    public sealed class JobParameters
+    {
+        private readonly string _jobIdentifier;
+        private readonly int _maxApplicationSubmissions;
+        private readonly int _driverMemory;
+
+        internal JobParameters(string jobIdentifier, int maxApplicationSubmissions, int driverMemory)
+        {
+            _jobIdentifier = jobIdentifier;
+            _maxApplicationSubmissions = maxApplicationSubmissions;
+            _driverMemory = driverMemory;
+        }
+
+        [Obsolete("Introduced to bridge deprecation of IJobSubmission.")]
+        internal static JobParameters FromJobSubmission(IJobSubmission jobSubmission)
+        {
+            return new JobParameters(
+                jobSubmission.JobIdentifier, jobSubmission.MaxApplicationSubmissions, jobSubmission.DriverMemory);
+        }
+
+        /// <summary>
+        /// The identifier of the job.
+        /// </summary>
+        public string JobIdentifier
+        {
+            get { return _jobIdentifier; }
+        }
+
+        /// <summary>
+        /// The maximum amount of times the job can be submitted. Used primarily in the 
+        /// driver restart scenario.
+        /// </summary>
+        public int MaxApplicationSubmissions
+        {
+            get { return _maxApplicationSubmissions;  }
+        }
+
+        /// <summary>
+        /// The size of the driver memory, in MB.
+        /// </summary>
+        public int DriverMemoryInMB
+        {
+            get { return _driverMemory; }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/API/JobParametersBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/JobParametersBuilder.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+namespace Org.Apache.REEF.Client.API
+{
+    /// <summary>
+    /// A builder for <see cref="JobParameters"/>.
+    /// </summary>
+    public sealed class JobParametersBuilder
+    {
+        private string _jobIdentifier;
+        private int _maxApplicationSubmissions = 1;
+        private int _driverMemory = 512;
+
+        private JobParametersBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="JobParametersBuilder"/>.
+        /// </summary>
+        public static JobParametersBuilder NewBuilder()
+        {
+            return new JobParametersBuilder();
+        }
+
+        /// <summary>
+        /// Builds a <see cref="JobParameters"/> object based on parameters passed to the builder.
+        /// </summary>
+        /// <returns></returns>
+        public JobParameters Build()
+        {
+            return new JobParameters(_jobIdentifier, _maxApplicationSubmissions, _driverMemory);
+        }
+
+        /// <summary>
+        /// Sets the identifier of the job.
+        /// </summary>
+        public JobParametersBuilder SetJobIdentifier(string id)
+        {
+            _jobIdentifier = id;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the maximum amount of times the job can be submitted. Used primarily in the 
+        /// driver restart scenario.
+        /// </summary>
+        public JobParametersBuilder SetMaxApplicationSubmissions(int maxApplicationSubmissions)
+        {
+            _maxApplicationSubmissions = maxApplicationSubmissions;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the amount of memory (in MB) to allocate for the Driver.
+        /// </summary>
+        /// <param name="driverMemoryInMb">The amount of memory (in MB) to allocate for the Driver.</param>
+        /// <returns>this</returns>
+        public JobParametersBuilder SetDriverMemory(int driverMemoryInMb)
+        {
+            _driverMemory = driverMemoryInMb;
+            return this;
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/API/JobRequest.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/JobRequest.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using Org.Apache.REEF.Tang.Interface;
+
+namespace Org.Apache.REEF.Client.API
+{
+    /// <summary>
+    /// Describes parameters for a single job submission.
+    /// </summary>
+    public sealed class JobRequest
+    {
+        private readonly JobParameters _jobParameters;
+        private readonly AppParameters _appParameters;
+
+        internal JobRequest(JobParameters jobParameters, AppParameters appParameters)
+        {
+            _jobParameters = jobParameters;
+            _appParameters = appParameters;
+        }
+
+        [Obsolete("Introduced to bridge deprecation of IJobSubmission.")]
+        internal static JobRequest FromJobSubmission(IJobSubmission jobSubmission)
+        {
+            return new JobRequest(
+                JobParameters.FromJobSubmission(jobSubmission), AppParameters.FromJobSubmission(jobSubmission));
+        }
+
+        /// <summary>
+        /// The assemblies to be made available to all containers.
+        /// </summary>
+        public ISet<string> GlobalAssemblies
+        {
+            get { return _appParameters.GlobalAssemblies; }
+        }
+
+        /// <summary>
+        /// The driver configurations
+        /// </summary>
+        public ISet<IConfiguration> DriverConfigurations
+        {
+            get { return _appParameters.DriverConfigurations; }
+        }
+
+        /// <summary>
+        /// The global files to be made available to all containers.
+        /// </summary>
+        public ISet<string> GlobalFiles
+        {
+            get { return _appParameters.GlobalFiles; }
+        }
+
+        /// <summary>
+        /// The assemblies to be made available only to the local container.
+        /// </summary>
+        public ISet<string> LocalAssemblies
+        {
+            get { return _appParameters.LocalAssemblies; }
+        }
+
+        /// <summary>
+        /// The files to be made available only to the local container.
+        /// </summary>
+        public ISet<string> LocalFiles
+        {
+            get { return _appParameters.LocalFiles; }
+        }
+
+        /// <summary>
+        /// The size of the driver memory, in MB.
+        /// </summary>
+        public int DriverMemory
+        {
+            get { return _jobParameters.DriverMemoryInMB; }
+        }
+
+        /// <summary>
+        /// The maximum amount of times the job can be submitted. Used primarily in the 
+        /// driver restart scenario.
+        /// </summary>
+        public int MaxApplicationSubmissions
+        {
+            get { return _jobParameters.MaxApplicationSubmissions; }
+        }
+
+        /// <summary>
+        /// The Job's identifier
+        /// </summary>
+        public string JobIdentifier
+        {
+            get { return _jobParameters.JobIdentifier; }
+        }
+
+        /// <summary>
+        /// Driver config file contents (Org.Apache.REEF.Bridge.exe.config)
+        /// Can be use to redirect assembly versions
+        /// </summary>
+        public string DriverConfigurationFileContents
+        {
+            get { return _appParameters.DriverConfigurationFileContents; }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="JobParameters"/> for this particular job submission.
+        /// </summary>
+        public JobParameters JobParameters
+        {
+            get { return _jobParameters; }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="AppParameters"/> for this particular job submission.
+        /// </summary>
+        public AppParameters AppParameters
+        {
+            get { return _appParameters; }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/API/JobRequestBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/JobRequestBuilder.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,39 +17,55 @@
 
 using System;
 using System.Collections.Generic;
+using Org.Apache.REEF.Common.Client.Parameters;
+using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.Client.API
 {
-    [Obsolete("Deprecated in 0.14. Will be removed.")]
-    internal class JobSubmissionBuilder : IJobSubmissionBuilder
+    public sealed class JobRequestBuilder
     {
-        private readonly JobRequestBuilder _jobRequestBuilder = JobRequestBuilder.NewBuilder();
+        private readonly AppParametersBuilder _appParametersBuilder = AppParametersBuilder.NewBuilder();
+        private readonly JobParametersBuilder _jobParametersBuilder = JobParametersBuilder.NewBuilder();
 
-        internal JobSubmissionBuilder(ISet<IConfigurationProvider> configurationProviders)
+        private JobRequestBuilder()
         {
-            _jobRequestBuilder.AddDriverConfigurationProviders(configurationProviders);
+        }
+
+        [Inject]
+        private JobRequestBuilder([Parameter(typeof(DriverConfigurationProviders))] ISet<IConfigurationProvider> configurationProviders)
+        {
+            AddDriverConfigurationProviders(configurationProviders);
+        }
+
+        public static JobRequestBuilder NewBuilder()
+        {
+            return new JobRequestBuilder();
         }
 
         /// <summary>
-        /// Add a file to be made available in all containers.
+        /// Bake the information provided so far and return a IJobSubmission 
         /// </summary>
-        /// <param name="fileName"></param>
-        /// <returns></returns>
-        public IJobSubmissionBuilder AddGlobalFile(string fileName)
+        public JobRequest Build()
         {
-            _jobRequestBuilder.AddGlobalFile(fileName);
+            return new JobRequest(_jobParametersBuilder.Build(), _appParametersBuilder.Build());
+        }
+
+        /// <summary>
+        /// Make this file available to all containers
+        /// </summary>
+        public JobRequestBuilder AddGlobalFile(string fileName)
+        {
+            _appParametersBuilder.AddGlobalFile(fileName);
             return this;
         }
 
         /// <summary>
-        /// Add a file to be made available only on the driver.
+        /// Files specific to one container
         /// </summary>
-        /// <param name="fileName"></param>
-        /// <returns></returns>
-        public IJobSubmissionBuilder AddLocalFile(string fileName)
+        public JobRequestBuilder AddLocalFile(string fileName)
         {
-            _jobRequestBuilder.AddLocalFile(fileName);
+            _appParametersBuilder.AddLocalFile(fileName);
             return this;
         }
 
@@ -58,9 +74,9 @@ namespace Org.Apache.REEF.Client.API
         /// </summary>
         /// <param name="fileName"></param>
         /// <returns></returns>
-        public IJobSubmissionBuilder AddGlobalAssembly(string fileName)
+        public JobRequestBuilder AddGlobalAssembly(string fileName)
         {
-            _jobRequestBuilder.AddGlobalAssembly(fileName);
+            _appParametersBuilder.AddGlobalAssembly(fileName);
             return this;
         }
 
@@ -69,9 +85,9 @@ namespace Org.Apache.REEF.Client.API
         /// </summary>
         /// <param name="fileName"></param>
         /// <returns></returns>
-        public IJobSubmissionBuilder AddLocalAssembly(string fileName)
+        public JobRequestBuilder AddLocalAssembly(string fileName)
         {
-            _jobRequestBuilder.AddLocalAssembly(fileName);
+            _appParametersBuilder.AddLocalAssembly(fileName);
             return this;
         }
 
@@ -80,9 +96,9 @@ namespace Org.Apache.REEF.Client.API
         /// </summary>
         /// <param name="configuration"></param>
         /// <returns></returns>
-        public IJobSubmissionBuilder AddDriverConfiguration(IConfiguration configuration)
+        public JobRequestBuilder AddDriverConfiguration(IConfiguration configuration)
         {
-            _jobRequestBuilder.AddDriverConfiguration(configuration);
+            _appParametersBuilder.AddDriverConfiguration(configuration);
             return this;
         }
 
@@ -91,9 +107,9 @@ namespace Org.Apache.REEF.Client.API
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        public IJobSubmissionBuilder AddLocalAssemblyForType(Type type)
+        public JobRequestBuilder AddLocalAssemblyForType(Type type)
         {
-            _jobRequestBuilder.AddLocalAssemblyForType(type);
+            _appParametersBuilder.AddLocalAssemblyForType(type);
             return this;
         }
 
@@ -102,9 +118,9 @@ namespace Org.Apache.REEF.Client.API
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        public IJobSubmissionBuilder AddGlobalAssemblyForType(Type type)
+        public JobRequestBuilder AddGlobalAssemblyForType(Type type)
         {
-            _jobRequestBuilder.AddGlobalAssemblyForType(type);
+            _appParametersBuilder.AddGlobalAssemblyForType(type);
             return this;
         }
 
@@ -113,9 +129,9 @@ namespace Org.Apache.REEF.Client.API
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        public IJobSubmissionBuilder SetJobIdentifier(string id)
+        public JobRequestBuilder SetJobIdentifier(string id)
         {
-            _jobRequestBuilder.SetJobIdentifier(id);
+            _jobParametersBuilder.SetJobIdentifier(id);
             return this;
         }
 
@@ -124,18 +140,18 @@ namespace Org.Apache.REEF.Client.API
         /// </summary>
         /// <param name="driverMemoryInMb">The amount of memory (in MB) to allocate for the Driver.</param>
         /// <returns>this</returns>
-        public IJobSubmissionBuilder SetDriverMemory(int driverMemoryInMb)
+        public JobRequestBuilder SetDriverMemory(int driverMemoryInMb)
         {
-            _jobRequestBuilder.SetDriverMemory(driverMemoryInMb);
+            _jobParametersBuilder.SetDriverMemory(driverMemoryInMb);
             return this;
         }
 
         /// <summary>
         /// Sets the maximum amount of times a job can be submitted.
         /// </summary>
-        public IJobSubmissionBuilder SetMaxApplicationSubmissions(int maxAppSubmissions)
+        public JobRequestBuilder SetMaxApplicationSubmissions(int maxAppSubmissions)
         {
-            _jobRequestBuilder.SetMaxApplicationSubmissions(maxAppSubmissions);
+            _jobParametersBuilder.SetMaxApplicationSubmissions(maxAppSubmissions);
             return this;
         }
 
@@ -145,19 +161,16 @@ namespace Org.Apache.REEF.Client.API
         /// </summary>
         /// <param name="driverConfigurationFileContents">Driver configuration file contents.</param>
         /// <returns>this</returns>
-        public IJobSubmissionBuilder SetDriverConfigurationFileContents(string driverConfigurationFileContents)
+        public JobRequestBuilder SetDriverConfigurationFileContents(string driverConfigurationFileContents)
         {
-            _jobRequestBuilder.SetDriverConfigurationFileContents(driverConfigurationFileContents);
+            _appParametersBuilder.SetDriverConfigurationFileContents(driverConfigurationFileContents);
             return this;
         }
 
-        /// <summary>
-        /// Builds the submission
-        /// </summary>
-        /// <returns>IJobSubmission</returns>
-        public IJobSubmission Build()
+        public JobRequestBuilder AddDriverConfigurationProviders(IEnumerable<IConfigurationProvider> configurationProviders)
         {
-            return new JobSubmission(_jobRequestBuilder.Build());
+            _appParametersBuilder.AddDriverConfigurationProviders(configurationProviders);
+            return this;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/API/JobSubmissionBuilderFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/JobSubmissionBuilderFactory.cs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
 using System.Collections.Generic;
 using Org.Apache.REEF.Common.Client.Parameters;
 using Org.Apache.REEF.Tang.Annotations;
@@ -25,6 +26,7 @@ namespace Org.Apache.REEF.Client.API
     /// <summary>
     /// Instantiates IJobSubmissionBuilder based on configurationProviders.
     /// </summary>
+    [Obsolete("Deprecated in 0.14. Please use JobRequestBuilder instead.")]
     public sealed class JobSubmissionBuilderFactory
     {
         private readonly ISet<IConfigurationProvider> _configurationProviders;

--- a/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
@@ -80,20 +80,20 @@ namespace Org.Apache.REEF.Client.Common
         /// <summary>
         /// Prepares the working directory for a Driver in driverFolderPath.
         /// </summary>
-        /// <param name="jobSubmission"></param>
+        /// <param name="appParameters"></param>
         /// <param name="driverFolderPath"></param>
-        internal void PrepareDriverFolder(IJobSubmission jobSubmission, string driverFolderPath)
+        internal void PrepareDriverFolder(AppParameters appParameters, string driverFolderPath)
         {
             Logger.Log(Level.Info, "Preparing Driver filesystem layout in " + driverFolderPath);
 
             // Setup the folder structure
-            CreateDefaultFolderStructure(jobSubmission, driverFolderPath);
+            CreateDefaultFolderStructure(appParameters, driverFolderPath);
 
-            // Add the jobSubmission into that folder structure
-            _fileSets.AddJobFiles(jobSubmission);
+            // Add the appParameters into that folder structure
+            _fileSets.AddJobFiles(appParameters);
 
             // Create the driver configuration
-            CreateDriverConfiguration(jobSubmission, driverFolderPath);
+            CreateDriverConfiguration(appParameters, driverFolderPath);
 
             // Add the REEF assemblies
             AddAssemblies();
@@ -105,15 +105,15 @@ namespace Org.Apache.REEF.Client.Common
         }
 
         /// <summary>
-        /// Merges the Configurations in jobSubmission and serializes them into the right place within driverFolderPath,
+        /// Merges the Configurations in appParameters and serializes them into the right place within driverFolderPath,
         /// assuming
         /// that points to a Driver's working directory.
         /// </summary>
-        /// <param name="jobSubmission"></param>
+        /// <param name="appParameters"></param>
         /// <param name="driverFolderPath"></param>
-        internal void CreateDriverConfiguration(IJobSubmission jobSubmission, string driverFolderPath)
+        internal void CreateDriverConfiguration(AppParameters appParameters, string driverFolderPath)
         {
-            var driverConfiguration = Configurations.Merge(jobSubmission.DriverConfigurations.ToArray());
+            var driverConfiguration = Configurations.Merge(appParameters.DriverConfigurations.ToArray());
 
             _configurationSerializer.ToFile(driverConfiguration,
                 Path.Combine(driverFolderPath, _fileNames.GetClrDriverConfigurationPath()));
@@ -126,9 +126,9 @@ namespace Org.Apache.REEF.Client.Common
         /// <summary>
         /// Creates the driver folder structure in this given folder as the root
         /// </summary>
-        /// <param name="jobSubmission">Job submission information</param>
+        /// <param name="appParameters">Job submission information</param>
         /// <param name="driverFolderPath">Driver folder path</param>
-        internal void CreateDefaultFolderStructure(IJobSubmission jobSubmission, string driverFolderPath)
+        internal void CreateDefaultFolderStructure(AppParameters appParameters, string driverFolderPath)
         {
             Directory.CreateDirectory(Path.Combine(driverFolderPath, _fileNames.GetReefFolderName()));
             Directory.CreateDirectory(Path.Combine(driverFolderPath, _fileNames.GetLocalFolderPath()));
@@ -146,9 +146,9 @@ namespace Org.Apache.REEF.Client.Common
             }
             
             var config = DefaultDriverConfigurationFileContents;
-            if (!string.IsNullOrEmpty(jobSubmission.DriverConfigurationFileContents))
+            if (!string.IsNullOrEmpty(appParameters.DriverConfigurationFileContents))
             {
-                config = jobSubmission.DriverConfigurationFileContents;
+                config = appParameters.DriverConfigurationFileContents;
             }
             File.WriteAllText(Path.Combine(driverFolderPath, _fileNames.GetBridgeExeConfigPath()), config);
         }

--- a/lang/cs/Org.Apache.REEF.Client/Common/FileSets.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/FileSets.cs
@@ -119,7 +119,7 @@ namespace Org.Apache.REEF.Client.Common
         /// Adds all the files referenced in the given JobSubmission
         /// </summary>
         /// <param name="submission"></param>
-        internal void AddJobFiles(IJobSubmission submission)
+        internal void AddJobFiles(AppParameters submission)
         {
             AddToGlobalFiles(submission.GlobalFiles);
             AddToGlobalFiles(submission.GlobalAssemblies);

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -59,12 +59,18 @@ under the License.
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="API\AppParameters.cs" />
+    <Compile Include="API\AppParametersBuilder.cs" />
     <Compile Include="API\ClientFactory.cs" />
     <Compile Include="API\Exceptions\ClasspathException.cs" />
     <Compile Include="API\Exceptions\JavaNotFoundException.cs" />
     <Compile Include="API\IJobSubmission.cs" />
     <Compile Include="API\IJobSubmissionBuilder.cs" />
     <Compile Include="API\IREEFClient.cs" />
+    <Compile Include="API\JobParameters.cs" />
+    <Compile Include="API\JobParametersBuilder.cs" />
+    <Compile Include="API\JobRequest.cs" />
+    <Compile Include="API\JobRequestBuilder.cs" />
     <Compile Include="API\JobSubmission.cs" />
     <Compile Include="API\JobSubmissionBuilder.cs" />
     <Compile Include="API\JobSubmissionBuilderFactory.cs" />

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetParamSerializer.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetParamSerializer.cs
@@ -44,9 +44,9 @@ namespace Org.Apache.REEF.Client.YARN
         /// <summary>
         /// Serializes the application parameters to reef/local/app-submission-params.json.
         /// </summary>
-        internal void SerializeAppFile(IJobSubmission jobSubmission, IInjector paramInjector, string localDriverFolderPath)
+        internal void SerializeAppFile(AppParameters appParameters, IInjector paramInjector, string localDriverFolderPath)
         {
-            var serializedArgs = SerializeAppArgsToBytes(jobSubmission, paramInjector, localDriverFolderPath);
+            var serializedArgs = SerializeAppArgsToBytes(appParameters, paramInjector, localDriverFolderPath);
 
             var submissionAppArgsFilePath = Path.Combine(
                 localDriverFolderPath, _fileNames.GetLocalFolderPath(), _fileNames.GetAppSubmissionParametersFile());
@@ -57,7 +57,7 @@ namespace Org.Apache.REEF.Client.YARN
             }
         }
 
-        internal byte[] SerializeAppArgsToBytes(IJobSubmission jobSubmission, IInjector paramInjector, string localDriverFolderPath)
+        internal byte[] SerializeAppArgsToBytes(AppParameters appParameters, IInjector paramInjector, string localDriverFolderPath)
         {
             var avroAppSubmissionParameters = new AvroAppSubmissionParameters
             {
@@ -79,9 +79,9 @@ namespace Org.Apache.REEF.Client.YARN
         /// <summary>
         /// Serializes the job parameters to job-submission-params.json.
         /// </summary>
-        internal void SerializeJobFile(IJobSubmission jobSubmission, string localDriverFolderPath, string jobSubmissionDirectory)
+        internal void SerializeJobFile(JobParameters jobParameters, string localDriverFolderPath, string jobSubmissionDirectory)
         {
-            var serializedArgs = SerializeJobArgsToBytes(jobSubmission, localDriverFolderPath, jobSubmissionDirectory);
+            var serializedArgs = SerializeJobArgsToBytes(jobParameters, localDriverFolderPath, jobSubmissionDirectory);
 
             var submissionJobArgsFilePath = Path.Combine(localDriverFolderPath,
                 _fileNames.GetJobSubmissionParametersFile());
@@ -92,11 +92,11 @@ namespace Org.Apache.REEF.Client.YARN
             }
         }
 
-        internal byte[] SerializeJobArgsToBytes(IJobSubmission jobSubmission, string localDriverFolderPath, string jobSubmissionDirectory)
+        internal byte[] SerializeJobArgsToBytes(JobParameters jobParameters, string localDriverFolderPath, string jobSubmissionDirectory)
         {
             var avroJobSubmissionParameters = new AvroJobSubmissionParameters
             {
-                jobId = jobSubmission.JobIdentifier,
+                jobId = jobParameters.JobIdentifier,
                 jobSubmissionFolder = localDriverFolderPath
             };
 

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFParamSerializer.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFParamSerializer.cs
@@ -56,9 +56,9 @@ namespace Org.Apache.REEF.Client.YARN
         /// <summary>
         /// Serializes the application parameters to reef/local/app-submission-params.json.
         /// </summary>
-        internal string SerializeAppFile(IJobSubmission jobSubmission, IInjector paramInjector, string driverFolderPath)
+        internal string SerializeAppFile(AppParameters appParameters, IInjector paramInjector, string driverFolderPath)
         {
-            var serializedArgs = SerializeAppArgsToBytes(jobSubmission, paramInjector);
+            var serializedArgs = SerializeAppArgsToBytes(appParameters, paramInjector);
 
             var submissionArgsFilePath = Path.Combine(driverFolderPath, _fileNames.GetAppSubmissionParametersFile());
             using (var argsFileStream = new FileStream(submissionArgsFilePath, FileMode.CreateNew))
@@ -69,7 +69,7 @@ namespace Org.Apache.REEF.Client.YARN
             return submissionArgsFilePath;
         }
 
-        internal byte[] SerializeAppArgsToBytes(IJobSubmission jobSubmission, IInjector paramInjector)
+        internal byte[] SerializeAppArgsToBytes(AppParameters appParameters, IInjector paramInjector)
         {
             var avroAppSubmissionParameters = new AvroAppSubmissionParameters
             {
@@ -90,9 +90,9 @@ namespace Org.Apache.REEF.Client.YARN
         /// <summary>
         /// Serializes the job parameters to job-submission-params.json.
         /// </summary>
-        internal string SerializeJobFile(IJobSubmission jobSubmission, IInjector paramInjector, string driverFolderPath)
+        internal string SerializeJobFile(JobParameters jobParameters, IInjector paramInjector, string driverFolderPath)
         {
-            var serializedArgs = SerializeJobArgsToBytes(jobSubmission, paramInjector, driverFolderPath);
+            var serializedArgs = SerializeJobArgsToBytes(jobParameters, paramInjector, driverFolderPath);
 
             var submissionArgsFilePath = Path.Combine(driverFolderPath, _fileNames.GetJobSubmissionParametersFile());
             using (var argsFileStream = new FileStream(submissionArgsFilePath, FileMode.CreateNew))
@@ -103,11 +103,11 @@ namespace Org.Apache.REEF.Client.YARN
             return submissionArgsFilePath;
         }
 
-        internal byte[] SerializeJobArgsToBytes(IJobSubmission jobSubmission, IInjector paramInjector, string driverFolderPath)
+        internal byte[] SerializeJobArgsToBytes(JobParameters jobParameters, IInjector paramInjector, string driverFolderPath)
         {
             var avroJobSubmissionParameters = new AvroJobSubmissionParameters
             {
-                jobId = jobSubmission.JobIdentifier,
+                jobId = jobParameters.JobIdentifier,
                 jobSubmissionFolder = driverFolderPath
             };
 
@@ -117,16 +117,16 @@ namespace Org.Apache.REEF.Client.YARN
                 sharedJobSubmissionParameters = avroJobSubmissionParameters
             };
 
-            var maxApplicationSubmissions = jobSubmission.MaxApplicationSubmissions == 1
+            var maxApplicationSubmissions = jobParameters.MaxApplicationSubmissions == 1
                 ? paramInjector.GetNamedInstance<DriverBridgeConfigurationOptions.MaxApplicationSubmissions, int>()
-                : jobSubmission.MaxApplicationSubmissions;
+                : jobParameters.MaxApplicationSubmissions;
 
             var avroYarnClusterJobSubmissionParameters = new AvroYarnClusterJobSubmissionParameters
             {
                 securityTokenKind = _securityTokenKind,
                 securityTokenService = _securityTokenService,
                 yarnJobSubmissionParameters = avroYarnJobSubmissionParameters,
-                driverMemory = jobSubmission.DriverMemory,
+                driverMemory = jobParameters.DriverMemoryInMB,
                 maxApplicationSubmissions = maxApplicationSubmissions
             };
 

--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
@@ -40,13 +40,13 @@ namespace Org.Apache.REEF.Examples.AllHandlers
         private const string Local = "local";
         private const string YARN = "yarn";
         private readonly IREEFClient _reefClient;
-        private readonly JobSubmissionBuilderFactory _jobSubmissionBuilderFactory;
+        private readonly JobRequestBuilder _jobRequestBuilder;
 
         [Inject]
-        private AllHandlers(IREEFClient reefClient, JobSubmissionBuilderFactory jobSubmissionBuilderFactory)
+        private AllHandlers(IREEFClient reefClient, JobRequestBuilder jobRequestBuilder)
         {
             _reefClient = reefClient;
-            _jobSubmissionBuilderFactory = jobSubmissionBuilderFactory;
+            _jobRequestBuilder = jobRequestBuilder;
         }
 
         private IJobSubmissionResult Run()
@@ -76,7 +76,7 @@ namespace Org.Apache.REEF.Examples.AllHandlers
                 .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
                 .Build();
 
-            var helloJobSubmission = _jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
+            var helloJobSubmission = _jobRequestBuilder
                 .AddDriverConfiguration(driverConfig)
                 .AddGlobalAssemblyForType(typeof(HelloDriverStartHandler))
                 .SetJobIdentifier("HelloDriver")

--- a/lang/cs/Org.Apache.REEF.Examples.DriverRestart/DriverRestart.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.DriverRestart/DriverRestart.cs
@@ -34,13 +34,13 @@ namespace Org.Apache.REEF.Examples.DriverRestart
     public sealed class DriverRestart
     {
         private readonly IREEFClient _reefClient;
-        private readonly JobSubmissionBuilderFactory _jobSubmissionBuilderFactory;
+        private readonly JobRequestBuilder _jobRequestBuilder;
 
         [Inject]
-        private DriverRestart(IREEFClient reefClient, JobSubmissionBuilderFactory jobSubmissionBuilderFactory)
+        private DriverRestart(IREEFClient reefClient, JobRequestBuilder jobRequestBuilder)
         {
             _reefClient = reefClient;
-            _jobSubmissionBuilderFactory = jobSubmissionBuilderFactory;
+            _jobRequestBuilder = jobRequestBuilder;
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Org.Apache.REEF.Examples.DriverRestart
                 .Build();
 
             // The JobSubmission contains the Driver configuration as well as the files needed on the Driver.
-            var restartJobSubmission = _jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
+            var restartJobSubmission = _jobRequestBuilder
                 .AddDriverConfiguration(driverConfiguration)
                 .AddGlobalAssemblyForType(typeof(HelloRestartDriver))
                 .SetJobIdentifier("DriverRestart_" + Guid.NewGuid().ToString().Substring(0, 6))

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
@@ -38,13 +38,13 @@ namespace Org.Apache.REEF.Examples.HelloREEF
         private const string YARN = "yarn";
         private const string YARNRest = "yarnrest";
         private readonly IREEFClient _reefClient;
-        private readonly JobSubmissionBuilderFactory _jobSubmissionBuilderFactory;
+        private readonly JobRequestBuilder _jobRequestBuilder;
 
         [Inject]
-        private HelloREEF(IREEFClient reefClient, JobSubmissionBuilderFactory jobSubmissionBuilderFactory)
+        private HelloREEF(IREEFClient reefClient, JobRequestBuilder jobRequestBuilder)
         {
             _reefClient = reefClient;
-            _jobSubmissionBuilderFactory = jobSubmissionBuilderFactory;
+            _jobRequestBuilder = jobRequestBuilder;
         }
 
         /// <summary>
@@ -59,13 +59,13 @@ namespace Org.Apache.REEF.Examples.HelloREEF
                 .Build();
 
             // The JobSubmission contains the Driver configuration as well as the files needed on the Driver.
-            var helloJobSubmission = _jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
+            var helloJobRequest = _jobRequestBuilder
                 .AddDriverConfiguration(helloDriverConfiguration)
                 .AddGlobalAssemblyForType(typeof(HelloDriver))
                 .SetJobIdentifier("HelloREEF")
                 .Build();
 
-            _reefClient.Submit(helloJobSubmission);
+            _reefClient.Submit(helloJobRequest);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
@@ -48,17 +48,19 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
         private static readonly Logger Logger = Logger.GetLogger(typeof(REEFIMRUClient));
 
         private readonly IREEFClient _reefClient;
-        private readonly JobSubmissionBuilderFactory _jobSubmissionBuilderFactory;
+        private readonly JobRequestBuilder _jobRequestBuilder;
         private readonly AvroConfigurationSerializer _configurationSerializer;
         private IJobSubmissionResult _jobSubmissionResult;
 
         [Inject]
-        private REEFIMRUClient(IREEFClient reefClient, AvroConfigurationSerializer configurationSerializer,
-            JobSubmissionBuilderFactory jobSubmissionBuilderFactory)
+        private REEFIMRUClient(
+            IREEFClient reefClient, 
+            AvroConfigurationSerializer configurationSerializer,
+            JobRequestBuilder jobRequestBuilder)
         {
             _reefClient = reefClient;
             _configurationSerializer = configurationSerializer;
-            _jobSubmissionBuilderFactory = jobSubmissionBuilderFactory;
+            _jobRequestBuilder = jobRequestBuilder;
         }
 
         /// <summary>
@@ -142,7 +144,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
                 .Build();
 
             // The JobSubmission contains the Driver configuration as well as the files needed on the Driver.
-            var imruJobSubmission = _jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
+            var imruJobSubmission = _jobRequestBuilder
                 .AddDriverConfiguration(imruDriverConfiguration)
                 .AddGlobalAssemblyForType(typeof(IMRUDriver<TMapInput, TMapOutput, TResult>))
                 .SetJobIdentifier(jobDefinition.JobName)

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/BroadcastAndReduceClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/BroadcastAndReduceClient.cs
@@ -96,8 +96,8 @@ namespace Org.Apache.REEF.Network.Examples.Client
         {
             IInjector injector = TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(runOnYarn, numberOfEvaluator, runtimeFolder));
             var reefClient = injector.GetInstance<IREEFClient>();
-            var jobSubmissionBuilderFactory = injector.GetInstance<JobSubmissionBuilderFactory>();
-            var jobSubmission = jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
+            var jobRequestBuilder = injector.GetInstance<JobRequestBuilder>();
+            var jobSubmission = jobRequestBuilder
                 .AddDriverConfiguration(driverConfig)
                 .AddGlobalAssemblyForType(globalAssemblyType)
                 .SetJobIdentifier(jobIdentifier)

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -292,8 +292,8 @@ namespace Org.Apache.REEF.Tests.Functional
         {
             IInjector injector = TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(runOnYarn, numberOfEvaluator, runtimeFolder));
             var reefClient = injector.GetInstance<IREEFClient>();
-            var jobSubmissionBuilderFactory = injector.GetInstance<JobSubmissionBuilderFactory>();
-            var jobSubmission = jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
+            var jobRequestBuilder = injector.GetInstance<JobRequestBuilder>();
+            var jobSubmission = jobRequestBuilder
                 .AddDriverConfiguration(driverConfig)
                 .AddGlobalAssemblyForType(globalAssemblyType)
                 .SetJobIdentifier(jobIdentifier)


### PR DESCRIPTION
This addressed the issue by
  * Deprecate IJobSubmission and its related classes and interfaces.
  * Added JobRequest, JobParameters, AppParameters, and their related classes.
  * Added methods to submit jobs with the newly introduced classes.

JIRA:
  [REEF-1204](https://issues.apache.org/jira/browse/REEF-1204)