### PR TITLE
[REEF-111] Provide continuous integration for the .NET code

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: {build}-{branch}
+version: "{build}-{branch}"
 
 shallow_clone: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.14.0-SNAPSHOT.{build}-{branch}
+
+shallow_clone: true
+
+platform: x64
+configuration: Debug
+
+cache:
+  - packages
+
+# install section: install maven, protoc etc.
+install:
+  - ps: .\dev\appveyor-install-dependencies.ps1
+
+build_script:
+  - cmd: msbuild .\lang\cs\Org.Apache.REEF.sln /p:Configuration="Debug" /p:Platform="x64" /m /v:m
+
+test_script:
+  - cmd: msbuild .\lang\cs\TestRunner.proj /p:Configuration="Debug" /p:Platform="x64"
+#  To run specific .dll only
+#  - cd .\lang\cs
+#  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Tests\Org.Apache.REEF.Tests.dll
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - ps: .\dev\appveyor-install-dependencies.ps1
 
 build_script:
-  - cmd: msbuild .\lang\cs\Org.Apache.REEF.sln /p:Configuration="Debug" /p:Platform="x64" /m /v:m
+  - cmd: msbuild .\lang\cs\Org.Apache.REEF.sln /p:Configuration="Debug" /p:Platform="x64" /m
 
 test_script:
   - cmd: msbuild .\lang\cs\TestRunner.proj /p:Configuration="Debug" /p:Platform="x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: 0.14.0-SNAPSHOT.{build}-{branch}
+version: 0.15.0-SNAPSHOT.{build}-{branch}
 
 shallow_clone: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: 0.15.0-SNAPSHOT.{build}-{branch}
+version: {build}-{branch}
 
 shallow_clone: true
 
@@ -21,7 +21,8 @@ platform: x64
 configuration: Debug
 
 cache:
-  - packages
+  - .\lang\cs\packages
+  - C:\Users\appveyor\.m2
 
 # install section: install maven, protoc etc.
 install:
@@ -32,9 +33,6 @@ build_script:
 
 test_script:
   - cmd: msbuild .\lang\cs\TestRunner.proj /p:Configuration="Debug" /p:Platform="x64"
-#  To run specific .dll only
-#  - cd .\lang\cs
-#  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Tests\Org.Apache.REEF.Tests.dll
 
 notifications:
   - provider: Email

--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -1,0 +1,65 @@
+<#
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+#>
+
+# create tools directory outside of REEF directory
+$up = (Get-Item -Path ".." -Verbose).FullName
+$tools = "$up\tools"
+if (!(Test-Path $tools))
+{
+    New-Item -ItemType Directory -Force -Path $tools | Out-Null
+}
+
+# ========================== maven
+Push-Location $tools
+
+$mavenVer = "3.3.3"
+Start-FileDownload "https://archive.apache.org/dist/maven/maven-3/$mavenVer/binaries/apache-maven-$mavenVer-bin.zip" "maven.zip"
+
+# extract
+Invoke-Expression "7z.exe x maven.zip" | Out-Null
+
+# add maven to environment variables
+$env:Path += ";$tools\apache-maven-$mavenVer\bin"
+$env:M2_HOME = "$tools\apache-maven-$mavenVer"
+
+Pop-Location
+
+# ========================== protoc
+$protocVer = "2.5.0"
+$protocPath = "$tools\protoc-$protocVer"
+if (!(Test-Path $protocPath))
+{
+    New-Item -ItemType Directory -Force -Path $protocPath | Out-Null
+}
+Push-Location $protocPath
+
+Start-FileDownload "https://github.com/google/protobuf/releases/download/v$protocVer/protoc-$protocVer-win32.zip" "protoc.zip"
+
+# extract
+Invoke-Expression "7z.exe x protoc.zip" | Out-Null
+
+# add protoc to environment variables
+$env:Path += ";$protocPath"
+
+Pop-Location
+
+# ========================== xUnit console runner
+$root = (Get-Item -Path "." -Verbose).FullName
+$packages = "$root\lang\cs\packages"
+Invoke-Expression "nuget install .\lang\cs\.nuget\packages.config -o $packages"

--- a/dev/change_version.py
+++ b/dev/change_version.py
@@ -91,8 +91,6 @@ def change_pom(file, new_version):
     f.write(changed_str)
     f.close()
 
-    print file
-
 """
 Change JavaBridgeJarFileName in lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs
 """
@@ -118,8 +116,6 @@ def change_constants_cs(file, new_version):
     f = open(file, 'w')
     f.write(changed_str)
     f.close()
