### PR TITLE
[REEF-1259] JSon 7.0.1 version is not downloaded for client who refer…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.Reef.Utilities.nuspec
+++ b/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.Reef.Utilities.nuspec
@@ -30,6 +30,7 @@ under the License.
     <tags>Reef/Wake/Tang common utilities</tags>
     <dependencies>
       <dependency id="Microsoft.Hadoop.Avro" version="1.5.6" />
+      <dependency id="Newtonsoft.Json" version="7.0.1" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
…ences REEF NuGet

Update NuGet spec dependency for REEF util as it is the one everyone reference to.

JIRA: [REEF-1259](https://issues.apache.org/jira/browse/REEF-1259)

This closes #