### PR TITLE
[REEF-325] Make .NET tests part of the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ To build and test in Visual Studio, open
 Alternatively, you can build REEF.NET from a developer command line
 via:
 
-    msbuild .\lang\cs\Org.Apache.REEF.sln
+    msbuild .\lang\cs\Org.Apache.REEF.sln /p:Configuration="Debug" /p:Platform="x64"
 
 To test, execute the following command thereafter:
 
-    msbuild .\lang\cs\TestRunner.proj
+    msbuild .\lang\cs\TestRunner.proj /p:Configuration="Debug" /p:Platform="x64"
 
 Additional Information
 ----------------------

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ To build and test in Visual Studio, open
 Alternatively, you can build REEF.NET from a developer command line
 via:
 
-    msbuild .\lang\cs\Org.Apache.REEF.sln /p:Configuration="Debug" /p:Platform="x64"
+    msbuild .\lang\cs\Org.Apache.REEF.sln
 
 To test, execute the following command thereafter:
 
-    msbuild .\lang\cs\TestRunner.proj /p:Configuration="Debug" /p:Platform="x64"
+    msbuild .\lang\cs\TestRunner.proj
 
 Additional Information
 ----------------------

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ via:
 
 To test, execute the following command thereafter:
 
-    vstest.console.exe .\lang\cs\bin\x64\Debug\Org.Apache.REEF.Tests\Org.Apache.REEF.Tests.dll /Platform:x64
+    msbuild .\lang\cs\TestRunner.proj
 
 Additional Information
 ----------------------

--- a/lang/cs/Org.Apache.REEF.Client.Tests/Org.Apache.REEF.Client.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/Org.Apache.REEF.Client.Tests.csproj
@@ -113,7 +113,12 @@ under the License.
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <Target Name="Test">
+    <Exec Command="$(PackagesDir)\xunit.runner.console.2.1.0\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll"
+     IgnoreStandardErrorWarningFormat="true"
+    />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/lang/cs/Org.Apache.REEF.Common.Tests/Org.Apache.REEF.Common.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Common.Tests/Org.Apache.REEF.Common.Tests.csproj
@@ -91,7 +91,12 @@ under the License.
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <Target Name="Test">
+    <Exec Command="$(PackagesDir)\xunit.runner.console.2.1.0\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll"
+     IgnoreStandardErrorWarningFormat="true"
+    />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/Org.Apache.REEF.Evaluator.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/Org.Apache.REEF.Evaluator.Tests.csproj
@@ -128,4 +128,9 @@ under the License.
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
+  <Target Name="Test">
+    <Exec Command="$(PackagesDir)\xunit.runner.console.2.1.0\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll"
+     IgnoreStandardErrorWarningFormat="true"
+    />
+  </Target>
 </Project>

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/Org.Apache.REEF.IMRU.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/Org.Apache.REEF.IMRU.Tests.csproj
@@ -104,4 +104,9 @@ under the License.
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
+  <Target Name="Test">
+    <Exec Command="$(PackagesDir)\xunit.runner.console.2.1.0\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll"
+     IgnoreStandardErrorWarningFormat="true"
+    />
+  </Target>
 </Project>

--- a/lang/cs/Org.Apache.REEF.IO.Tests/Org.Apache.REEF.IO.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/Org.Apache.REEF.IO.Tests.csproj
@@ -118,4 +118,9 @@ under the License.
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
+  <Target Name="Test">
+    <Exec Command="$(PackagesDir)\xunit.runner.console.2.1.0\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll"
+     IgnoreStandardErrorWarningFormat="true"
+    />
+  </Target>
 </Project>

--- a/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
@@ -116,7 +116,12 @@ under the License.
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <Target Name="Test">
+    <Exec Command="$(PackagesDir)\xunit.runner.console.2.1.0\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll"
+     IgnoreStandardErrorWarningFormat="true"
+    />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.csproj
@@ -175,7 +175,12 @@ under the License.
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <Target Name="Test">
+    <Exec Command="$(PackagesDir)\xunit.runner.console.2.1.0\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll"
+     IgnoreStandardErrorWarningFormat="true"
+    />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -180,7 +180,12 @@ under the License.
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+  <Target Name="Test">
+    <Exec Command="$(PackagesDir)\xunit.runner.console.2.1.0\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll"
+     IgnoreStandardErrorWarningFormat="true"
+    />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.csproj
@@ -97,7 +97,12 @@ under the License.
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesDir)\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <Target Name="Test">
+    <Exec Command="$(PackagesDir)\xunit.runner.console.2.1.0\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll"
+     IgnoreStandardErrorWarningFormat="true"
+    />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/lang/cs/TestRunner.proj
+++ b/lang/cs/TestRunner.proj
@@ -21,6 +21,6 @@ under the License.
   </ItemGroup>
   <Target Name="Test">
     <MSBuild Projects="@(ProjectReferences)"
-             Targets="Test" Properties="Configuration=Debug;Platform=x64" StopOnFirstFailure="true" />
+             Targets="Test" Properties="Configuration=$(Configuration);Platform=$(Platform)" StopOnFirstFailure="true" />
   </Target>
 </Project>

--- a/lang/cs/TestRunner.proj
+++ b/lang/cs/TestRunner.proj
@@ -19,6 +19,12 @@ under the License.
   <ItemGroup>
     <ProjectReferences Include="*\*.Tests.csproj" />
   </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == '' ">
+    <Configuration>Debug</Configuration>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == '' ">
+    <Platform>x64</Platform>
+  </PropertyGroup>
   <Target Name="Test">
     <MSBuild Projects="@(ProjectReferences)"
              Targets="Test" Properties="Configuration=$(Configuration);Platform=$(Platform)" StopOnFirstFailure="true" />

--- a/lang/cs/TestRunner.proj
+++ b/lang/cs/TestRunner.proj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<Project DefaultTargets="Test" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProjectReferences Include="*\*.Tests.csproj" />
+  </ItemGroup>
+  <Target Name="Test">
+    <MSBuild Projects="@(ProjectReferences)"
+             Targets="Test" Properties="Configuration=Debug;Platform=x64" StopOnFirstFailure="true" />
+  </Target>
+</Project>

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -75,6 +75,6 @@ under the License.
   <!-- Locations -->
   <PropertyGroup>
     <!--The root directory of the REEF source tree. -->
-    <REEF_Source_Folder>$([System.IO.Path]::GetFullPath($(SolutionDir)\..\..))</REEF_Source_Folder>
+    <REEF_Source_Folder>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)\..\..\..))</REEF_Source_Folder>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This change
 * configures .NET tests to be executed with a single command.
   xUnit console runner is used to run tests.
 * modifies REEF_Source_Folder in build.props so that msbuild
   commands work regardless of current directory.

JIRA:
  [REEF-325](https://issues.apache.org/jira/browse/REEF-325)

Pull request:
  This closes #