### PR TITLE
[REEF-1235] Reset snapshot version for release 0.15 and update script

### DIFF
--- a/dev/change_version.py
+++ b/dev/change_version.py
@@ -92,8 +92,7 @@ def change_pom(file, new_version):
     f.close()
 
 """
-Change JavaBridgeJarFileName in lang/cs/Org.Apache.REEF.Driver/Constants.cs
-or in lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs
+Change JavaBridgeJarFileName in lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs
 """
 def change_constants_cs(file, new_version):
     changed_str = ""
@@ -181,9 +180,12 @@ def change_build_props(file, is_snapshot):
         if "<IsSnapshot>" in line and "</IsSnapshot>" in line:
             old_is_snapshot = r1.search(line).group(1)
             changed_str += line.replace(old_is_snapshot, is_snapshot)
-        elif "<SnapshotNumber>" in line and "</SnapshotNumber>" in line and is_snapshot=="false":
+        elif "<SnapshotNumber>" in line and "</SnapshotNumber>" in line:
             old_snapshot_number = r2.search(line).group(1)
-            changed_str += line.replace(old_snapshot_number, "00")
+            if is_snapshot=="false":
+              changed_str += line.replace(old_snapshot_number, "00")
+            else:
+              changed_str += line.replace(old_snapshot_number, "01")
         else:
             changed_str += line
     f.close()
@@ -249,7 +251,7 @@ def change_project_number_Doxyfile(file, new_version):
 
 """
 Change version of every pom.xml, every AssemblyInfo.cs,
-Constants.cs, AssemblyInfo.cpp, run.cmd and Resources.xml
+AssemblyInfo.cpp, run.cmd and Resources.xml
 """
 def change_version(reef_home, new_version, pom_only):
     if pom_only:
@@ -273,9 +275,6 @@ def change_version(reef_home, new_version, pom_only):
         change_assembly_info_cs(reef_home + "/lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp", new_version)
         print reef_home + "/lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp"
 
-        change_constants_cs(reef_home + "/lang/cs/Org.Apache.REEF.Driver/Constants.cs", new_version)
-        print reef_home + "/lang/cs/Org.Apache.REEF.Driver/Constants.cs"
-
         change_constants_cs(reef_home + "/lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs", new_version)
         print reef_home + "/lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs"
 
@@ -289,8 +288,7 @@ def change_version(reef_home, new_version, pom_only):
         print reef_home + "/Doxyfile"
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Script for changing version of every pom.xml, " \
-        + "every AssemblyInfo.cs, Constants.cs, and AssemblyInfo.cpp")
+    parser = argparse.ArgumentParser(description="Script for changing REEF version in all files that use it")
     parser.add_argument("reef_home", type=str, help="REEF home")
     parser.add_argument("reef_version", type=str, help="REEF version")
     parser.add_argument("-s", "--isSnapshot", type=str, metavar="<true or false>", help="Change 'IsSnapshot' to true or false", required=True)

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -59,7 +59,7 @@ under the License.
   <!-- REEF NuGet properties -->
   <PropertyGroup>
     <IsSnapshot>true</IsSnapshot>
-    <SnapshotNumber>04</SnapshotNumber>
+    <SnapshotNumber>01</SnapshotNumber>
     <PushPackages>false</PushPackages>
     <NuGetRepository>https://www.nuget.org</NuGetRepository>
     <NuGetError>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</NuGetError>


### PR DESCRIPTION
This change:
 * adds reset of snapshot version to change_version.py
 * removes update of Constants.cs from change_version.py, as
   the file does not use version any more
 * resets snapshot version to 01 using updated script

JIRA:
  [REEF-1235](https://issues.apache.org/jira/browse/REEF-1235)

Pull request:
  This closes #