### PR TITLE
[REEF-1231] Too many open files in NetworkConnectionServiceTest

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
@@ -74,8 +74,7 @@ public final class NameClient implements NameResolver {
       @Parameter(NameResolverRetryCount.class) final int retryCount,
       @Parameter(NameResolverRetryTimeout.class) final int retryTimeout,
       final LocalAddressProvider localAddressProvider,
-      final TransportFactory tpFactory,
-      final NameLookupClient lookupClient) {
+      final TransportFactory tpFactory) {
 
     final BlockingQueue<NamingLookupResponse> replyLookupQueue = new LinkedBlockingQueue<>();
     final BlockingQueue<NamingRegisterResponse> replyRegisterQueue = new LinkedBlockingQueue<>();
@@ -86,7 +85,8 @@ public final class NameClient implements NameResolver {
             new NamingResponseHandler(replyLookupQueue, replyRegisterQueue), codec)),
         null, retryCount, retryTimeout);
 
-    this.lookupClient = lookupClient;
+    this.lookupClient = new NameLookupClient(serverAddr, serverPort, timeout, factory,
+        retryCount, retryTimeout, replyLookupQueue, this.transport);
 
     this.registryClient = new NameRegistryClient(serverAddr, serverPort, timeout,
         factory, replyRegisterQueue, this.transport);

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
@@ -85,7 +85,7 @@ public final class NameLookupClient implements Stage, NamingLookup {
    * @param replyQueue a reply queue
    * @param transport  a transport
    */
-  public NameLookupClient(final String serverAddr,
+  NameLookupClient(final String serverAddr,
                           final int serverPort,
                           final long timeout,
                           final IdentifierFactory factory,
@@ -96,7 +96,7 @@ public final class NameLookupClient implements Stage, NamingLookup {
     this.serverSocketAddr = new InetSocketAddress(serverAddr, serverPort);
     this.timeout = timeout;
     this.cache = new NameCache(timeout);
-    this.codec = NamingCodecFactory.createLookupCodec(factory);
+    this.codec = NamingCodecFactory.createFullCodec(factory);
     this.replyQueue = replyQueue;
     this.retryCount = retryCount;
     this.retryTimeout = retryTimeout;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
@@ -72,6 +72,37 @@ public final class NameLookupClient implements Stage, NamingLookup {
   private final int retryCount;
   private final int retryTimeout;
 
+
+  /**
+   * Constructs a naming lookup client.
+   *
+   * @param serverAddr a server address
+   * @param serverPort a server port number
+   * @param timeout    request timeout in ms
+   * @param factory    an identifier factory
+   * @param retryCount a count of retrying lookup
+   * @param retryTimeout retry timeout
+   * @param replyQueue a reply queue
+   * @param transport  a transport
+   */
+  public NameLookupClient(final String serverAddr,
+                          final int serverPort,
+                          final long timeout,
+                          final IdentifierFactory factory,
+                          final int retryCount,
+                          final int retryTimeout,
+                          final BlockingQueue<NamingLookupResponse> replyQueue,
+                          final Transport transport) {
+    this.serverSocketAddr = new InetSocketAddress(serverAddr, serverPort);
+    this.timeout = timeout;
+    this.cache = new NameCache(timeout);
+    this.codec = NamingCodecFactory.createLookupCodec(factory);
+    this.replyQueue = replyQueue;
+    this.retryCount = retryCount;
+    this.retryTimeout = retryTimeout;
+    this.transport = transport;
+  }
+
   /**
     * Constructs a naming lookup client.
     *
@@ -91,7 +122,6 @@ public final class NameLookupClient implements Stage, NamingLookup {
             @Parameter(NameResolverRetryTimeout.class) final int retryTimeout,
             final LocalAddressProvider localAddressProvider,
             final TransportFactory tpFactory) {
-
     this.serverSocketAddr = new InetSocketAddress(serverAddr, serverPort);
     this.timeout = timeout;
     this.cache = new NameCache(timeout);

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameRegistryClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameRegistryClient.java
@@ -70,7 +70,7 @@ public class NameRegistryClient implements Stage, NamingRegistry {
    * @param serverPort a name server port
    * @param factory    an identifier factory
    */
-  public NameRegistryClient(
+  NameRegistryClient(
       final String serverAddr, final int serverPort, final IdentifierFactory factory,
       final LocalAddressProvider localAddressProvider) {
     this(serverAddr, serverPort, 10000, factory, localAddressProvider);
@@ -84,7 +84,7 @@ public class NameRegistryClient implements Stage, NamingRegistry {
    * @param timeout    timeout in ms
    * @param factory    an identifier factory
    */
-  public NameRegistryClient(final String serverAddr,
+  NameRegistryClient(final String serverAddr,
                             final int serverPort,
                             final long timeout,
                             final IdentifierFactory factory,
@@ -107,7 +107,7 @@ public class NameRegistryClient implements Stage, NamingRegistry {
     }
   }
 
-  public NameRegistryClient(final String serverAddr, final int serverPort,
+  NameRegistryClient(final String serverAddr, final int serverPort,
                             final long timeout, final IdentifierFactory factory,
                             final BlockingQueue<NamingRegisterResponse> replyQueue,
                             final Transport transport) {


### PR DESCRIPTION
This pull request addressed the issue [REEF-1231](https://issues.apache.org/jira/browse/REEF-1231) by
* adding a public constructor of `NameLookupClient`
* removing `NameLookupClient` injection from `NameClient`

JIRA:
[REEF-1231] https://issues.apache.org/jira/browse/REEF-1231

Pull Request:
Closes #