-
-    print file
 
 """
 Change version in every AssemblyInfo.cs and AssemblyInfo.cpp
@@ -149,8 +145,6 @@ def change_assembly_info_cs(file, new_version):
     f.write(changed_str)
     f.close()
 
-    print file
-
 """
 Read 'IsSnapshot' from lang/cs/build.props
 """
@@ -168,8 +162,6 @@ def read_is_snapshot(file):
             else:
                 return False
     f.close()
-
-    print file
 
 """
 Change lang/cs/build.props for the release branch
@@ -231,8 +223,6 @@ def change_shaded_jar_name(file, new_version):
     f.write(changed_str)
     f.close()
 
-    print file
-
 """
 Change the version in Doxyfile
 """
@@ -258,34 +248,6 @@ def change_project_number_Doxyfile(file, new_version):
     f.write(changed_str)
     f.close()
 
-    print file
-
-"""
-Change the version in appveyor.yml
-"""
-def change_project_number_appveyor(file, new_version):
-    changed_str = ""
-
-    f = open(file, 'r')
-    while True:
-        line = f.readline()
-        if not line:
-            break
-
-        if "version: " in line:
-            r = re.compile('version: (.*?)\.{build}')
-            m = r.search(line)
-            old_version = m.group(1)
-            changed_str += line.replace(old_version, new_version)
-        else:
-            changed_str += line
-    f.close()
-
-    f = open(file, 'w')
-    f.write(changed_str)
-    f.close()
-
-    print file
 
 """
 Change version of every pom.xml, every AssemblyInfo.cs,
@@ -295,28 +257,35 @@ def change_version(reef_home, new_version, pom_only):
     if pom_only:
         for fi in get_filepaths(reef_home):
             if "pom.xml" in fi:
+                print fi
                 change_pom(fi, new_version)
 
     else:
         for fi in get_filepaths(reef_home):
             if "pom.xml" in fi:
+                print fi
                 change_pom(fi, new_version)
             if "AssemblyInfo.cs" in fi:
+                print fi
                 change_assembly_info_cs(fi, new_version)
 
         change_assembly_info_cs(reef_home + "/lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp", new_version)
+        print reef_home + "/lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp"
 
         change_assembly_info_cs(reef_home + "/lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp", new_version)
+        print reef_home + "/lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp"
 
         change_constants_cs(reef_home + "/lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs", new_version)
+        print reef_home + "/lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs"
 
         change_shaded_jar_name(reef_home + "/lang/cs/Org.Apache.REEF.Client/Properties/Resources.xml", new_version)
+        print reef_home + "/lang/cs/Org.Apache.REEF.Client/Properties/Resources.xml"
 
         change_shaded_jar_name(reef_home + "/lang/cs/Org.Apache.REEF.Client/run.cmd", new_version)
+        print reef_home + "/lang/cs/Org.Apache.REEF.Client/run.cmd"
 
         change_project_number_Doxyfile(reef_home + "/Doxyfile", new_version)
-
-        change_project_number_appveyor(reef_home + "/appveyor.yml", new_version)
+        print reef_home + "/Doxyfile"
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Script for changing REEF version in all files that use it")

--- a/dev/change_version.py
+++ b/dev/change_version.py
@@ -91,6 +91,8 @@ def change_pom(file, new_version):
     f.write(changed_str)
     f.close()
 
+    print file
+
 """
 Change JavaBridgeJarFileName in lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs
 """
@@ -116,6 +118,8 @@ def change_constants_cs(file, new_version):
     f = open(file, 'w')
     f.write(changed_str)
     f.close()
+
+    print file
 
 """
 Change version in every AssemblyInfo.cs and AssemblyInfo.cpp
@@ -145,6 +149,8 @@ def change_assembly_info_cs(file, new_version):
     f.write(changed_str)
     f.close()
 
+    print file
+
 """
 Read 'IsSnapshot' from lang/cs/build.props
 """
@@ -162,6 +168,8 @@ def read_is_snapshot(file):
             else:
                 return False
     f.close()
+
+    print file
 
 """
 Change lang/cs/build.props for the release branch
@@ -223,6 +231,8 @@ def change_shaded_jar_name(file, new_version):
     f.write(changed_str)
     f.close()
 
+    print file
+
 """
 Change the version in Doxyfile
 """
@@ -248,6 +258,34 @@ def change_project_number_Doxyfile(file, new_version):
     f.write(changed_str)
     f.close()
 
+    print file
+
+"""
+Change the version in appveyor.yml
+"""
+def change_project_number_appveyor(file, new_version):
+    changed_str = ""
+
+    f = open(file, 'r')
+    while True:
+        line = f.readline()
+        if not line:
+            break
+
+        if "version: " in line:
+            r = re.compile('version: (.*?)\.{build}')
+            m = r.search(line)
+            old_version = m.group(1)
+            changed_str += line.replace(old_version, new_version)
+        else:
+            changed_str += line
+    f.close()
+
+    f = open(file, 'w')
+    f.write(changed_str)
+    f.close()
+
+    print file
 
 """
 Change version of every pom.xml, every AssemblyInfo.cs,
