### PR TITLE
[REEF-1261] Enable ConstructorWithoutParamsCheck from sevntu-checkstyle

### DIFF
--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFuture.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexAggregateFuture.java
@@ -89,7 +89,8 @@ public final class VortexAggregateFuture<TInput, TOutput> implements VortexFutur
     final Pair<List<Integer>, AggregateResult> resultPair = resultQueue.poll(timeout, timeUnit);
 
     if (resultPair == null) {
-      throw new TimeoutException();
+      throw new TimeoutException("Synchronous aggregation of the next future result timed out. Timeout = " + timeout
+              + " in time units: " + timeUnit);
     }
 
     removeFromTaskletIdInputMap(resultPair.getLeft());

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexFuture.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/api/VortexFuture.java
@@ -113,7 +113,8 @@ public final class VortexFuture<TOutput>
     try {
       if (timeout.isPresent() && unit.isPresent()) {
         if (!countDownLatch.await(timeout.get(), unit.get())) {
-          throw new TimeoutException();
+          throw new TimeoutException("Cancellation of the VortexFuture timed out. Timeout = " + timeout.get()
+                  + " in time units: " + unit.get());
         }
       } else {
         countDownLatch.await();
@@ -174,7 +175,8 @@ public final class VortexFuture<TOutput>
   public TOutput get(final long timeout, final TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException, CancellationException {
     if (!countDownLatch.await(timeout, unit)) {
-      throw new TimeoutException();
+      throw new TimeoutException("Waiting for the results of the task timed out. Timeout = " + timeout
+              + " in time units: " + unit);
     }
 
     return get();

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/TestUtil.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/TestUtil.java
@@ -142,7 +142,7 @@ public final class TestUtil {
         while(true) {
           Thread.sleep(100);
           if (Thread.currentThread().isInterrupted()) {
-            throw new InterruptedException();
+            throw new InterruptedException("Interrupted thread: " + Thread.currentThread());
           }
         }
       }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
@@ -120,6 +120,7 @@ public final class REEFLauncher {
     return new RuntimeException(msg, t);
   }
 
+  @SuppressWarnings("checkstyle:constructorwithoutparams") // avoids logging the same message twice in fatal()
   private static Configuration readConfigurationFromDisk(
           final String configPath, final ConfigurationSerializer serializer) {
     LOG.log(Level.FINEST, "Loading configuration file: {0}", configPath);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatusManager.java
@@ -149,6 +149,7 @@ public final class DriverStatusManager {
   /**
    * Perform a clean shutdown of the Driver.
    */
+  @SuppressWarnings("checkstyle:constructorwithoutparams") // Exception() here captures the callstack
   public synchronized void onComplete() {
     LOG.entering(DriverStatusManager.class.getCanonicalName(), "onComplete");
     if (this.isShuttingDownOrFailing()) {

--- a/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
@@ -249,6 +249,12 @@
 
         <module name="AvoidHidingCauseExceptionCheck" />
 
+        <!-- ConstructorWithoutParams is suppressed for files with the word "Test" in the filename -->
+        <module name="ConstructorWithoutParamsCheck" >
+            <property name="classNameFormat" value=".*Exception$" />
+            <property name="ignoredClassNameFormat" value="UnsupportedOperationException|NotImplementedException|NoSuchElementException" />
+        </module>
+
     </module>
 
 </module>

--- a/lang/java/reef-common/src/main/resources/checkstyle-suppress.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle-suppress.xml
@@ -23,4 +23,5 @@
     <suppress checks=".*" files=".*\\target\\generated-sources\\.*" />
     <suppress checks="IllegalThrows" files=".*Test.*" />
     <suppress checks="IllegalCatch"  files=".*Test.*" />
+    <suppress checks="ConstructorWithoutParams"  files=".*Test.*" />
 </suppressions>

--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -250,6 +250,12 @@
 
         <module name="AvoidHidingCauseExceptionCheck" />
 
+        <!-- ConstructorWithoutParams is suppressed for files with the word "Test" in the filename -->
+        <module name="ConstructorWithoutParamsCheck" >
+          <property name="classNameFormat" value=".*Exception$" />
+          <property name="ignoredClassNameFormat" value="UnsupportedOperationException|NotImplementedException|NoSuchElementException" />
+        </module>
+
     </module>
 
 </module>

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/LocalNameResolverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/LocalNameResolverImpl.java
@@ -98,7 +98,7 @@ public final class LocalNameResolverImpl implements NameResolver {
           try {
             final InetSocketAddress addr = nameServer.lookup(id);
             if (addr == null) {
-              throw new NullPointerException();
+              throw new NullPointerException("The lookup of the address in the nameServer returned null for id " + id);
             } else {
               return addr;
             }

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/EvaluatorControlHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/EvaluatorControlHandler.java
@@ -49,7 +49,7 @@ final class EvaluatorControlHandler implements EventHandler<RemoteMessage<Evalua
     } else if (evaluatorControl.getEvaluatorRelease() != null) {
       this.mesosExecutor.get().onEvaluatorRelease(evaluatorControl.getEvaluatorRelease());
     } else {
-      throw new IllegalArgumentException();
+      throw new IllegalArgumentException("Received a remoteMessage with the unknown Evaluator Control status.");
     }
   }
 }

--- a/lang/java/reef-tang/tang-tint/src/main/java/org/apache/reef/tang/util/Tint.java
+++ b/lang/java/reef-tang/tang-tint/src/main/java/org/apache/reef/tang/util/Tint.java
@@ -362,7 +362,8 @@ public class Tint {
           } else if (n instanceof ClassNode<?>) {
             out.println(t.toHtmlString((ClassNode<?>) n, currentPackage));
           } else {
-            throw new IllegalStateException();
+            throw new IllegalStateException("The node is neither ClassNode nor NamedParameterNode."
+                    + "The node variable n has this value: " + n.getFullName());
           }
         }
         out.println("</div>");

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
@@ -175,7 +175,8 @@ public final class AvroConfigurationSerializer implements ConfigurationSerialize
         } else if (value instanceof Node) {
           val = ((Node) value).getFullName();
         } else {
-          throw new IllegalStateException();
+          throw new IllegalStateException("The value bound to a given NamedParameterNode "
+                  + key + " is neither the set of class hierarchy nodes nor strings.");
         }
         configurationEntries.add(ConfigurationEntry.newBuilder()
             .setKey(key.getFullName())

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
@@ -353,7 +353,8 @@ public class ConfigurationModule {
         } else if (value instanceof Node) {
           val = ((Node) value).getFullName();
         } else {
-          throw new IllegalStateException();
+          throw new IllegalStateException("The value bound to a given NamedParameterNode "
+                  + key + " is neither the set of class hierarchy nodes nor strings.");
         }
         l.add(key.getFullName() + '=' + escape(val));
       }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/ConfigurationBuilderImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/ConfigurationBuilderImpl.java
@@ -130,7 +130,8 @@ public class ConfigurationBuilderImpl implements ConfigurationBuilder {
       } else if (e.getValue() instanceof String) {
         bindSetEntry(name, (String) e.getValue());
       } else {
-        throw new IllegalStateException();
+        throw new IllegalStateException("The value of the named parameter node in boundSetEntries"
+                + " is neither String nor Node. The actual type is  " + e.getValue().getClass());
       }
     }
     // The boundLists set contains bound lists with their target NamedParameters

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/Subplan.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/Subplan.java
@@ -32,7 +32,8 @@ public final class Subplan<T> extends InjectionPlan<T> {
     super(node);
     this.alternatives = alternatives;
     if (selectedIndex < -1 || selectedIndex >= alternatives.length) {
-      throw new ArrayIndexOutOfBoundsException();
+      throw new ArrayIndexOutOfBoundsException("Actual value of selectedIndex is " + selectedIndex
+      + ". The length of the 'alternatives' vararg is " + alternatives.length);
     }
     this.selectedIndex = selectedIndex;
     if (selectedIndex != -1) {
@@ -127,7 +128,7 @@ public final class Subplan<T> extends InjectionPlan<T> {
 
   public InjectionPlan<? extends T> getDelegatedPlan() {
     if (selectedIndex == -1) {
-      throw new IllegalStateException();
+      throw new IllegalStateException("selectedIndex equals -1");
     } else {
       return alternatives[selectedIndex];
     }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/ClassHierarchyImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/ClassHierarchyImpl.java
@@ -200,7 +200,8 @@ public class ClassHierarchyImpl implements JavaClassHierarchy {
     }
 
     if (root == null) {
-      throw new NullPointerException();
+      throw new NullPointerException("The root of the path to node is null. "
+              + "The class name is likely to be malformed. The clazz.getName() returns " + clazz.getName());
     }
     final Node parent = root;
 

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/InjectorImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/InjectorImpl.java
@@ -106,7 +106,7 @@ public class InjectorImpl implements Injector {
       if (cn.getFullName().equals(ReflectionUtilities.getFullName(Injector.class))
           || cn.getFullName().equals(ReflectionUtilities.getFullName(InjectorImpl.class))) {
         // This would imply that we're treating injector as a singleton somewhere.  It should be copied fresh each time.
-        throw new IllegalStateException();
+        throw new IllegalStateException("Injector should be copied fresh each time.");
       }
       try {
         final ClassNode<?> newCn = (ClassNode<?>) i.namespace.getNode(cn

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaNodeFactory.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaNodeFactory.java
@@ -222,7 +222,10 @@ public final class JavaNodeFactory {
     } else if (hasStringSetDefault) {
       defaultInstanceAsStrings = namedParameter.default_values();
     } else {
-      throw new IllegalStateException();
+      throw new IllegalStateException("The named parameter " + namedParameter.short_name() + " has a default value,"
+              + " but the value cannot be retrieved. The defaultCount is " + defaultCount
+              + ", but hasClassDefault, hasStringDefault, hasClassSetDefault, hasStringSetDefault"
+              + " conditions are all false");
     }
 
     final String documentation = namedParameter.doc();
@@ -303,7 +306,10 @@ public final class JavaNodeFactory {
     final Type[] genericParamTypes = constructor.getGenericParameterTypes();
     final Annotation[][] paramAnnotations = constructor.getParameterAnnotations();
     if (paramTypes.length != paramAnnotations.length) {
-      throw new IllegalStateException();
+      throw new IllegalStateException("The paramTypes.length is " + paramTypes.length
+              + ", and paramAnnotations.length is " + paramAnnotations.length
+              + ". These values should be equal."
+      );
     }
     final ConstructorArg[] args = new ConstructorArg[genericParamTypes.length];
     for (int i = 0; i < genericParamTypes.length; i++) {

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/protobuf/ProtocolBufferClassHierarchy.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/protobuf/ProtocolBufferClassHierarchy.java
@@ -310,7 +310,7 @@ public class ProtocolBufferClassHierarchy implements ClassHierarchy {
     if (j == 1) {
       return str;
     } else {
-      throw new ArrayIndexOutOfBoundsException();
+      throw new ArrayIndexOutOfBoundsException("The value of j should be 1, but actually is " + j);
     }
   }
 

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/ReflectionUtilities.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/ReflectionUtilities.java
@@ -266,7 +266,8 @@ public final class ReflectionUtilities {
       final Class<?> clazz = (Class<?>) type;
 
       if (!clazz.equals(type)) {
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("The clazz is "  + clazz + " and the type is "
+                + type + ". They must be equal to each other.");
       }
 
       final ArrayList<Type> al = new ArrayList<>();

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/watcher/FailedContextHandler.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/watcher/FailedContextHandler.java
@@ -30,7 +30,7 @@ public final class FailedContextHandler implements EventHandler<ContextStart> {
 
   @Inject
   private FailedContextHandler() {
-    throw new RuntimeException();
+    throw new RuntimeException("Fails the context.");
   }
 
   @Override

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/watcher/FailedTaskStartHandler.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/watcher/FailedTaskStartHandler.java
@@ -30,7 +30,7 @@ public final class FailedTaskStartHandler implements EventHandler<TaskStart> {
 
   @Inject
   private FailedTaskStartHandler() {
-    throw new RuntimeException();
+    throw new RuntimeException("Fails the task.");
   }
 
   @Override

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/FailureSchedulingContextStartHandler.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/FailureSchedulingContextStartHandler.java
@@ -40,6 +40,9 @@ final class FailureSchedulingContextStartHandler implements EventHandler<Context
   }
 
   @Override
+  // this check is suppressed for all tests, that is, for files which names contain the word "Test"
+  // the name of this file does not contain the word, but it still belongs to tests
+  @SuppressWarnings("checkstyle:constructorwithoutparams")
   public void onNext(final ContextStart contextStart) {
     this.clock.scheduleAlarm(0, new EventHandler<Alarm>() {
       @Override

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/WrappedValue.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/WrappedValue.java
@@ -73,7 +73,7 @@ final class WrappedValue<V> {
       this.notifyAll();
     }
     if (!value.isPresent()) {
-      throw new ExecutionException("valueFetcher returned null", new NullPointerException());
+      throw new ExecutionException(new NullPointerException("valueFetcher returned null"));
     } else {
       return value.get();
     }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/Vertex.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/Vertex.java
@@ -35,14 +35,14 @@ public class Vertex<T> {
                 final Vertex<?>[] constructorArguments) {
     this.object = object;
     if (object == null) {
-      throw new NullPointerException();
+      throw new NullPointerException("The first argument of the Vertex constructor is null.");
     }
     this.name = name;
     this.constructorDef = constructorDef;
     this.constructorArguments = constructorArguments;
     for (final Vertex<?> v : constructorArguments) {
       if (v == null) {
-        throw new NullPointerException();
+        throw new NullPointerException("One of the vertices in the Vertex constructorArguments is null.");
       }
     }
   }
@@ -50,14 +50,14 @@ public class Vertex<T> {
   public Vertex(final T object, final ConstructorDef<T> constructorDef, final Vertex<?>[] constructorArguments) {
     this.object = object;
     if (object == null) {
-      throw new NullPointerException();
+      throw new NullPointerException("The first argument of the Vertex constructor is null.");
     }
     this.name = null;
     this.constructorDef = constructorDef;
     this.constructorArguments = constructorArguments;
     for (final Vertex<?> v : constructorArguments) {
       if (v == null) {
-        throw new NullPointerException();
+        throw new NullPointerException("One of the vertices in the Vertex constructorArguments is null.");
       }
     }
   }
@@ -65,7 +65,7 @@ public class Vertex<T> {
   public Vertex(final Object object) {
     this.object = object;
     if (object == null) {
-      throw new NullPointerException();
+      throw new NullPointerException("The argument of the Vertex constructor is null.");
     }
     this.name = null;
     this.constructorDef = null;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
@@ -93,7 +93,7 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
 
   public AutoCloseable registerErrorHandler(final EventHandler<Exception> theHandler) {
     this.transport.registerErrorHandler(theHandler);
-    return new Subscription(new Exception(), this);
+    return new Subscription(new Exception("Token for finding the error handler subscription"), this);
   }
 
   /**

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxThreadPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxThreadPoolStage.java
@@ -153,8 +153,9 @@ public final class RxThreadPoolStage<T> extends AbstractRxStage<T> {
         try {
           // no timeout for completion, only close()
           if (!executor.awaitTermination(3153600000L, TimeUnit.SECONDS)) {
-            LOG.log(Level.SEVERE, "Executor terminated due to unrequired timeout");
-            observer.onError(new TimeoutException());
+            TimeoutException e = new TimeoutException("Executor terminated due to unrequired timeout");
+            LOG.log(Level.SEVERE, e.getMessage());
+            observer.onError(e);
           }
         } catch (final InterruptedException e) {
           e.printStackTrace();

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@ under the License.
         <jackson.version>1.9.13</jackson.version>
         <protobuf.version>2.5.0</protobuf.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
-        <sevntu.checkstyle.plugin.version>1.15.0</sevntu.checkstyle.plugin.version>
+        <sevntu.checkstyle.plugin.version>1.20.0</sevntu.checkstyle.plugin.version>
         <checkstyle.version>6.12</checkstyle.version>
         <findbugs.version>3.0.2</findbugs.version>
         <reflections.version>0.9.9-RC1</reflections.version>


### PR DESCRIPTION
This patch:
 * Bumps up the sevntu-checkstyle version to 1.20.0; the check is released in this version
 * Fixes violations of the check in the REEF Java codebase
 * Makes the check ignore the test files

JIRA:
 [REEF-1261] (https://issues.apache.org/jira/browse/REEF-1261)