### PR TITLE
[REEF-1212] Make Org.Apache.REEF.Client.Yarn.IJobResourceUploader int…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client.Tests/JobResourceUploaderTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/JobResourceUploaderTests.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using NSubstitute;
 using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Client.Yarn;
@@ -52,25 +53,25 @@ namespace Org.Apache.REEF.Client.Tests
         }
 
         [Fact]
-        public void UploadJobResourceCreatesResourceArchive()
+        public async Task UploadJobResourceCreatesResourceArchive()
         {
             var testContext = new TestContext();
             var jobResourceUploader = testContext.GetJobResourceUploader();
 
-            jobResourceUploader.UploadArchiveResource(AnyDriverLocalFolderPath, AnyDriverResourceUploadPath);
+            await jobResourceUploader.UploadArchiveResourceAsync(AnyDriverLocalFolderPath, AnyDriverResourceUploadPath);
 
             // Archive file generator recieved exactly one call with correct driver local folder path
             testContext.ResourceArchiveFileGenerator.Received(1).CreateArchiveToUpload(AnyDriverLocalFolderPath);
         }
 
         [Fact]
-        public void UploadJobResourceReturnsJobResourceDetails()
+        public async Task UploadJobResourceReturnsJobResourceDetails()
         {
             var testContext = new TestContext();
             var jobResourceUploader = testContext.GetJobResourceUploader();
 
-            var archiveJobResource = jobResourceUploader.UploadArchiveResource(AnyDriverLocalFolderPath, AnyDriverResourceUploadPath);
-            var fileJobResource = jobResourceUploader.UploadFileResource(AnyLocalJobFilePath, AnyDriverResourceUploadPath);
+            var archiveJobResource = await jobResourceUploader.UploadArchiveResourceAsync(AnyDriverLocalFolderPath, AnyDriverResourceUploadPath);
+            var fileJobResource = await jobResourceUploader.UploadFileResourceAsync(AnyLocalJobFilePath, AnyDriverResourceUploadPath);
             var jobResources = new List<JobResource> { archiveJobResource, fileJobResource };
 
             foreach (var resource in jobResources)
@@ -85,13 +86,13 @@ namespace Org.Apache.REEF.Client.Tests
         }
 
         [Fact]
