### PR TITLE
[REEF-1232] Fix binding in TaskConfiguration for ITaskMessageSource

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Tasks/TaskConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Tasks/TaskConfiguration.cs
@@ -94,7 +94,7 @@ namespace Org.Apache.REEF.Common.Tasks
             {
                 return new TaskConfiguration()
                     .BindImplementation(GenericType<ITask>.Class, Task)
-                    .BindImplementation(GenericType<ITaskMessageSource>.Class, OnSendMessage)
+                    .BindSetEntry(GenericType<TaskConfigurationOptions.TaskMessageSources>.Class, OnSendMessage)
                     .BindImplementation(GenericType<IDriverMessageHandler>.Class, OnMessage)
                     .BindImplementation(GenericType<IDriverConnectionMessageHandler>.Class, OnDriverConnectionChanged)
                     .BindNamedParameter(GenericType<TaskConfigurationOptions.Identifier>.Class, Identifier)

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestContextStack.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestContextStack.cs
@@ -57,8 +57,8 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             CleanUp(testFolder);
             TestRun(DriverConfigurations(), typeof(ContextStackHandlers), 1, "testContextStack", "local", testFolder);
             ValidateSuccessForLocalRuntime(2, testFolder: testFolder);
-            ValidateMessageSuccessfullyLogged(TaskValidationMessage, testFolder);
-            ValidateMessageSuccessfullyLogged(ClosedContextValidationMessage, testFolder);
+            ValidateMessageSuccessfullyLoggedForDriver(TaskValidationMessage, testFolder);
+            ValidateMessageSuccessfullyLoggedForDriver(ClosedContextValidationMessage, testFolder);
             CleanUp(testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
@@ -50,7 +50,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             CleanUp(testFolder);
             TestRun(DriverConfigurations(), typeof(FailedEvaluatorDriver), 1, "failedEvaluatorTest", "local", testFolder);
             ValidateSuccessForLocalRuntime(0, numberOfEvaluatorsToFail: 1, testFolder: testFolder);
-            ValidateMessageSuccessfullyLogged(FailedEvaluatorMessage, testFolder);
+            ValidateMessageSuccessfullyLoggedForDriver(FailedEvaluatorMessage, testFolder);
             CleanUp(testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
@@ -51,7 +51,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             CleanUp(testFolder);
             TestRun(DriverConfigurations(), typeof(FailedTaskDriver), 1, "failedTaskTest", "local", testFolder);
             ValidateSuccessForLocalRuntime(numberOfContextsToClose: 1, numberOfTasksToFail: 1, testFolder: testFolder);
-            ValidateMessageSuccessfullyLogged(FailedTaskMessage, testFolder);
+            ValidateMessageSuccessfullyLoggedForDriver(FailedTaskMessage, testFolder);
             CleanUp(testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleContext.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleContext.cs
@@ -64,7 +64,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             CleanUp(testFolder);
             TestRun(configuration, typeof(TestContextHandlers), 1, "testSimpleContext", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder: testFolder);
-            ValidateMessageSuccessfullyLogged(ValidationMessage, testFolder);
+            ValidateMessageSuccessfullyLoggedForDriver(ValidationMessage, testFolder);
             CleanUp(testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
@@ -50,7 +50,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             CleanUp(testFolder);
             TestRun(DriverConfigurations(), typeof(HelloSimpleEventHandlers), 2, "simpleHandler", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder: testFolder);
-            ValidateMessageSuccessfullyLogged("Evaluator is assigned with 3072 MB of memory and 1 cores.", testFolder);
+            ValidateMessageSuccessfullyLoggedForDriver("Evaluator is assigned with 3072 MB of memory and 1 cores.", testFolder);
             CleanUp(testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/MessageTask.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/MessageTask.cs
@@ -44,10 +44,11 @@ namespace Org.Apache.REEF.Tests.Functional.Messaging
         public Optional<TaskMessage> Message
         {
             get
-            {
+            {              
                 TaskMessage defaultTaskMessage = TaskMessage.From(
                     "messagingSourceId",
                     ByteUtilities.StringToByteArrays(MessageSend + " generated at " + DateTime.Now.ToString(CultureInfo.InvariantCulture)));
+                LOGGER.Log(Level.Info, "Message is sent back from task to driver:" + defaultTaskMessage.Message);
                 return Optional<TaskMessage>.Of(defaultTaskMessage);
             }
 
@@ -70,7 +71,6 @@ namespace Org.Apache.REEF.Tests.Functional.Messaging
 
         private void DriverMessage(string message)
         {
-            LOGGER.Log(Level.Info, "Received DriverMessage in TaskMsg: " + message);
             if (!message.Equals(MessageDriver.Message))
             {
                 Exceptions.Throw(new Exception("Unexpected driver message: " + message), "Unexpected driver message received: " + message, LOGGER);
@@ -90,10 +90,10 @@ namespace Org.Apache.REEF.Tests.Functional.Messaging
             public void Handle(IDriverMessage value)
             {
                 string message = string.Empty;
-                LOGGER.Log(Level.Verbose, "Received a message from driver, handling it with MessagingDriverMessageHandler");
                 if (value.Message.IsPresent())
                 {
                     message = ByteUtilities.ByteArraysToString(value.Message.Value);
+                    LOGGER.Log(Level.Info, "Received a message from driver, handling it with MessagingDriverMessageHandler:" + message);
                 }
                 _parentTask.DriverMessage(message);
             }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/TestTaskMessage.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/TestTaskMessage.cs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Defaults;
@@ -48,10 +51,22 @@ namespace Org.Apache.REEF.Tests.Functional.Messaging
         //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestSendTaskMessage()
         {
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
+            string testFolder = DefaultRuntimeFolder + Guid.NewGuid();
             CleanUp(testFolder);
             TestRun(DriverConfigurations(), typeof(MessageDriver), 1, "simpleHandler", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder: testFolder);
+
+            var messages = new List<string>();
+            messages.Add("TaskMessagingTaskMessageHandler received following message from Task:");
+            messages.Add("Message: MESSAGE:TASK generated");
+            messages.Add("is to send message MESSAGE::DRIVER");      
+            ValidateMessageSuccessfullyLogged(messages, "driver", DriverStdout, testFolder, 0);
+
+            var messages2 = new List<string>();
+            messages.Add("Received a message from driver, handling it with MessagingDriverMessageHandler:MESSAGE::DRIVER");
+            messages.Add("Message is sent back from task to driver:");
+            ValidateMessageSuccessfullyLogged(messages2, "Node-*", EvaluatorStdout, testFolder, 0);
+
             CleanUp(testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTest.cs
@@ -50,7 +50,7 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
             string testFolder = DefaultRuntimeFolder + TestNumber++;
             CleanUp(testFolder);
             TestRun(DriverConfigurationsWithEvaluatorRequest(), typeof(EvaluatorRequestingDriver), 1, "EvaluatorRequestingDriver", "local", testFolder);
-            ValidateMessageSuccessfullyLogged("Runtime Name: Local", testFolder, 2);
+            ValidateMessageSuccessfullyLoggedForDriver("Runtime Name: Local", testFolder, 2);
             CleanUp(testFolder);
         }
 


### PR DESCRIPTION
*replace the binding in TaskConfiguration for ITaskMessageSource from an interface to a set of interface
*Update TestTaskMessage classes to verify the messages back forth between driver and task
*Update  test bases class for evaluator log validation as well.

JIRA: [REEF-1232](https://issues.apache.org/jira/browse/REEF-1232)

This closes #