### PR TITLE
[REEF-1279] Injecting RuntimeClock in event handler creates second in…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/RootContextLauncher.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/RootContextLauncher.cs
@@ -24,6 +24,8 @@ using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Wake.Time;
+using Org.Apache.REEF.Wake.Time.Runtime;
 
 namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
 {
@@ -45,7 +47,12 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
             Id = id;
             _rootContextConfiguration = contextConfiguration;
             _rootServiceInjector = InjectServices(rootServiceConfig);
+
+            // TODO[JIRA REEF-217]: Remove usage of BindVolatileInstance.
             _rootServiceInjector.BindVolatileInstance(GenericType<IHeartBeatManager>.Class, heartbeatManager);
+            _rootServiceInjector.BindVolatileInstance(GenericType<IClock>.Class, heartbeatManager.EvaluatorSettings.RuntimeClock);
+            _rootServiceInjector.BindVolatileInstance(GenericType<RuntimeClock>.Class, heartbeatManager.EvaluatorSettings.RuntimeClock);
+
             RootTaskConfig = rootTaskConfig;
         }
 

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorSettings.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorSettings.cs
@@ -43,7 +43,9 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
         private readonly string _rootContextId;
         private readonly int _heartBeatPeriodInMs;
         private readonly int _maxHeartbeatRetries;
-        private readonly IClock _clock;
+
+        // TODO[JIRA REEF-1281]: Use IClock.
+        private readonly RuntimeClock _clock;
         private readonly IRemoteManager<REEFMessage> _remoteManager;
         private readonly IInjector _injector;
         private readonly IConfiguration _rootContextConfig;
@@ -216,8 +218,9 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
 
         /// <summary>
         /// return Runtime Clock injected from the constructor
+        /// TODO[JIRA REEF-1281]: Use IClock.
         /// </summary>
-        public IClock RuntimeClock
+        public RuntimeClock RuntimeClock
         {
             get
             {


### PR DESCRIPTION
…stance of clock

This addressed the issue by
  * BindVolatileInstance for clocks to the service injector.

JIRA:
  [REEF-1279](https://issues.apache.org/jira/browse/REEF-1279)