### PR TITLE
[REEF-1228] Fix TestDriverConfigGenerator failure on the first test run

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -92,7 +92,6 @@ under the License.
     <Compile Include="Common\JobSubmissionResult.cs" />
     <Compile Include="Common\JavaClientLauncher.cs" />
     <Compile Include="Common\ResourceArchiveFileGenerator.cs" />
-    <Compile Include="Common\ResourceHelper.cs" />
     <Compile Include="Local\LocalClient.cs" />
     <Compile Include="Local\LocalJobSubmissionResult.cs" />
     <Compile Include="Local\LocalRuntimeClientConfiguration.cs" />

--- a/lang/cs/Org.Apache.REEF.Common/Jar/ResourceHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Jar/ResourceHelper.cs
@@ -16,17 +16,39 @@
 // under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Resources;
+using Org.Apache.REEF.Utilities.Attributes;
 
-namespace Org.Apache.REEF.Client.Common
+namespace Org.Apache.REEF.Common.Jar
 {
     /// <summary>
     /// Helps with retrieval of embedded resources.
     /// See Org.Apache.REEF.Client.csproj for embedding resources and use this class to retrieve them.
     /// </summary>
-    internal class ResourceHelper
+    [Private]
+    public class ResourceHelper
     {
+        public const string ClientJarFullName = "ClientJarFullName";
+        public const string DriverJarFullName = "DriverJarFullName";
+        public const string ClrDriverFullName = "ClrDriverFullName";
+
+        // We embed certain binaries in client dll.
+        // Following items in tuples refer to resource names in Org.Apache.REEF.Client.dll
+        // The first resource item contains the name of the file 
+        // such as "reef-bridge-java-<version>-shaded.jar". The second resource
+        // item contains the byte contents for said file.
+        // Please note that the identifiers below need to be in sync with 2 other files
+        // 1. $(SolutionDir)\Org.Apache.REEF.Client\Properties\Resources.xml
+        // 2. $(SolutionDir)\Org.Apache.REEF.Client\Org.Apache.REEF.Client.csproj
+        public readonly static Dictionary<string, string> FileResources = new Dictionary<string, string>
+        {
+            { ClientJarFullName, "reef_bridge_client" },
+            { DriverJarFullName, "reef_bridge_driver" },
+            { ClrDriverFullName, "reef_clrdriver" },
+        };
+
         private const string CouldNotRetrieveResource = "Could not retrieve resource '{0}'";
         private readonly ResourceSet _resourceSet;
 
@@ -35,7 +57,7 @@ namespace Org.Apache.REEF.Client.Common
         /// </summary>
         /// <param name="assembly"></param>
         /// <returns>ResourceSet</returns>
-        internal ResourceHelper(Assembly assembly)
+        public ResourceHelper(Assembly assembly)
         {
             var names = assembly.GetManifestResourceNames();
             if (null == names[0])
@@ -71,7 +93,7 @@ namespace Org.Apache.REEF.Client.Common
         /// </summary>
         /// <param name="resourceName"></param>
         /// <returns>T</returns>
-        internal string GetString(string resourceName)
+        public string GetString(string resourceName)
         {
             return GetResource<string>(resourceName);
         }
@@ -81,7 +103,7 @@ namespace Org.Apache.REEF.Client.Common
         /// </summary>
         /// <param name="resourceName"></param>
         /// <returns>T</returns>
-        internal byte[] GetBytes(string resourceName)
+        public byte[] GetBytes(string resourceName)
         {
             return GetResource<byte[]>(resourceName);
         }

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -107,6 +107,7 @@ under the License.
     <Compile Include="Io\NamingConfiguration.cs" />
     <Compile Include="Io\NamingConfigurationOptions.cs" />
     <Compile Include="Io\TcpPortConfigurationProvider.cs" />
+    <Compile Include="Jar\ResourceHelper.cs" />
     <Compile Include="ITaskSubmittable.cs" />
     <Compile Include="Client\Parameters\DriverConfigurationProviders.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/lang/cs/Org.Apache.REEF.Tests/Utility/TestDriverConfigGenerator.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Utility/TestDriverConfigGenerator.cs
@@ -16,13 +16,27 @@
 // under the License.
 
 using System;
+using System.IO;
 using Org.Apache.REEF.Driver;
+using Org.Apache.REEF.Client.Common;
+using Org.Apache.REEF.Common.Jar;
 using Xunit;
 
 namespace Org.Apache.REEF.Tests.Utility
 {
     public class TestDriverConfigGenerator
     {
+        public TestDriverConfigGenerator()
+        {
+            var resourceHelper = new ResourceHelper(typeof(IJobSubmissionResult).Assembly);
+            var fileName = resourceHelper.GetString(ResourceHelper.DriverJarFullName);
+            if (!File.Exists(fileName))
+            {
+                File.WriteAllBytes(fileName, 
+                    resourceHelper.GetBytes(ResourceHelper.FileResources[ResourceHelper.DriverJarFullName]));
+            }
+        }
+
         [Fact]
         public void TestGeneratingFullDriverConfigFile()
         {


### PR DESCRIPTION
This change modifies TestDriverConfigGenerator to extract
reef-bridge-java-<version>-shaded.jar from O.A.R.Client assembly resources
before running tests.

JIRA:
  [REEF-1228](https://issues.apache.org/jira/browse/REEF-1228)

Pull request:
  This closes #