### PR TITLE
[REEF-547] Remove deprecated registerErrorHandler method in RemoteManager

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
@@ -68,15 +68,6 @@ public class RemoteManager {
     return this.raw.registerHandler(messageType, theHandler);
   }
 
-  // TODO[JIRA REEF-547]: This method uses deprecated raw.registerErrorHandler.
-  /**
-   * @deprecated in 0.14, will be deleted in 0.15
-   */
-  @Deprecated
-  public AutoCloseable registerErrorHandler(final EventHandler<Exception> theHandler) {
-    return this.raw.registerErrorHandler(theHandler);
-  }
-
   public String getMyIdentifier() {
     return this.raw.getMyIdentifier().toString();
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManager.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManager.java
@@ -77,18 +77,6 @@ public interface RemoteManager extends Stage {
                                                  final EventHandler<RemoteMessage<T>> theHandler);
 
   /**
-   * Register an EventHandler that gets called by Wake in the presence of
-   * errors. Note that user-level errors that need to cross the network need
-   * to be handled as standard messages.
-   *
-   * @param theHandler the exception event handler
-   * @return the subscription that can be used to unsubscribe later
-   * @deprecated before 0.14, will be deleted in 0.15
-   */
-  @Deprecated
-  AutoCloseable registerErrorHandler(final EventHandler<Exception> theHandler);
-
-  /**
    * Access the Identifier of this.
    *
    * @return the Identifier of this.

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
@@ -153,18 +153,6 @@ public final class DefaultRemoteManagerImplementation implements RemoteManager {
   }
 
   /**
-   * Registers an exception handler and returns a subscription.
-   */
-  @Override
-  public AutoCloseable registerErrorHandler(final EventHandler<Exception> theHandler) {
-    if (LOG.isLoggable(Level.FINE)) {
-      LOG.log(Level.FINE, "RemoteManager: {0} handler: {1}",
-          new Object[]{this.name, theHandler.getClass().getName()});
-    }
-    return this.handlerContainer.registerErrorHandler(theHandler);
-  }
-
-  /**
    * Returns my identifier.
    */
   @Override


### PR DESCRIPTION
This is the last of the deprecated APIs listed in JIRA.

JIRA:
  [REEF-547](https://issues.apache.org/jira/browse/REEF-547)

Pull request:
  This closes #