### PR TITLE
[REEF-1229] Make sure Evaluator PID is written for short lived Evaluators

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
@@ -62,7 +62,7 @@ public final class REEFLauncher {
   private static final Logger LOG = Logger.getLogger(REEFLauncher.class.getName());
 
   private static final Configuration LAUNCHER_STATIC_CONFIG = Tang.Factory.getTang().newConfigurationBuilder()
-          .bindSetEntry(Clock.StartHandler.class, PIDStoreStartHandler.class)
+          .bindSetEntry(Clock.RuntimeStartHandler.class, PIDStoreStartHandler.class)
           .bindNamedParameter(RemoteConfiguration.ErrorHandler.class, REEFErrorHandler.class)
           .bindNamedParameter(RemoteConfiguration.ManagerName.class, "REEF_LAUNCHER")
           .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/ExtensibleLocalRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/ExtensibleLocalRuntimeConfiguration.java
@@ -22,7 +22,6 @@ import org.apache.reef.client.parameters.DriverConfigurationProviders;
 import org.apache.reef.runtime.common.client.CommonRuntimeConfiguration;
 import org.apache.reef.runtime.common.client.DriverConfigurationProvider;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
-import org.apache.reef.runtime.common.evaluator.PIDStoreStartHandler;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.local.LocalClasspathProvider;
@@ -31,7 +30,6 @@ import org.apache.reef.runtime.local.client.parameters.RackNames;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.tang.formats.*;
-import org.apache.reef.wake.time.Clock;
 
 import java.util.concurrent.ExecutorService;
 
@@ -91,7 +89,6 @@ public final class ExtensibleLocalRuntimeConfiguration extends ConfigurationModu
           .bindNamedParameter(RootFolder.class, RUNTIME_ROOT_FOLDER)
           .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
           .bindSetEntry(DriverConfigurationProviders.class, DRIVER_CONFIGURATION_PROVIDERS)
-          .bindSetEntry(Clock.StartHandler.class, PIDStoreStartHandler.class)
           .bindSetEntry(RackNames.class, RACK_NAMES)
           .build();
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
@@ -22,7 +22,6 @@ import org.apache.reef.client.parameters.DriverConfigurationProviders;
 import org.apache.reef.runtime.common.client.CommonRuntimeConfiguration;
 import org.apache.reef.runtime.common.client.DriverConfigurationProvider;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
-import org.apache.reef.runtime.common.evaluator.PIDStoreStartHandler;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.local.LocalClasspathProvider;
@@ -31,7 +30,6 @@ import org.apache.reef.runtime.local.client.parameters.RackNames;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.tang.formats.*;
-import org.apache.reef.wake.time.Clock;
 
 import java.util.concurrent.ExecutorService;
 
@@ -86,7 +84,6 @@ public class LocalRuntimeConfiguration extends ConfigurationModuleBuilder {
       .bindNamedParameter(RootFolder.class, RUNTIME_ROOT_FOLDER)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
       .bindSetEntry(DriverConfigurationProviders.class, DRIVER_CONFIGURATION_PROVIDERS)
-      .bindSetEntry(Clock.StartHandler.class, PIDStoreStartHandler.class)
       .bindSetEntry(RackNames.class, RACK_NAMES)
       .build();
 

--- a/lang/java/reef-runtime-standalone/src/main/java/org/apache/reef/runtime/standalone/client/StandaloneRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-standalone/src/main/java/org/apache/reef/runtime/standalone/client/StandaloneRuntimeConfiguration.java
@@ -21,12 +21,10 @@ package org.apache.reef.runtime.standalone.client;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.client.parameters.DriverConfigurationProviders;
 import org.apache.reef.runtime.common.client.CommonRuntimeConfiguration;
-import org.apache.reef.runtime.common.evaluator.PIDStoreStartHandler;
 import org.apache.reef.runtime.standalone.client.parameters.NodeListFilePath;
 import org.apache.reef.runtime.standalone.client.parameters.RootFolder;
 import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.tang.formats.*;
-import org.apache.reef.wake.time.Clock;
 
 /**
  * A ConfigurationModule to configure the standalone resourcemanager.
@@ -62,8 +60,5 @@ public final class StandaloneRuntimeConfiguration extends ConfigurationModuleBui
       .bindNamedParameter(RootFolder.class, RUNTIME_ROOT_FOLDER)
       .bindNamedParameter(NodeListFilePath.class, NODE_LIST_FILE_PATH)
       .bindSetEntry(DriverConfigurationProviders.class, DRIVER_CONFIGURATION_PROVIDERS)
-      .bindSetEntry(Clock.StartHandler.class, PIDStoreStartHandler.class)
       .build();
-
-
 }


### PR DESCRIPTION
  This makes `PIDStoreStartHandler` an `EventHandler<RuntimeStart>` and adds
  synchronization logic in `EvaluatorRuntime` to make sure it is always
  invoked.

  Also, this removes the double bindings of `PIDStoreStartHandler`, which was
  bound in the various runtimes as well as in `REEFLauncher`. This change
  binds it only in `REEFLauncher`

JIRA:
  [REEF-1229](https://issues.apache.org/jira/browse/REEF-1229)