### PR TITLE
[REEF-1264] Fix NuGet script for publishing NuGets

### DIFF
--- a/lang/cs/.nuget/NuGet.targets
+++ b/lang/cs/.nuget/NuGet.targets
@@ -52,6 +52,9 @@ under the License.
     <PropertyGroup Condition=" '$(OS)' != 'Windows_NT'">
         <!-- We need to launch nuget.exe with the mono command if we're not on windows -->
         <NuGetToolsPath>$(SolutionDir)\.nuget</NuGetToolsPath>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <ThisNugetPackagePath>$(SolutionDir2).nuget\packages\$(RootNamespace).$(REEF_NugetVersion).nupkg</ThisNugetPackagePath>
     </PropertyGroup>
 


### PR DESCRIPTION
This change moves variable ThisNugetPackagePath outside of conditional
property group, so that it's defined unconditionally on all machines.
After REEF-1197 it was defined only on machines with environment
variable OS != Windows_NT, which is not true for multiple machines
with later versions of Windows.

JIRA:
  [REEF-1264](https://issues.apache.org/jira/browse/REEF-1264)

Pull request:
  This closes #