### PR TITLE
 [REEF-1276] Improve error message shown when injectable class has  [Parameter] annotation

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
@@ -427,6 +427,17 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Assert.NotNull(b);
             Assert.NotNull(c);
         }
+
+        // See REEF-1276
+        [Fact]
+        public void TestInjectableClassWithParameterAnnotationThrowsMeaningfulException()
+        {
+            ITang tang = TangFactory.GetTang();
+            IInjector i = tang.NewInjector(tang.NewConfigurationBuilder().Build());
+
+            Action injection = () => i.GetInstance(typeof(ClazzA));
+            Assert.Throws<ArgumentException>(injection);
+        }
     }
 
     [NamedParameter]
@@ -695,5 +706,25 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
     [NamedParameter(DefaultClass = typeof(string))]
     class BadParsableDefaultClass : Name<string>
     {        
+    }
+
+    // ClazzB is injectable and does not need the Parameter annotation in the ClazzA constructor
+    class ClazzA
+    {
+        private ClazzB objectB;
+
+        public class ClazzB 
+        {
+            [Inject]
+            public ClazzB()
+            {
+            }
+        }
+
+        [Inject]
+        public ClazzA([Parameter(typeof(ClazzB))] ClazzB objectB)
+        {
+            this.objectB = objectB;
+        }
     }
  }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
@@ -167,6 +167,17 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                         RegisterType(constructorArg.Gettype());  // Gettype returns param's Type.fullname
                         if (constructorArg.GetNamedParameterName() != null)
                         {
+                            var pn = RegisterType(constructorArg.GetNamedParameterName());
+                            
+                            if (!(pn is INamedParameterNode))
+                            {
+                                string message = string.Format(CultureInfo.CurrentCulture,
+                                                               "The class {0}, used in the constructor of {1}, should not be defined as a NamedParameter.",
+                                                               constructorArg.GetNamedParameterName(),
+                                                               constructorDef.GetClassName());
+                                Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new ArgumentException(message), LOGGER);
+                            }
+
                             INamedParameterNode np = (INamedParameterNode)RegisterType(constructorArg.GetNamedParameterName());
                             try
                             {


### PR DESCRIPTION

 This patch:
  * Throws an Argument Exception with a message stating the class that should not be defined as a NamedParameter

 JIRA:
  [REEF-1276] (https://issues.apache.org/jira/browse/REEF-1276)