### PR TITLE
[REEF-1275] Move build/test instructions from wiki to Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Hadoop.
 
 Online Documentation
 ====================
-This file will cover the very basics of compiling and testing
-REEF. Much more detailed information can be found in the following
-places:
+Detailed information on REEF can be found in the following places:
 
   * [The project website](http://reef.apache.org/)
   * [The project wiki](https://cwiki.apache.org/confluence/display/REEF/Home)
@@ -26,53 +24,7 @@ sufficient.
 Building REEF
 =============
 
-Requirements
-------------
+|   | Java   | .NET |
+|---|:------:|:----:|
+|Build & run unit tests| [java\BUILD.md](lang/java/BUILD.md) | [cs\BUILD.md](lang/cs/BUILD.md) |
 
-  * Java 7 Development Kit.
-  * [Apache Maven](http://maven.apache.org) 3.3 or newer. Make sure that
-    `mvn` is in your `PATH`.
-  * [Protocol Buffers](https://code.google.com/p/protobuf/) Compiler
-    version 2.5. Make sure that `protoc` is on your `PATH`.
-  * For REEF.NET, you will also need [Visual Studio]
-    (http://www.visualstudio.com), preferably Version 2015 (2013 is still 
-    supported). Most REEF developers use the free Community Edition.
-
-REEF Java
----------
-The Java side of REEF is built using Apache Maven. To build, execute:
-
-    mvn -DskipTests clean install
-
-To test, execute:
-
-    mvn test
-
-Note that the tests will take several minutes to complete. You will
-also see stack traces fly by. Not to worry: those are part of the
-tests that test REEF's error reporting.
-
-REEF.NET
---------
-REEF.NET uses REEF Java. In fact, the instructions below build REEF
-Java as part of building REEF.NET. Hence, the same requirements apply.
-
-To build and test in Visual Studio, open
-`lang\cs\Org.Apache.REEF.sln`.
-
-Alternatively, you can build REEF.NET from a developer command line
-via:
-
-    msbuild .\lang\cs\Org.Apache.REEF.sln
-
-To test, execute the following command thereafter:
-
-    msbuild .\lang\cs\TestRunner.proj
-
-Additional Information
-----------------------
-More detailed documentation, including building from PowerShell and
-creating NuGets is available from the [project
-wiki](https://cwiki.apache.org/confluence/display/REEF/Home),
-specifically the [building
-instructions](https://cwiki.apache.org/confluence/display/REEF/Compiling+REEF).

--- a/lang/cs/BUILD.md
+++ b/lang/cs/BUILD.md
@@ -1,0 +1,44 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Building and Testing REEF .NET
+==================
+
+Prerequisites
+-------------
+
+  * Windows OS.
+  * [Building REEF Java](../java/BUILD.md).
+  * [Visual Studio](http://www.visualstudio.com) 2015 (preferred) or 2013. Most REEF developers use the free Community Edition.
+  * NuGet 2.8.6 or later.
+  * xunit.runner.console.2.1.0 package (installing it might require manual restore of NuGet packages).
+
+
+Instructions
+------------
+
+To build and run tests in Visual Studio, open `lang\cs\Org.Apache.REEF.sln`, build entire solution and run all tests in Test Explore.
+
+To build REEF.NET from command line, execute
+
+    msbuild .\lang\cs\Org.Apache.REEF.sln
+
+To run .NET tests from command line, execute
+
+    msbuild .\lang\cs\TestRunner.proj

--- a/lang/java/BUILD.md
+++ b/lang/java/BUILD.md
@@ -1,0 +1,79 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Building and Testing REEF Java
+==================
+
+Prerequisites
+-------------
+
+  * Java Development Kit 7 or 8. Make sure that `$JAVA_HOME` points to it.
+  * [Apache Maven](https://maven.apache.org/download.cgi) 3.3 or newer.
+    Make sure that `mvn` is in your `$PATH` and `$M2_HOME` points to its installation.
+  * [Protocol Buffers Compiler version 2.5](https://github.com/google/protobuf/releases/tag/v2.5.0).
+    Make sure that `protoc` is on your `PATH`.
+
+Build Instructions
+------------
+
+The Java side of REEF is built using Apache Maven. To build and run tests, execute:
+
+    mvn clean install
+
+To perform build alone without tests in a multithreaded mode, execute
+
+    mvn -TC1 -DskipTests clean install
+
+To perform "fast" build, which skips tests and all code quality enforcement tools, execute:
+
+    mvn clean install -DskipTests -TC1 -P!code-quality
+
+Test Instructions
+------------
+
+To run tests separately on local runtime, execute:
+
+    mvn test
+
+Note that the tests will take several minutes to complete. You will
+also see stack traces fly by. Not to worry: those are part of the
+tests that test REEF's error reporting.
+
+Code Quality Enforcement Tools
+------------
+
+Java build incorporates several code quality tools:
+
+* **Apache RAT** verifies that Apache headers are in place where needed. To run this check separately, execute:
+
+  `mvn apache-rat:check`
+
+* **Checkstyle** verifies that all Java code adheres to a coding standard. To run this check separately, execute:
+
+  `mvn checkstyle:checkstyle`
+
+  Per-project Checkstyle reports can be found at `\<project>\target\site\checkstyle.html`.  Violations which caused the build break will show up as errors and need to be fixed; violations which show up as warnings or info can be ignored.
+
+* **Findbugs** looks for potential bugs in Java code, and can fail the build if any high-priority warnings are found.
+  To run this check separately, execute:
+
+  `mvn findbugs:check xml:transform`
+
+  Per-project Findbugs reports can be found at `\<project>\target\findbugs\findbugsXml.html`.
+


### PR DESCRIPTION
This change creates BUILD.md files with build/test instructions
for Java and .NET and updates project's README.md to reference them.

JIRA:
  [REEF-1275](https://issues.apache.org/jira/browse/REEF-1275)

Pull request:
  This closes #