### PR TITLE
[REEF-347] Configure .NET tests to only listen on 127.0.0.1

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Common/EnvironmentDriverConfigurationProviders.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/EnvironmentDriverConfigurationProviders.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Collections.Generic;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Interface;
+
+namespace Org.Apache.REEF.Client.Common
+{
+    /// <summary>
+    /// This named parameter is used to target receivers Configuration providers at driver level, provided by the Environment.
+    /// </summary>
+    [NamedParameter]
+    internal sealed class EnvironmentDriverConfigurationProviders : Name<ISet<IConfigurationProvider>>
+    {
+        private EnvironmentDriverConfigurationProviders()
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/Local/LocalClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Local/LocalClient.cs
@@ -30,9 +30,13 @@ using Org.Apache.REEF.Common.Avro;
 using Org.Apache.REEF.Common.Files;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.AsyncUtils;
 using Org.Apache.REEF.Utilities.Attributes;
 using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Wake.Remote;
+using Org.Apache.REEF.Wake.Remote.Impl;
 using Org.Apache.REEF.Wake.Remote.Parameters;
 
 namespace Org.Apache.REEF.Client.Local
@@ -58,6 +62,7 @@ namespace Org.Apache.REEF.Client.Local
         private readonly int _maxNumberOfConcurrentEvaluators;
         private readonly string _runtimeFolder;
         private readonly REEFFileNames _fileNames;
+        private readonly IConfiguration _localConfigurationOnDriver;
 
         [Inject]
         private LocalClient(DriverFolderPreparationHelper driverFolderPreparationHelper,
@@ -71,6 +76,7 @@ namespace Org.Apache.REEF.Client.Local
             _maxNumberOfConcurrentEvaluators = maxNumberOfConcurrentEvaluators;
             _javaClientLauncher = javaClientLauncher;
             _fileNames = fileNames;
+            _localConfigurationOnDriver = TangFactory.GetTang().NewConfigurationBuilder().BindImplementation(GenericType<ILocalAddressProvider>.Class, GenericType<LoopbackLocalAddressProvider>.Class).Build();
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Client/Local/LocalDriverConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Local/LocalDriverConfigurationProvider.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Common.Evaluator.Parameters;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Wake.Remote;
+using Org.Apache.REEF.Wake.Remote.Impl;
+
+namespace Org.Apache.REEF.Client.Local
+{
+    /// <summary>
+    /// The environment driver configuration provider for the Local Runtime.
+    /// </summary>
+    internal sealed class LocalDriverConfigurationProvider : IConfigurationProvider
+    {
+        private readonly IConfiguration _configuration;
+
+        [Inject]
+        private LocalDriverConfigurationProvider()
+        {
+            _configuration = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindImplementation<ILocalAddressProvider, LoopbackLocalAddressProvider>()
+                .BindSetEntry<EvaluatorConfigurationProviders, LoopbackLocalAddressProvider, IConfigurationProvider>()
+                .Build();
+        }
+
+        public IConfiguration GetConfiguration()
+        {
+            return _configuration;
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/Local/LocalRuntimeClientConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Local/LocalRuntimeClientConfiguration.cs
@@ -16,8 +16,10 @@
 // under the License.
 
 using Org.Apache.REEF.Client.API;
+using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Client.Local.Parameters;
 using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 
 namespace Org.Apache.REEF.Client.Local
@@ -45,6 +47,8 @@ namespace Org.Apache.REEF.Client.Local
 
         public static ConfigurationModule ConfigurationModule = new LocalRuntimeClientConfiguration()
             .BindImplementation(GenericType<IREEFClient>.Class, GenericType<LocalClient>.Class)
+            .BindSetEntry<EnvironmentDriverConfigurationProviders, LocalDriverConfigurationProvider, IConfigurationProvider>(
+                GenericType<EnvironmentDriverConfigurationProviders>.Class, GenericType<LocalDriverConfigurationProvider>.Class)
             .BindNamedParameter(GenericType<LocalRuntimeDirectory>.Class, RuntimeFolder)
             .BindNamedParameter(GenericType<NumberOfEvaluators>.Class, NumberOfEvaluators)
             .Build();

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -85,6 +85,7 @@ under the License.
     <Compile Include="Common\DotNetFile.cs" />
     <Compile Include="Common\ClientConstants.cs" />
     <Compile Include="Common\DriverFolderPreparationHelper.cs" />
+    <Compile Include="Common\EnvironmentDriverConfigurationProviders.cs" />
     <Compile Include="Common\IFile.cs" />
     <Compile Include="Common\IResourceArchiveFileGenerator.cs" />
     <Compile Include="Common\FileSets.cs" />
@@ -94,6 +95,7 @@ under the License.
     <Compile Include="Common\JavaClientLauncher.cs" />
     <Compile Include="Common\ResourceArchiveFileGenerator.cs" />
     <Compile Include="Local\LocalClient.cs" />
+    <Compile Include="Local\LocalDriverConfigurationProvider.cs" />
     <Compile Include="Local\LocalJobSubmissionResult.cs" />
     <Compile Include="Local\LocalRuntimeClientConfiguration.cs" />
     <Compile Include="Local\Parameters\LocalRuntimeDirectory.cs" />

--- a/lang/cs/Org.Apache.REEF.Network.Tests/NetworkService/NetworkServiceTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/NetworkService/NetworkServiceTests.cs
@@ -158,7 +158,7 @@ namespace Org.Apache.REEF.Network.Tests.NetworkService
             var nameClient = injector.GetInstance<NameClient>();
             var remoteManagerFactory = injector.GetInstance<IRemoteManagerFactory>();
             return new NetworkService<string>(networkServicePort,
-                handler, new StringIdentifierFactory(), new StringCodec(), nameClient, remoteManagerFactory);
+                handler, new StringIdentifierFactory(), new StringCodec(), nameClient, injector.GetInstance<ILocalAddressProvider>(), remoteManagerFactory);
         }
 
         private class MessageHandler : IObserver<NsMessage<string>>

--- a/lang/cs/Org.Apache.REEF.Network/Naming/NameServer.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/NameServer.cs
@@ -49,12 +49,14 @@ namespace Org.Apache.REEF.Network.Naming
         /// Create a new NameServer to run on the specified port.
         /// </summary>
         /// <param name="port">The port to listen for incoming connections on.</param>
+        /// <param name="addressProvider">The address provider.</param>
         /// <param name="tcpPortProvider">If port is 0, this interface provides 
         /// a port range to try.
         /// </param>
         [Inject]
         private NameServer(
             [Parameter(typeof(NamingConfigurationOptions.NameServerPort))] int port,
+            ILocalAddressProvider addressProvider,
             ITcpPortProvider tcpPortProvider)
         {
             IObserver<TransportEvent<NamingEvent>> handler = CreateServerHandler();
@@ -64,7 +66,7 @@ namespace Org.Apache.REEF.Network.Naming
             // Start transport server, get listening IP endpoint
             _logger.Log(Level.Info, "Starting naming server");
             _server = new TransportServer<NamingEvent>(
-                new IPEndPoint(NetworkUtils.LocalIPAddress, port), handler, 
+                new IPEndPoint(addressProvider.LocalAddress, port), handler, 
                 codec, tcpPortProvider);
             _server.Run();
             LocalEndpoint = _server.LocalEndpoint;

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkService.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkService.cs
@@ -25,7 +25,6 @@ using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Utilities.Logging;
 using Org.Apache.REEF.Wake;
 using Org.Apache.REEF.Wake.Remote;
-using Org.Apache.REEF.Wake.Util;
 
 namespace Org.Apache.REEF.Network.NetworkService
 {
@@ -42,7 +41,7 @@ namespace Org.Apache.REEF.Network.NetworkService
         private readonly ICodec<NsMessage<T>> _codec; 
         private IIdentifier _localIdentifier;
         private IDisposable _messageHandlerDisposable;
-        private readonly Dictionary<IIdentifier, IConnection<T>> _connectionMap;  
+        private readonly Dictionary<IIdentifier, IConnection<T>> _connectionMap;
 
         /// <summary>
         /// Create a new NetworkService.
@@ -52,6 +51,7 @@ namespace Org.Apache.REEF.Network.NetworkService
         /// <param name="idFactory">The factory used to create IIdentifiers</param>
         /// <param name="codec">The codec used for serialization</param>
         /// <param name="nameClient"></param>
+        /// <param name="localAddressProvider">The local address provider</param>
         /// <param name="remoteManagerFactory">Used to instantiate remote manager instances.</param>
         [Inject]
         public NetworkService(
@@ -60,11 +60,12 @@ namespace Org.Apache.REEF.Network.NetworkService
             IIdentifierFactory idFactory,
             ICodec<T> codec,
             INameClient nameClient,
+            ILocalAddressProvider localAddressProvider,
             IRemoteManagerFactory remoteManagerFactory)
         {
             _codec = new NsMessageCodec<T>(codec, idFactory);
 
-            IPAddress localAddress = NetworkUtils.LocalIPAddress;
+            IPAddress localAddress = localAddressProvider.LocalAddress;
             _remoteManager = remoteManagerFactory.GetInstance(localAddress, nsPort, _codec);
             _messageHandler = messageHandler;
 

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/StreamingNetworkService.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/StreamingNetworkService.cs
@@ -55,6 +55,7 @@ namespace Org.Apache.REEF.Network.NetworkService
         /// <param name="remoteManagerFactory">Writable RemoteManagerFactory to create a 
         /// Writable RemoteManager</param>
         /// <param name="codec">Codec for Network Service message</param>
+        /// <param name="localAddressProvider">The local address provider</param>
         /// <param name="injector">Fork of the injector that created the Network service</param>
         [Inject]
         private StreamingNetworkService(
@@ -63,10 +64,10 @@ namespace Org.Apache.REEF.Network.NetworkService
             INameClient nameClient,
             StreamingRemoteManagerFactory remoteManagerFactory,
             NsMessageStreamingCodec<T> codec,
+            ILocalAddressProvider localAddressProvider,
             IInjector injector)
         {
-            IPAddress localAddress = NetworkUtils.LocalIPAddress;
-            _remoteManager = remoteManagerFactory.GetInstance(localAddress, codec);
+            _remoteManager = remoteManagerFactory.GetInstance(localAddressProvider.LocalAddress, codec);
 
             // Create and register incoming message handler
             // TODO[REEF-419] This should use the TcpPortProvider mechanism

--- a/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
@@ -53,6 +53,9 @@ under the License.
     <Compile Include="IIdentifierFactory.cs" />
     <Compile Include="Remote\IConnectionRetryHandler.cs" />
     <Compile Include="Remote\Impl\RemoteConnectionRetryHandler.cs" />
+    <Compile Include="Remote\ILocalAddressProvider.cs" />
+    <Compile Include="Remote\Impl\DefaultLocalAddressProvider.cs" />
+    <Compile Include="Remote\Impl\LoopbackLocalAddressProvider.cs" />
     <Compile Include="Remote\Impl\RemoteEventStreamingCodec.cs" />
     <Compile Include="Remote\Impl\StreamingRemoteManagerFactory.cs" />
     <Compile Include="Remote\Impl\DefaultRemoteManagerFactory.cs" />

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/ILocalAddressProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/ILocalAddressProvider.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Net;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Remote.Impl;
+
+namespace Org.Apache.REEF.Wake.Remote
+{
+    /// <summary>
+    /// Provides the local address.
+    /// </summary>
+    [DefaultImplementation(typeof(DefaultLocalAddressProvider))]
+    public interface ILocalAddressProvider
+    {
+        IPAddress LocalAddress { get; }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultLocalAddressProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultLocalAddressProvider.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Net;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Util;
+
+namespace Org.Apache.REEF.Wake.Remote.Impl
+{
+    /// <summary>
+    /// The local address provider that provides the local IP address using <see cref="NetworkUtils.LocalIPAddress"/>.
+    /// </summary>
+    public sealed class DefaultLocalAddressProvider : ILocalAddressProvider
+    {
+        [Inject]
+        private DefaultLocalAddressProvider()
+        {
+            LocalAddress = NetworkUtils.LocalIPAddress;
+        }
+
+        public IPAddress LocalAddress { get; private set; }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManager.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManager.cs
@@ -85,9 +85,13 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// <summary>
         /// Constructs a DefaultRemoteManager. Does not listen for incoming messages.
         /// </summary>
+        /// <param name="localAddressProvider">The local address provider</param>
         /// <param name="codec">The codec used for serializing messages</param>
         /// <param name="tcpClientFactory">provides TcpClient for given endpoint</param>
-        internal DefaultRemoteManager(ICodec<T> codec, ITcpClientConnectionFactory tcpClientFactory)
+        internal DefaultRemoteManager(
+            ILocalAddressProvider localAddressProvider, 
+            ICodec<T> codec, 
+            ITcpClientConnectionFactory tcpClientFactory)
         {
             using (LOGGER.LogFunction("DefaultRemoteManager::DefaultRemoteManager"))
             {
@@ -101,7 +105,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
                 _codec = new RemoteEventCodec<T>(codec);
                 _cachedClients = new Dictionary<IPEndPoint, ProxyObserver>();
 
-                LocalEndpoint = new IPEndPoint(NetworkUtils.LocalIPAddress, 0);
+                LocalEndpoint = new IPEndPoint(localAddressProvider.LocalAddress, 0);
                 Identifier = new SocketRemoteIdentifier(LocalEndpoint);
             }
         }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManagerFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManagerFactory.cs
@@ -29,11 +29,16 @@ namespace Org.Apache.REEF.Wake.Impl
     {
         private readonly ITcpPortProvider _tcpPortProvider;
         private readonly ITcpClientConnectionFactory _tcpClientFactory;
+        private readonly ILocalAddressProvider _localAddressProvider;
 
         [Inject]
-        private DefaultRemoteManagerFactory(ITcpPortProvider tcpPortProvider, ITcpClientConnectionFactory tcpClientFactory)
+        private DefaultRemoteManagerFactory(
+            ITcpPortProvider tcpPortProvider,  
+            ITcpClientConnectionFactory tcpClientFactory, 
+            ILocalAddressProvider localAddressProvider)
         {
             _tcpPortProvider = tcpPortProvider;
+            _localAddressProvider = localAddressProvider;
             _tcpClientFactory = tcpClientFactory;
         }
 
@@ -70,7 +75,7 @@ namespace Org.Apache.REEF.Wake.Impl
         /// <returns>IRemoteManager instance</returns>
         public IRemoteManager<T> GetInstance<T>(ICodec<T> codec)
         {
-            return new DefaultRemoteManager<T>(codec, _tcpClientFactory);
+            return new DefaultRemoteManager<T>(_localAddressProvider, codec, _tcpClientFactory);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/Link.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/Link.cs
@@ -61,7 +61,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
 
             _codec = codec;
             _channel = new Channel(Client.GetStream());
-            _localEndpoint = GetLocalEndpoint();
+            _localEndpoint = (IPEndPoint)Client.Client.LocalEndPoint;
             _disposed = false;
         }
 
@@ -85,7 +85,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
             Client = client;
             _codec = codec;
             _channel = new Channel(Client.GetStream());
-            _localEndpoint = GetLocalEndpoint();
+            _localEndpoint = (IPEndPoint)Client.Client.LocalEndPoint;
             _disposed = false;
         }
 
@@ -235,17 +235,6 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         public override int GetHashCode()
         {
             return RemoteEndpoint.GetHashCode();
-        }
-
-        /// <summary>
-        /// Discovers the IPEndpoint for the current machine.
-        /// </summary>
-        /// <returns>The local IPEndpoint</returns>
-        private IPEndPoint GetLocalEndpoint()
-        {
-            IPAddress address = NetworkUtils.LocalIPAddress;
-            int port = ((IPEndPoint)Client.Client.LocalEndPoint).Port;
-            return new IPEndPoint(address, port);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/LoopbackLocalAddressProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/LoopbackLocalAddressProvider.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Net;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
+
+namespace Org.Apache.REEF.Wake.Remote.Impl
+{
+    /// <summary>
+    /// Provides the loopback address as the local address.
+    /// </summary>
+    public sealed class LoopbackLocalAddressProvider : ILocalAddressProvider, IConfigurationProvider
+    {
+        private readonly IConfiguration _configuration;
+
+        [Inject]
+        private LoopbackLocalAddressProvider()
+        {
+            _configuration = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindImplementation(GenericType<ILocalAddressProvider>.Class, GenericType<LoopbackLocalAddressProvider>.Class)
+                .Build();
+        }
+
+        /// <summary>
+        /// Returns the loopback address.
+        /// </summary>
+        public IPAddress LocalAddress
+        {
+            get { return IPAddress.Loopback; }
+        }
+
+        public IConfiguration GetConfiguration()
+        {
+            return _configuration;
+        }
+    }
+}

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalSubmissionFromCS.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalSubmissionFromCS.java
@@ -35,6 +35,7 @@ import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectory;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
 import org.apache.reef.tang.Tang;
+import org.apache.reef.wake.remote.address.LoopbackLocalAddressProvider;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeCount;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeTryCount;
@@ -108,6 +109,7 @@ final class LocalSubmissionFromCS {
 
     final Configuration userProviderConfiguration = Tang.Factory.getTang().newConfigurationBuilder()
         .bindSetEntry(DriverConfigurationProviders.class, TcpPortConfigurationProvider.class)
+        .bindSetEntry(DriverConfigurationProviders.class, LoopbackLocalAddressProvider.class)
         .bindNamedParameter(TcpPortRangeBegin.class, Integer.toString(tcpBeginPort))
         .bindNamedParameter(TcpPortRangeCount.class, Integer.toString(tcpRangeCount))
         .bindNamedParameter(TcpPortRangeTryCount.class, Integer.toString(tcpTryCount))

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/LoopbackLocalAddressProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/LoopbackLocalAddressProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.remote.address;
+
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.wake.remote.RemoteConfiguration;
+
+import javax.inject.Inject;
+import java.net.InetAddress;
+
+/**
+ * A LocalAddressProvider that always uses the Loopback Address. This is used
+ * mainly in local runtime for C# to prevent firewall message popups.
+ */
+public final class LoopbackLocalAddressProvider implements LocalAddressProvider {
+
+  @Inject
+  private LoopbackLocalAddressProvider() {
+  }
+
+  @Override
+  public String getLocalAddress() {
+    // Use the loopback address.
+    return InetAddress.getLoopbackAddress().getHostAddress();
+  }
+
+  @Override
+  public Configuration getConfiguration() {
+    return Tang.Factory.getTang().newConfigurationBuilder()
+        .bind(LocalAddressProvider.class, LoopbackLocalAddressProvider.class)
+        .bindNamedParameter(RemoteConfiguration.HostAddress.class, getLocalAddress())
+        .build();
+  }
+}


### PR DESCRIPTION
This addressed the issue by
  * Adding an environment-dependent DriverConfigurationProvider.
  * Have C# Local Runtime processes listen only on the loopback address.

JIRA:
  [REEF-347](https://issues.apache.org/jira/browse/REEF-347)