@@ -257,35 +295,28 @@ def change_version(reef_home, new_version, pom_only):
     if pom_only:
         for fi in get_filepaths(reef_home):
             if "pom.xml" in fi:
-                print fi
                 change_pom(fi, new_version)
 
     else:
         for fi in get_filepaths(reef_home):
             if "pom.xml" in fi:
-                print fi
                 change_pom(fi, new_version)
             if "AssemblyInfo.cs" in fi:
-                print fi
                 change_assembly_info_cs(fi, new_version)
 
         change_assembly_info_cs(reef_home + "/lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp", new_version)
-        print reef_home + "/lang/cs/Org.Apache.REEF.Bridge/AssemblyInfo.cpp"
 
         change_assembly_info_cs(reef_home + "/lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp", new_version)
-        print reef_home + "/lang/cs/Org.Apache.REEF.ClrDriver/AssemblyInfo.cpp"
 
         change_constants_cs(reef_home + "/lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs", new_version)
-        print reef_home + "/lang/cs/Org.Apache.REEF.Driver/DriverConfigGenerator.cs"
 
         change_shaded_jar_name(reef_home + "/lang/cs/Org.Apache.REEF.Client/Properties/Resources.xml", new_version)
-        print reef_home + "/lang/cs/Org.Apache.REEF.Client/Properties/Resources.xml"
 
         change_shaded_jar_name(reef_home + "/lang/cs/Org.Apache.REEF.Client/run.cmd", new_version)
-        print reef_home + "/lang/cs/Org.Apache.REEF.Client/run.cmd"
 
         change_project_number_Doxyfile(reef_home + "/Doxyfile", new_version)
-        print reef_home + "/Doxyfile"
+
+        change_project_number_appveyor(reef_home + "/appveyor.yml", new_version)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Script for changing REEF version in all files that use it")

--- a/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
+++ b/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
@@ -63,7 +63,7 @@ under the License.
       <Client_JAR_Name>reef-bridge-client-$(REEF_Version)-shaded.jar</Client_JAR_Name>
       <Client_JAR>$(REEF_Source_Folder)\lang\java\reef-bridge-client\target\$(Client_JAR_Name)</Client_JAR>
     </PropertyGroup>
-    <Exec Command='call "$(M2_HOME)\bin\mvn.cmd" --projects lang/java/reef-bridge-java,lang/java/reef-bridge-client --also-make -TC1 -DskipTests -P!code-quality install' Condition="!Exists('$(Bridge_JAR)')" WorkingDirectory="$(REEF_Source_Folder)" />
+    <Exec Command='call "$(M2_HOME)\bin\mvn.cmd" --projects lang/java/reef-bridge-java,lang/java/reef-bridge-client --also-make -TC1 -DskipTests -P!code-quality -q install' Condition="!Exists('$(Bridge_JAR)')" WorkingDirectory="$(REEF_Source_Folder)" />
     <Copy DestinationFolder="$(OutputPath)" SourceFiles="$(Bridge_JAR)" />
     <Copy DestinationFolder="$(OutputPath)" SourceFiles="$(Client_JAR)" />
   </Target>
@@ -79,7 +79,7 @@ under the License.
       <Client_JAR_Name>reef-bridge-client-$(REEF_Version)-shaded.jar</Client_JAR_Name>
       <Client_JAR>$(REEF_Source_Folder)\lang\java\reef-bridge-client\target\$(Client_JAR_Name)</Client_JAR>
     </PropertyGroup>
-    <Exec Command='call "$(M2_HOME)\bin\mvn.cmd" -TC1 -DskipTests clean' Condition="Exists('$(Bridge_JAR)')" WorkingDirectory="$(REEF_Source_Folder)" />
+    <Exec Command='call "$(M2_HOME)\bin\mvn.cmd" -TC1 -DskipTests -q clean' Condition="Exists('$(Bridge_JAR)')" WorkingDirectory="$(REEF_Source_Folder)" />
     <Delete Files="$(OutputPath)\$(Bridge_JAR_Name)" />
     <Delete Files="$(OutputPath)\$(Client_JAR_Name)" />
 


### PR DESCRIPTION
This change:
  * adds configuration for building and testing .NET code in AppVeyor
  * converts Java build in .NET code to quiet mode to reduce logs
  * updates change_version.py to include version in appveyor.yml

JIRA:
  [REEF-111](https://issues.apache.org/jira/browse/REEF-111)

Pull request:
  This closes #