### PR TITLE
[REEF-743] Convert project files to Visual Studio 2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Requirements
     `mvn` is in your `PATH`.
   * [Protocol Buffers](https://code.google.com/p/protobuf/) Compiler
     version 2.5. Make sure that `protoc` is on your `PATH`.
-  * For REEF.NET, you will also need [Visual Studio
-    2013](http://www.visualstudio.com). Most REEF developers use the
-    free Community Edition.
+  * For REEF.NET, you will also need [Visual Studio]
+    (http://www.visualstudio.com), preferably Version 2015 (2013 is still 
+    supported). Most REEF developers use the free Community Edition.
 
 REEF Java
 ---------

--- a/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj
+++ b/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj
@@ -43,15 +43,31 @@ under the License.
     <RootNamespace>Org.Apache.REEF.Bridge</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <!--
+    Switch the PlatformToolset based on the Visual Studio Version
+  -->
+  <PropertyGroup>
+    <!-- Assume Visual Studio 2015 / 14.0 as the default -->
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <!-- Visual Studio 2013 (12.0) -->
+  <PropertyGroup Condition="'$(VisualStudioVersion)' == '12.0'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <!-- Visual Studio 2015 (14.0) -->
+  <PropertyGroup Condition="'$(VisualStudioVersion)' == '14.0'">
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <!--
+    End of: Switch the PlatformToolset based on the Visual Studio Version
+  -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
     <RestorePackages>true</RestorePackages>


### PR DESCRIPTION
  This converts `Org.Apache.REEF.Bridge.vcxproj` to Visual Studio 2015 format.

  This also adds a new solution `Org.Apache.REEF.VS2013.sln` as well as a new
  `Org.Apache.REEF.Bridge.VS2013.vcxproj` for users of that version of Visual
  Studio.

JIRA:
  [REEF-743](https://issues.apache.org/jira/browse/REEF-743)