### PR TITLE
[REEF-1273] Race condition between Task failed and Task done

### DIFF
--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/ContextRuntimeTests.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/ContextRuntimeTests.cs
@@ -231,6 +231,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
                     }
 
                     testTask.CountDownEvent.Signal();
+                    testTask.DisposedEvent.Wait();
                 }
             }
         }
@@ -272,6 +273,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
                     }
 
                     testTask.CountDownEvent.Signal();
+                    testTask.DisposedEvent.Wait();
                 }
             }
         }
@@ -304,6 +306,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
                 testTask.CountDownEvent.Signal();
                 testTask.StopEvent.Wait();
                 Assert.False(contextRuntime.GetTaskStatus().IsPresent());
+                testTask.DisposedEvent.Wait();
 
                 contextRuntime.StartTask(taskConfig, hbMgr);
                 Assert.Equal(contextRuntime.GetTaskStatus().Value.state, State.RUNNING);
@@ -319,6 +322,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
                 secondTestTask.CountDownEvent.Signal();
                 secondTestTask.StopEvent.Wait();
                 Assert.False(contextRuntime.GetTaskStatus().IsPresent());
+                secondTestTask.DisposedEvent.Wait();
             }
         }
 
@@ -449,15 +453,18 @@ namespace Org.Apache.REEF.Evaluator.Tests
             {
                 CountDownEvent = new CountdownEvent(1);
                 StopEvent = new CountdownEvent(1);
+                DisposedEvent = new CountdownEvent(1);
             }
 
             public CountdownEvent CountDownEvent { get; private set; }
 
             public CountdownEvent StopEvent { get; private set; }
 
+            public CountdownEvent DisposedEvent { get; private set; }
+
             public void Dispose()
             {
-                throw new NotImplementedException();
+                DisposedEvent.Signal();
             }
 
             public byte[] Call(byte[] memento)


### PR DESCRIPTION
This addressed the issue by
  * Checking task state before failing the job.
  * Adding CountDownEvents in Tasks to wait until jobs are Done in tests.

JIRA:
  [REEF-1273](https://issues.apache.org/jira/browse/REEF-1273)