-        public void UploadJobResourceMakesCorrectFileSystemCalls()
+        public async Task UploadJobResourceMakesCorrectFileSystemCalls()
         {
             var testContext = new TestContext();
             var jobResourceUploader = testContext.GetJobResourceUploader();
 
-            jobResourceUploader.UploadArchiveResource(AnyDriverLocalFolderPath, AnyDriverResourceUploadPath);
-            jobResourceUploader.UploadFileResource(AnyLocalJobFilePath, AnyDriverResourceUploadPath);
+            await jobResourceUploader.UploadArchiveResourceAsync(AnyDriverLocalFolderPath, AnyDriverResourceUploadPath);
+            await jobResourceUploader.UploadFileResourceAsync(AnyLocalJobFilePath, AnyDriverResourceUploadPath);
 
             testContext.FileSystem.Received(1).CreateUriForPath(AnyUploadedResourcePath);
 

--- a/lang/cs/Org.Apache.REEF.Client/Common/IJavaClientLauncher.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/IJavaClientLauncher.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.Client.Common
@@ -26,7 +27,7 @@ namespace Org.Apache.REEF.Client.Common
     [DefaultImplementation(typeof(JavaClientLauncher))]
     internal interface IJavaClientLauncher
     {
-        void Launch(string javaClassName, params string[] parameters);
+        Task LaunchAsync(string javaClassName, params string[] parameters);
 
         /// <summary>
         /// Add entries to the end of the classpath of the java client.

--- a/lang/cs/Org.Apache.REEF.Client/Local/LocalClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Local/LocalClient.cs
@@ -157,7 +157,8 @@ namespace Org.Apache.REEF.Client.Local
             var driverFolder = PrepareDriverFolder(jobRequest);
             var submissionJobArgsFilePath = CreateBootstrapAvroJobConfig(jobRequest.JobParameters, driverFolder);
             var submissionAppArgsFilePath = CreateBootstrapAvroAppConfig(jobRequest.AppParameters, driverFolder);
-            _javaClientLauncher.Launch(JavaClassName, submissionJobArgsFilePath, submissionAppArgsFilePath);
+            _javaClientLauncher.LaunchAsync(JavaClassName, submissionJobArgsFilePath, submissionAppArgsFilePath)
+                .GetAwaiter().GetResult();
             Logger.Log(Level.Info, "Submitted the Driver for execution.");
         }
 
@@ -167,7 +168,8 @@ namespace Org.Apache.REEF.Client.Local
             var submissionJobArgsFilePath = CreateBootstrapAvroJobConfig(jobRequest.JobParameters, driverFolder);
             var submissionAppArgsFilePath = CreateBootstrapAvroAppConfig(jobRequest.AppParameters, driverFolder);
 
-            Task.Run(() => _javaClientLauncher.Launch(JavaClassName, submissionJobArgsFilePath, submissionAppArgsFilePath));
+            _javaClientLauncher.LaunchAsync(JavaClassName, submissionJobArgsFilePath, submissionAppArgsFilePath)
+                .GetAwaiter().GetResult();
 
             var fileName = Path.Combine(driverFolder, _fileNames.DriverHttpEndpoint);
             JobSubmissionResult result = new LocalJobSubmissionResult(this, fileName);

--- a/lang/cs/Org.Apache.REEF.Client/YARN/IJobResourceUploader.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/IJobResourceUploader.cs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System.Threading.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.Client.Yarn
@@ -28,7 +29,7 @@ namespace Org.Apache.REEF.Client.Yarn
         /// <param name="driverLocalFolderPath">Local folder where REEF application resources are staged</param>
         /// <param name="remoteUploadDirectoryPath">Remote directory path where we will upload resources</param>
         /// <returns>Path, modification time and size of uploaded file as JobResource</returns>
-        JobResource UploadArchiveResource(string driverLocalFolderPath, string remoteUploadDirectoryPath);
+        Task<JobResource> UploadArchiveResourceAsync(string driverLocalFolderPath, string remoteUploadDirectoryPath);
 
         /// <summary>
         /// Locates a file resource and uploads it to DFS destination path.
@@ -36,6 +37,6 @@ namespace Org.Apache.REEF.Client.Yarn
         /// <param name="fileLocalPath">file path</param>
         /// <param name="remoteUploadDirectoryPath">Remote directory path where we will upload resources</param>
         /// <returns>Path, modification time and size of uploaded file as JobResource</returns>
-        JobResource UploadFileResource(string fileLocalPath, string remoteUploadDirectoryPath);
+        Task<JobResource> UploadFileResourceAsync(string fileLocalPath, string remoteUploadDirectoryPath);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
@@ -125,7 +125,9 @@ namespace Org.Apache.REEF.Client.Yarn
             var submissionAppArgsFilePath = _paramSerializer.SerializeAppFile(jobRequest.AppParameters, paramInjector, driverFolderPath);
 
             // Submit the driver
-            _javaClientLauncher.Launch(JavaClassName, submissionJobArgsFilePath, submissionAppArgsFilePath);
+            _javaClientLauncher.LaunchAsync(JavaClassName, submissionJobArgsFilePath, submissionAppArgsFilePath)
+                .GetAwaiter()
+                .GetResult();
             Logger.Log(Level.Info, "Submitted the Driver for execution." + jobRequest.JobIdentifier);
         }
 

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetClient.cs
@@ -97,12 +97,18 @@ namespace Org.Apache.REEF.Client.YARN
                 _paramSerializer.SerializeAppFile(jobRequest.AppParameters, paramInjector, localDriverFolderPath);
                 _paramSerializer.SerializeJobFile(jobRequest.JobParameters, localDriverFolderPath, jobSubmissionDirectory);
 
-                var archiveResource = _jobResourceUploader.UploadArchiveResource(localDriverFolderPath, jobSubmissionDirectory);
+                var archiveResource =
+                    _jobResourceUploader.UploadArchiveResourceAsync(localDriverFolderPath, jobSubmissionDirectory)
+                        .GetAwaiter()
+                        .GetResult();
 
                 // Path to the job args file.
                 var jobArgsFilePath = Path.Combine(localDriverFolderPath, _fileNames.GetJobSubmissionParametersFile());
 
-                var argFileResource = _jobResourceUploader.UploadFileResource(jobArgsFilePath, jobSubmissionDirectory);
+                var argFileResource =
+                    _jobResourceUploader.UploadFileResourceAsync(jobArgsFilePath, jobSubmissionDirectory)
+                        .GetAwaiter()
+                        .GetResult();
 
                 // upload prepared folder to DFS
                 var jobResources = new List<JobResource> { archiveResource, argFileResource };


### PR DESCRIPTION
…erface async

This addressed the issue by

  * Making the interface async
  * Make IJavaClientLauncher async and use this in legacy uploader
  * Fix usages and tests

JIRA:
 [REEF-1212](https://issues.apache.org/jira/browse/REEF-1212)