### PR TITLE
[REEF-552] Make MessagingTransportFactory constructor private

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
@@ -36,17 +36,12 @@ import javax.inject.Inject;
 /**
  * Factory that creates a messaging transport.
  */
-public class MessagingTransportFactory implements TransportFactory {
+public final class MessagingTransportFactory implements TransportFactory {
 
   private final String localAddress;
 
-  /**
-   * @deprecated Have an instance injected instead.
-   */
-  @Deprecated
   @Inject
-  // TODO[JIRA REEF-703]: change constructor to private
-  public MessagingTransportFactory(final LocalAddressProvider localAddressProvider) {
+  private MessagingTransportFactory(final LocalAddressProvider localAddressProvider) {
     this.localAddress = localAddressProvider.getLocalAddress();
   }
 


### PR DESCRIPTION
This change does the last item on the original list: converting
MessagingTransportFactory constructor to private.

JIRA:
  [REEF-552](https://issues.apache.org/jira/browse/REEF-552)

Pull request:
  This closes #