### PR TITLE
[REEF-1219]  Adding CopyToLocal in FileSystemInputPartitionConfiguration

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileInputPartitionTest.cs
+++ b/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileInputPartitionTest.cs
@@ -54,7 +54,7 @@ namespace Org.Apache.REEF.IO.TestClient
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FilePathForPartitions, remoteFilePath1)
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FilePathForPartitions, remoteFilePath2)
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FileSerializerConfig, serializerConfString)
-                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.CopyLocal, "true")
+                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.CopyToLocal, "true")
                 .Build(),
                   HadoopFileSystemConfiguration.ConfigurationModule.Build())
                 .GetInstance<IPartitionedInputDataSet>();

--- a/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileInputPartitionTest.cs
+++ b/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileInputPartitionTest.cs
@@ -46,7 +46,6 @@ namespace Org.Apache.REEF.IO.TestClient
             var serializerConf = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindImplementation<IFileDeSerializer<IEnumerable<byte>>, ByteSerializer>(GenericType<IFileDeSerializer<IEnumerable<byte>>>.Class,
                     GenericType<ByteSerializer>.Class)
-                .BindNamedParam<CopyToLocal, bool>("true")
                 .Build();
             var serializerConfString = (new AvroConfigurationSerializer()).ToString(serializerConf);
 
@@ -55,6 +54,7 @@ namespace Org.Apache.REEF.IO.TestClient
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FilePathForPartitions, remoteFilePath1)
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FilePathForPartitions, remoteFilePath2)
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FileSerializerConfig, serializerConfString)
+                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.CopyLocal, "true")
                 .Build(),
                   HadoopFileSystemConfiguration.ConfigurationModule.Build())
                 .GetInstance<IPartitionedInputDataSet>();

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
@@ -52,7 +52,7 @@ namespace Org.Apache.REEF.IO.Tests
             var dataSet = TangFactory.GetTang()
                 .NewInjector(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.ConfigurationModule
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FilePathForPartitions, filePaths)
-                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.CopyLocal, "true")
+                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.CopyToLocal, "true")
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FileSerializerConfig,
                         GetByteSerializerConfigString())
                     .Build())
@@ -77,7 +77,7 @@ namespace Org.Apache.REEF.IO.Tests
                         sourceFilePath1 + ";" + sourceFilePath2)
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FileSerializerConfig,
                         GetByteSerializerConfigString())
-                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.CopyLocal, "true")
+                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.CopyToLocal, "true")
                     .Build())
                 .GetInstance<IPartitionedInputDataSet>();
 
@@ -197,7 +197,7 @@ namespace Org.Apache.REEF.IO.Tests
                 .NewInjector(FileSystemInputPartitionConfiguration<IEnumerable<Row>>.ConfigurationModule
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<Row>>.FilePathForPartitions, sourceFilePath1)
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<Row>>.FilePathForPartitions, sourceFilePath2)
-                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<Row>>.CopyLocal, "true")
+                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<Row>>.CopyToLocal, "true")
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<Row>>.FileSerializerConfig, GetRowSerializerConfigString())
                     .Build())
                 .GetInstance<IPartitionedInputDataSet>();

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
@@ -52,6 +52,7 @@ namespace Org.Apache.REEF.IO.Tests
             var dataSet = TangFactory.GetTang()
                 .NewInjector(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.ConfigurationModule
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FilePathForPartitions, filePaths)
+                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.CopyLocal, "true")
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FileSerializerConfig,
                         GetByteSerializerConfigString())
                     .Build())
@@ -76,6 +77,7 @@ namespace Org.Apache.REEF.IO.Tests
                         sourceFilePath1 + ";" + sourceFilePath2)
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FileSerializerConfig,
                         GetByteSerializerConfigString())
+                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.CopyLocal, "true")
                     .Build())
                 .GetInstance<IPartitionedInputDataSet>();
 
@@ -195,6 +197,7 @@ namespace Org.Apache.REEF.IO.Tests
                 .NewInjector(FileSystemInputPartitionConfiguration<IEnumerable<Row>>.ConfigurationModule
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<Row>>.FilePathForPartitions, sourceFilePath1)
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<Row>>.FilePathForPartitions, sourceFilePath2)
+                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<Row>>.CopyLocal, "true")
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<Row>>.FileSerializerConfig, GetRowSerializerConfigString())
                     .Build())
                 .GetInstance<IPartitionedInputDataSet>();
@@ -287,7 +290,6 @@ namespace Org.Apache.REEF.IO.Tests
                 .BindImplementation<IFileDeSerializer<IEnumerable<byte>>, ByteSerializer>(
                     GenericType<IFileDeSerializer<IEnumerable<byte>>>.Class,
                     GenericType<ByteSerializer>.Class)
-                .BindNamedParam<CopyToLocal, bool>("true")
                 .Build();
             return (new AvroConfigurationSerializer()).ToString(serializerConf);
         }
@@ -298,7 +300,6 @@ namespace Org.Apache.REEF.IO.Tests
                 .BindImplementation<IFileDeSerializer<IEnumerable<Row>>, RowSerializer>(
                     GenericType<IFileDeSerializer<IEnumerable<Row>>>.Class,
                     GenericType<RowSerializer>.Class)
