### PR TITLE
[REEF-1196] Allow specifying runtime name in evaluator request

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -38,17 +38,28 @@ public final class EvaluatorRequest {
   private final int cores;
   private final List<String> nodeNames;
   private final List<String> rackNames;
+  private final String runtimeName;
 
   EvaluatorRequest(final int number,
-      final int megaBytes,
-      final int cores,
-      final List<String> nodeNames,
-      final List<String> rackNames) {
+                   final int megaBytes,
+                   final int cores,
+                   final List<String> nodeNames,
+                   final List<String> rackNames) {
+    this(number, megaBytes, cores, nodeNames, rackNames, "");
+  }
+
+  EvaluatorRequest(final int number,
+                   final int megaBytes,
+                   final int cores,
+                   final List<String> nodeNames,
+                   final List<String> rackNames,
+                   final String runtimeName) {
     this.number = number;
     this.megaBytes = megaBytes;
     this.cores = cores;
     this.nodeNames = nodeNames;
     this.rackNames = rackNames;
+    this.runtimeName = runtimeName;
   }
 
   /**
@@ -116,6 +127,15 @@ public final class EvaluatorRequest {
   }
 
   /**
+   * Access the required runtime name.
+   *
+   * @return the runtime name that we need the Evaluator to run on
+   */
+  public String getRuntimeName() {
+    return  runtimeName;
+  }
+
+  /**
    * {@link EvaluatorRequest}s are build using this Builder.
    */
   public static final class Builder implements org.apache.reef.util.Builder<EvaluatorRequest> {
@@ -125,6 +145,7 @@ public final class EvaluatorRequest {
     private int cores = 1; //if not set, default to 1
     private final List<String> nodeNames = new ArrayList<>();
     private final List<String> rackNames = new ArrayList<>();
+    private String runtimeName = "";
 
     private Builder() {
     }
@@ -139,6 +160,7 @@ public final class EvaluatorRequest {
       setNumber(request.getNumber());
       setMemory(request.getMegaBytes());
       setNumberOfCores(request.getNumberOfCores());
+      setRuntimeName(request.getRuntimeName());
       for (final String nodeName : request.getNodeNames()) {
         addNodeName(nodeName);
       }
@@ -156,6 +178,18 @@ public final class EvaluatorRequest {
     @SuppressWarnings("checkstyle:hiddenfield")
     public Builder setMemory(final int megaBytes) {
       this.megaBytes = megaBytes;
+      return this;
+    }
+
+    /**
+     * Set the name of the desired runtime.
+     *
+     * @param runtimeName to request for the Evaluator.
+     * @return this builder
+     */
+    @SuppressWarnings("checkstyle:hiddenfield")
+    public Builder setRuntimeName(final String runtimeName) {
+      this.runtimeName = runtimeName;
       return this;
     }
 
@@ -215,7 +249,7 @@ public final class EvaluatorRequest {
      */
     @Override
     public EvaluatorRequest build() {
-      return new EvaluatorRequest(this.n, this.megaBytes, this.cores, this.nodeNames, this.rackNames);
+      return new EvaluatorRequest(this.n, this.megaBytes, this.cores, this.nodeNames, this.rackNames, this.runtimeName);
     }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -132,7 +132,7 @@ public final class EvaluatorRequest {
    * @return the runtime name that we need the Evaluator to run on
    */
   public String getRuntimeName() {
-    return  runtimeName;
+    return runtimeName;
   }
 
   /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
@@ -77,7 +77,9 @@ public final class EvaluatorRequestorImpl implements EvaluatorRequestor {
     if (req.getRackNames() == null) {
       throw new IllegalArgumentException("Rack names cannot be null");
     }
-
+    if(req.getRuntimeName() == null) {
+      throw new IllegalArgumentException("Runtime name cannot be null");
+    }
     // for backwards compatibility, we will always set the relax locality flag
     // to true unless the user configured racks, in which case we will check for
     // the ANY modifier (*), if not there, then we won't relax the locality
@@ -105,6 +107,7 @@ public final class EvaluatorRequestorImpl implements EvaluatorRequestor {
           .addNodeNames(req.getNodeNames())
           .addRackNames(req.getRackNames())
           .setRelaxLocality(relaxLocality)
+          .setRuntimeName(req.getRuntimeName())
           .build();
       this.resourceRequestHandler.onNext(request);
     }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEvent.java
@@ -60,4 +60,9 @@ public interface ResourceLaunchEvent {
      * @return List of libraries local to this Evaluator
      */
   Set<FileResource> getFileSet();
+
+  /**
+   * @return name of the runtime to launch the Evaluator on
+   */
+  String getRuntimeName();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEventImpl.java
@@ -40,6 +40,7 @@ public final class ResourceLaunchEventImpl implements ResourceLaunchEvent {
   private final Configuration evaluatorConf;
   private final EvaluatorProcess process;
   private final Set<FileResource> fileSet;
+  private final String runtimeName;
 
   private ResourceLaunchEventImpl(final Builder builder) {
     this.identifier = BuilderUtils.notNull(builder.identifier);
@@ -47,6 +48,7 @@ public final class ResourceLaunchEventImpl implements ResourceLaunchEvent {
     this.evaluatorConf = BuilderUtils.notNull(builder.evaluatorConf);
     this.process = BuilderUtils.notNull(builder.process);
     this.fileSet = BuilderUtils.notNull(builder.fileSet);
+    this.runtimeName = BuilderUtils.notNull(builder.runtimeName);
   }
 
   @Override
@@ -74,6 +76,11 @@ public final class ResourceLaunchEventImpl implements ResourceLaunchEvent {
     return fileSet;
   }
 
+  @Override
+  public String getRuntimeName() {
+    return runtimeName;
+  }
+
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -87,12 +94,21 @@ public final class ResourceLaunchEventImpl implements ResourceLaunchEvent {
     private Configuration evaluatorConf;
     private EvaluatorProcess process;
     private Set<FileResource> fileSet = new HashSet<>();
+    private String runtimeName;
 
     /**
      * @see ResourceLaunchEvent#getIdentifier()
      */
     public Builder setIdentifier(final String identifier) {
       this.identifier = identifier;
+      return this;
+    }
+
+    /**
+     * @see ResourceLaunchEvent#getRuntimeName()
+     */
+    public Builder setRuntimeName(final String runtimeName) {
+      this.runtimeName = runtimeName;
       return this;
     }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEvent.java
@@ -34,4 +34,9 @@ public interface ResourceReleaseEvent {
    * @return Id of the resource to release
    */
   String getIdentifier();
+
+  /**
+   * @return name of the runtime that this resource belongs to
+   */
+  String getRuntimeName();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEventImpl.java
@@ -27,14 +27,21 @@ import org.apache.reef.util.BuilderUtils;
 public final class ResourceReleaseEventImpl implements ResourceReleaseEvent {
 
   private final String identifier;
+  private final String runtimeName;
 
   private ResourceReleaseEventImpl(final Builder builder) {
     this.identifier = BuilderUtils.notNull(builder.identifier);
+    this.runtimeName = BuilderUtils.notNull(builder.runtimeName);
   }
 
   @Override
   public String getIdentifier() {
     return identifier;
+  }
+
+  @Override
+  public String getRuntimeName() {
+    return runtimeName;
   }
 
   public static Builder newBuilder() {
@@ -47,12 +54,20 @@ public final class ResourceReleaseEventImpl implements ResourceReleaseEvent {
   public static final class Builder implements org.apache.reef.util.Builder<ResourceReleaseEvent> {
 
     private String identifier;
-
+    private String runtimeName;
     /**
      * @see ResourceReleaseEvent#getIdentifier()
      */
     public Builder setIdentifier(final String identifier) {
       this.identifier = identifier;
+      return this;
+    }
+
+    /**
+     * @see ResourceReleaseEvent#getRuntimeName()
+     */
+    public Builder setRuntimeName(final String runtimeName) {
+      this.runtimeName = runtimeName;
       return this;
     }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
@@ -75,5 +75,5 @@ public interface ResourceRequestEvent {
   /**
    * @return The runtime name
    */
-  Optional<String> getRuntimeName();
+  String getRuntimeName();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
@@ -71,4 +71,9 @@ public interface ResourceRequestEvent {
    *   the preferred list. If false, strictly enforce the preferences.
    */
   Optional<Boolean> getRelaxLocality();
+
+  /**
+   * @return The runtime name
+   */
+  Optional<String> getRuntimeName();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
@@ -36,7 +36,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
   private final Optional<Integer> priority;
   private final Optional<Integer> virtualCores;
   private final Optional<Boolean> relaxLocality;
-  private final Optional<String> runtimeName;
+  private final String runtimeName;
 
   private ResourceRequestEventImpl(final Builder builder) {
     this.resourceCount = BuilderUtils.notNull(builder.resourceCount);
@@ -46,7 +46,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     this.priority = Optional.ofNullable(builder.priority);
     this.virtualCores = Optional.ofNullable(builder.virtualCores);
     this.relaxLocality = Optional.ofNullable(builder.relaxLocality);
-    this.runtimeName = Optional.ofNullable(builder.runtimeName);
+    this.runtimeName = BuilderUtils.notNull(builder.runtimeName);
   }
 
   @Override
@@ -85,7 +85,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
   }
 
   @Override
-  public Optional<String> getRuntimeName() {
+  public String getRuntimeName() {
     return runtimeName;
   }
 
@@ -117,7 +117,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
       this.priority = resourceRequestEvent.getPriority().orElse(null);
       this.virtualCores = resourceRequestEvent.getVirtualCores().orElse(null);
       this.relaxLocality = resourceRequestEvent.getRelaxLocality().orElse(null);
-      this.runtimeName = resourceRequestEvent.getRuntimeName().orElse(null);
+      this.runtimeName = resourceRequestEvent.getRuntimeName();
       return this;
     }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
@@ -202,7 +202,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     }
 
     /**
-     * @see ResourceRequestEvent#getRelaxLocality
+     * @see ResourceRequestEvent#getRuntimeName
      */
     public Builder setRuntimeName(final String runtimeName) {
       this.runtimeName = runtimeName;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
@@ -36,6 +36,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
   private final Optional<Integer> priority;
   private final Optional<Integer> virtualCores;
   private final Optional<Boolean> relaxLocality;
+  private final Optional<String> runtimeName;
 
   private ResourceRequestEventImpl(final Builder builder) {
     this.resourceCount = BuilderUtils.notNull(builder.resourceCount);
@@ -45,6 +46,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     this.priority = Optional.ofNullable(builder.priority);
     this.virtualCores = Optional.ofNullable(builder.virtualCores);
     this.relaxLocality = Optional.ofNullable(builder.relaxLocality);
+    this.runtimeName = Optional.ofNullable(builder.runtimeName);
   }
 
   @Override
@@ -82,6 +84,11 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     return relaxLocality;
   }
 
+  @Override
+  public Optional<String> getRuntimeName() {
+    return runtimeName;
+  }
+
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -97,6 +104,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     private Integer priority;
     private Integer virtualCores;
     private Boolean relaxLocality;
+    private String runtimeName;
 
     /**
      * Create a builder from an existing ResourceRequestEvent.
@@ -109,6 +117,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
       this.priority = resourceRequestEvent.getPriority().orElse(null);
       this.virtualCores = resourceRequestEvent.getVirtualCores().orElse(null);
       this.relaxLocality = resourceRequestEvent.getRelaxLocality().orElse(null);
+      this.runtimeName = resourceRequestEvent.getRuntimeName().orElse(null);
       return this;
     }
 
@@ -189,6 +198,14 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
      */
     public Builder setRelaxLocality(final boolean relaxLocality) {
       this.relaxLocality = relaxLocality;
+      return this;
+    }
+
+    /**
+     * @see ResourceRequestEvent#getRelaxLocality
+     */
+    public Builder setRuntimeName(final String runtimeName) {
+      this.runtimeName = runtimeName;
       return this;
     }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
@@ -46,7 +46,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     this.priority = Optional.ofNullable(builder.priority);
     this.virtualCores = Optional.ofNullable(builder.virtualCores);
     this.relaxLocality = Optional.ofNullable(builder.relaxLocality);
-    this.runtimeName = BuilderUtils.notNull(builder.runtimeName);
+    this.runtimeName = builder.runtimeName == null ? "" : builder.runtimeName;
   }
 
   @Override

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
@@ -244,7 +244,8 @@ public final class AllocatedEvaluatorImpl implements AllocatedEvaluator {
             .setRemoteId(this.remoteID)
             .setEvaluatorConf(evaluatorConfiguration)
             .addFiles(this.files)
-            .addLibraries(this.libraries);
+            .addLibraries(this.libraries)
+            .setRuntimeName(this.getEvaluatorDescriptor().getRuntimeName());
 
     rbuilder.setProcess(this.evaluatorManager.getEvaluatorDescriptor().getProcess());
     this.evaluatorManager.onResourceLaunch(rbuilder.build());

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -244,16 +244,20 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
             @Override
             public void onNext(final Alarm alarm) {
               EvaluatorManager.this.resourceReleaseHandler.onNext(
-                  ResourceReleaseEventImpl.newBuilder()
-                      .setIdentifier(EvaluatorManager.this.evaluatorId).build()
+                      ResourceReleaseEventImpl.newBuilder()
+                              .setIdentifier(EvaluatorManager.this.evaluatorId)
+                              .setRuntimeName(EvaluatorManager.this.getEvaluatorDescriptor().getRuntimeName())
+                              .build()
               );
             }
           });
         } catch (final IllegalStateException e) {
           LOG.log(Level.WARNING, "Force resource release because the client closed the clock.", e);
           EvaluatorManager.this.resourceReleaseHandler.onNext(
-              ResourceReleaseEventImpl.newBuilder()
-                  .setIdentifier(EvaluatorManager.this.evaluatorId).build()
+                  ResourceReleaseEventImpl.newBuilder()
+                          .setIdentifier(EvaluatorManager.this.evaluatorId)
+                          .setRuntimeName(EvaluatorManager.this.getEvaluatorDescriptor().getRuntimeName())
+                          .build()
           );
         }
       }


### PR DESCRIPTION
This changeset addresses the issue by:
  1)Adding runtime name to the evaluator request
  2)Propagating runtime name to the evaluatiormanager
  3)Adding runtime name to the Resource Events implementations

JIRA:
  [REEF-1196](https://issues.apache.org/jira/browse/REEF-1196)