### PR TITLE
[REEF-1142] Making caching configurable in the remote managers

### DIFF
--- a/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
@@ -62,6 +62,7 @@ under the License.
     <Compile Include="IObserverFactory.cs" />
     <Compile Include="IStage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Remote\IRemoteObserver.cs" />
     <Compile Include="Remote\ITcpPortProvider.cs" />
     <Compile Include="Remote\Parameters\TcpPortRangeCount.cs" />
     <Compile Include="Remote\Parameters\TcpPortRangeSeed.cs" />

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/IRemoteObserver.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/IRemoteObserver.cs
@@ -14,31 +14,14 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 using System;
-using System.Net;
-using Org.Apache.REEF.Wake.Remote.Impl;
 
 namespace Org.Apache.REEF.Wake.Remote
 {
-    public interface IRemoteManager<T> : IStage
+    /// <summary>
+    /// A disposable remote observer observer, that is not managed by the manager that creates it
+    /// </summary>
+    public interface IRemoteObserver<T> : IObserver<T>, IDisposable
     {
-        IRemoteIdentifier Identifier { get; }
-
-        IPEndPoint LocalEndpoint { get; }
-
-        IObserver<T> GetRemoteObserver(RemoteEventEndPoint<T> dest);
-
-        IObserver<T> GetRemoteObserver(IPEndPoint remoteEndpoint);
-
-        IRemoteObserver<T> GetUnmanagedRemoteObserver(RemoteEventEndPoint<T> dest);
-
-        IRemoteObserver<T> GetUnmanagedObserver(IPEndPoint remoteEndpoint);
-
-        IDisposable RegisterObserver(RemoteEventEndPoint<T> source, IObserver<T> theObserver);
-
-        IDisposable RegisterObserver(IPEndPoint remoteEndpoint, IObserver<T> theObserver);
-
-        IDisposable RegisterObserver(IObserver<IRemoteMessage<T>> theObserver);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManagerFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManagerFactory.cs
@@ -34,19 +34,19 @@ namespace Org.Apache.REEF.Wake.Impl
             _tcpPortProvider = tcpPortProvider;
         }
 
-        public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, int port, ICodec<T> codec, bool enableCaching = true)
+        public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, int port, ICodec<T> codec)
         {
-            return new DefaultRemoteManager<T>(localAddress, port, codec, _tcpPortProvider, enableCaching);
+            return new DefaultRemoteManager<T>(localAddress, port, codec, _tcpPortProvider);
         }
 
-        public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, ICodec<T> codec, bool enableCaching = true)
+        public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, ICodec<T> codec)
         {
-            return new DefaultRemoteManager<T>(localAddress, 0, codec, _tcpPortProvider, enableCaching);
+            return new DefaultRemoteManager<T>(localAddress, 0, codec, _tcpPortProvider);
         }
 
-        public IRemoteManager<T> GetInstance<T>(ICodec<T> codec, bool enableCaching = true)
+        public IRemoteManager<T> GetInstance<T>(ICodec<T> codec)
         {
-            return new DefaultRemoteManager<T>(codec, enableCaching);
+            return new DefaultRemoteManager<T>(codec);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManagerFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManagerFactory.cs
@@ -34,19 +34,19 @@ namespace Org.Apache.REEF.Wake.Impl
             _tcpPortProvider = tcpPortProvider;
         }
 
-        public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, int port, ICodec<T> codec)
+        public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, int port, ICodec<T> codec, bool enableCaching = true)
         {
-            return new DefaultRemoteManager<T>(localAddress, port, codec, _tcpPortProvider);
+            return new DefaultRemoteManager<T>(localAddress, port, codec, _tcpPortProvider, enableCaching);
         }
 
-        public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, ICodec<T> codec)
+        public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, ICodec<T> codec, bool enableCaching = true)
         {
-            return new DefaultRemoteManager<T>(localAddress, 0, codec, _tcpPortProvider);
+            return new DefaultRemoteManager<T>(localAddress, 0, codec, _tcpPortProvider, enableCaching);
         }
 
-        public IRemoteManager<T> GetInstance<T>(ICodec<T> codec)
+        public IRemoteManager<T> GetInstance<T>(ICodec<T> codec, bool enableCaching = true)
         {
-            return new DefaultRemoteManager<T>(codec);
+            return new DefaultRemoteManager<T>(codec, enableCaching);
         }
     }
 }


### PR DESCRIPTION
This addressed the issue by adding boolean flag to the remote manager factory
that allows disabling caching of the observers.
JIRA:
[REEF-1142] (https://issues.apache.org/jira/browse/1246)