-                .BindNamedParam<CopyToLocal, bool>("true")
                 .Build();
             return (new AvroConfigurationSerializer()).ToString(serializerConf);
         }

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileInputPartitionDescriptor.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileInputPartitionDescriptor.cs
@@ -31,11 +31,13 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         private readonly string _id;
         private readonly IList<string> _filePaths;
         private readonly IConfiguration _filePartitionDeserializerConfig;
+        private readonly bool _copyToLocal;
 
-        internal FileInputPartitionDescriptor(string id, IList<string> filePaths, IConfiguration filePartitionDeserializerConfig)
+        internal FileInputPartitionDescriptor(string id, IList<string> filePaths, bool copyToLocal, IConfiguration filePartitionDeserializerConfig)
         {
             _id = id;
             _filePaths = filePaths;
+            _copyToLocal = copyToLocal;
             _filePartitionDeserializerConfig = filePartitionDeserializerConfig;
         }
 
@@ -52,6 +54,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         {
             var builder = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindImplementation(GenericType<IInputPartition<T>>.Class, GenericType<FileSystemInputPartition<T>>.Class)
+                .BindNamedParameter<CopyToLocal, bool>(GenericType<CopyToLocal>.Class, _copyToLocal.ToString())
                 .BindStringNamedParam<PartitionId>(_id);
 
             foreach (string p in _filePaths)

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartitionConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartitionConfiguration.cs
@@ -41,7 +41,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         /// <summary>
         /// This specify if the file needs to be copied to local in FilePathsForInputPartitions 
         /// </summary>
-        public static readonly OptionalParameter<bool> CopyLocal = new OptionalParameter<bool>();
+        public static readonly OptionalParameter<bool> CopyToLocal = new OptionalParameter<bool>();
 
         /// <summary>
         /// This configuration module set FileSystemDataSet as IPartitionedDataSet.
@@ -51,7 +51,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
             .BindImplementation(GenericType<IPartitionedInputDataSet>.Class, GenericType<FileSystemPartitionInputDataSet<T>>.Class)
             .BindSetEntry(GenericType<FilePathsForInputPartitions>.Class, FilePathForPartitions)
             .BindNamedParameter(GenericType<FileDeSerializerConfigString>.Class, FileSerializerConfig)
-            .BindNamedParameter(GenericType<CopyToLocal>.Class, CopyLocal)
+            .BindNamedParameter(GenericType<CopyToLocal>.Class, CopyToLocal)
             .Build();
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartitionConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartitionConfiguration.cs
@@ -39,6 +39,11 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         public static readonly RequiredParameter<string> FileSerializerConfig = new RequiredParameter<string>();
 
         /// <summary>
+        /// This specify if the file needs to be copied to local in FilePathsForInputPartitions 
+        /// </summary>
+        public static readonly OptionalParameter<bool> CopyLocal = new OptionalParameter<bool>();
+
+        /// <summary>
         /// This configuration module set FileSystemDataSet as IPartitionedDataSet.
         /// It also set required parameters for injecting FileSystemDataSet
         /// </summary>
@@ -46,6 +51,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
             .BindImplementation(GenericType<IPartitionedInputDataSet>.Class, GenericType<FileSystemPartitionInputDataSet<T>>.Class)
             .BindSetEntry(GenericType<FilePathsForInputPartitions>.Class, FilePathForPartitions)
             .BindNamedParameter(GenericType<FileDeSerializerConfigString>.Class, FileSerializerConfig)
+            .BindNamedParameter(GenericType<CopyToLocal>.Class, CopyLocal)
             .Build();
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionInputDataSet.cs
@@ -51,6 +51,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         private FileSystemPartitionInputDataSet(
             [Parameter(typeof(FilePathsForInputPartitions))] ISet<string> filePaths,
             IFileSystem fileSystem,
+            [Parameter(typeof(CopyToLocal))] bool copyToLocal,
             [Parameter(typeof(FileDeSerializerConfigString))] string fileSerializerConfigString,
             AvroConfigurationSerializer avroConfigurationSerializer)
         {
@@ -68,7 +69,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
                 var paths = path.Split(new string[] { StringSeparators }, StringSplitOptions.None);
                
                 var id = "FilePartition-" + i++;
-                _partitions[id] = new FileInputPartitionDescriptor<T>(id, paths.ToList(), fileSerializerConfig); 
+                _partitions[id] = new FileInputPartitionDescriptor<T>(id, paths.ToList(), copyToLocal, fileSerializerConfig); 
             }
         }
 


### PR DESCRIPTION
Add CopyToLocal  to FileSystemInputPartition Configuration module builder
Update FileSystemPartitionInputDataSet to take it as a named parameter and pass it to the FileInputPartitionDescriptor
Add it to GetPartitionConfiguration() in FileInputPartitionDescriptor

JIRA: [REEF-1219](https://issues.apache.org/jira/browse/REEF-1219)

This closes #