### PR TITLE
[REEF-1265] Clean up tests inherited from ReefFunctionalTests

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
@@ -29,18 +29,13 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(TestBridgeClient));
 
-        public TestBridgeClient()
-        {
-            Init();
-        }
-
         [Fact(Skip = "Requires Yarn")]
         [Trait("Priority", "1")]
         [Trait("Category", "FunctionalGated")]
         [Trait("Description", "Run CLR Bridge on Yarn")]
         public async Task CanRunClrBridgeExampleOnYarn()
         {
-            string testRuntimeFolder = DefaultRuntimeFolder + TestNumber++;
+            string testRuntimeFolder = DefaultRuntimeFolder + TestId;
             await RunClrBridgeClient(true, testRuntimeFolder);
         }
 
@@ -51,8 +46,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public async Task CanRunClrBridgeExampleOnLocalRuntime()
         {
-            string testRuntimeFolder = DefaultRuntimeFolder + TestNumber++;
-            CleanUp(testRuntimeFolder);
+            string testRuntimeFolder = DefaultRuntimeFolder + TestId;
             await RunClrBridgeClient(false, testRuntimeFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestCloseTask.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestCloseTask.cs
@@ -52,11 +52,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         private const string CompletedValidationMessage = "CompletedValidationmessage";
         private const string FailToCloseTaskMessage = "FailToCloseTaskMessage";
 
-        public TestCloseTask()
-        {
-            Init();
-        }
-
         /// <summary>
         /// This test is close a running task with a close handler registered
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestContextStack.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestContextStack.cs
@@ -44,11 +44,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
 
         private static readonly Logger Logger = Logger.GetLogger(typeof(TestContextStack));
 
-        public TestContextStack()
-        {
-            Init();
-        }
-
         /// <summary>
         /// Does a simple test of whether a context can be submitted on top of another context.
         /// </summary>
@@ -56,7 +51,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         public void TestContextStackingOnLocalRuntime()
         {
             string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
-            CleanUp(testFolder);
             TestRun(DriverConfigurations(GenericType<ActiveContextSubmitContextHandler>.Class),
                 typeof(ContextStackHandlers), 1, "testContextStack", "local", testFolder);
             ValidateSuccessForLocalRuntime(2, testFolder: testFolder);
@@ -73,7 +67,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         public void TestContextStackingWithServiceOnLocalRuntime()
         {
             string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
-            CleanUp(testFolder);
             TestRun(DriverConfigurations(GenericType<ActiveContextSubmitContextAndServiceHandler>.Class),
                 typeof(ContextStackHandlers), 1, "testContextAndServiceStack", "local", testFolder);
             ValidateSuccessForLocalRuntime(2, testFolder: testFolder);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
@@ -42,11 +42,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         private const string FailSignal = "Fail";
         private const string TaskId = "1234567";
 
-        public TestFailedEvaluatorEventHandler()
-        {
-            Init();
-        }
-
         [Fact]
         [Trait("Priority", "1")]
         [Trait("Category", "FunctionalGated")]
@@ -54,7 +49,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestFailedEvaluatorEventHandlerOnLocalRuntime()
         {
-            string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(DriverConfigurations(), typeof(FailedEvaluatorDriver), 1, "failedEvaluatorTest", "local", testFolder);
             ValidateSuccessForLocalRuntime(0, numberOfEvaluatorsToFail: 1, testFolder: testFolder);
             ValidateMessageSuccessfullyLoggedForDriver(FailedEvaluatorMessage, testFolder);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
@@ -35,11 +35,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
     {
         private const string FailedTaskMessage = "I have successfully seen a failed task.";
 
-        public TestFailedTaskEventHandler()
-        {
-            Init();
-        }
-
         [Fact]
         [Trait("Priority", "1")]
         [Trait("Category", "FunctionalGated")]
@@ -47,8 +42,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestFailedTaskEventHandlerOnLocalRuntime()
         {
-            string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(DriverConfigurations(), typeof(FailedTaskDriver), 1, "failedTaskTest", "local", testFolder);
             ValidateSuccessForLocalRuntime(numberOfContextsToClose: 1, numberOfTasksToFail: 1, testFolder: testFolder);
             ValidateMessageSuccessfullyLoggedForDriver(FailedTaskMessage, testFolder);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleContext.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleContext.cs
@@ -40,11 +40,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
 
         private static readonly Logger Logger = Logger.GetLogger(typeof(TestSimpleContext));
 
-        public TestSimpleContext()
-        {
-            Init();
-        }
-
         /// <summary>
         /// Does a simple test of context submission.
         /// </summary>
@@ -60,8 +55,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
 
         private void TestContextOnLocalRuntime(IConfiguration configuration)
         {
-            string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(configuration, typeof(TestContextHandlers), 1, "testSimpleContext", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder: testFolder);
             ValidateMessageSuccessfullyLoggedForDriver(ValidationMessage, testFolder);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
@@ -34,11 +34,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
     [Collection("FunctionalTests")]
     public class TestSimpleEventHandlers : ReefFunctionalTest
     {
-        public TestSimpleEventHandlers()
-        {
-            Init();
-        }
-
         [Fact]
         [Trait("Priority", "1")]
         [Trait("Category", "FunctionalGated")]
@@ -46,8 +41,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void RunSimpleEventHandlerOnLocalRuntime()
         {
-            string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(DriverConfigurations(), typeof(HelloSimpleEventHandlers), 2, "simpleHandler", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder: testFolder);
             ValidateMessageSuccessfullyLoggedForDriver("Evaluator is assigned with 3072 MB of memory and 1 cores.", testFolder);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSuspendTask.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSuspendTask.cs
@@ -44,11 +44,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         private const string SuspendValidationMessage = "SuspendValidationMessage";
         private const string CompletedValidationMessage = "CompletedValidationmessage";
 
-        public TestSuspendTask()
-        {
-            Init();
-        }
-
         /// <summary>
         /// Does a simple test of invoking suspend task with a message from the Driver
         /// and makes sure the target task receives the suspend message.
@@ -58,8 +53,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         [Fact]
         public void TestSuspendTaskOnLocalRuntime()
         {
-            string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(DriverConfigurations(), typeof(SuspendTaskHandlers), 1, "testSuspendTask", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder: testFolder);
             ValidateMessageSuccessfullyLoggedForDriver(SuspendValidationMessage, testFolder);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Driver/TestDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Driver/TestDriver.cs
@@ -29,11 +29,6 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
     [Collection("FunctionalTests")]
     public class TestDriver : ReefFunctionalTest
     {
-        public TestDriver()
-        {
-            CleanUp();
-        }
-
         /// <summary>
         /// This is to test DriverTestStartHandler. No evaluator and tasks are involved.
         /// </summary>
@@ -44,10 +39,10 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
         //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestDriverStart()
         {
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(DriverConfigurations(), typeof(DriverTestStartHandler), 0, "DriverTestStartHandler", "local", testFolder);
             ValidateSuccessForLocalRuntime(0, testFolder: testFolder);
+            CleanUp(testFolder);
         }
 
         public IConfiguration DriverConfigurations()

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/FaultTolerant/TestContextStart.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/FaultTolerant/TestContextStart.cs
@@ -42,18 +42,13 @@ namespace Org.Apache.REEF.Tests.Functional.FaultTolerant
         private const string StartedMessage = "Do something started.";
         private const string CompletedMessage = "Do something completed.";
 
-        public TestContextStart()
-        {
-            Init();
-        }
-
         /// <summary>
         /// This test case submit a context with a Context start handler and do something in the handler
         /// </summary>
         [Fact]
         public void TestDosomethingOnContextStartOnLocalRuntime()
         {
-            string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(DriverConfigurations(), typeof(ContextStartDriver), 1, "ContextStartDriver", "local", testFolder);
             ValidateSuccessForLocalRuntime(2, testFolder: testFolder);
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/BroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/BroadcastReduceTest.cs
@@ -34,26 +34,21 @@ namespace Org.Apache.REEF.Tests.Functional.Group
     [Collection("FunctionalTests")]
     public class BroadcastReduceTest : ReefFunctionalTest
     {
-        public BroadcastReduceTest()
-        {
-            CleanUp();
-        }
-
         [Fact]
         public void TestBroadcastAndReduceOnLocalRuntime()
         {
             int numTasks = 9;
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestBroadcastAndReduce(false, numTasks, testFolder);
             ValidateSuccessForLocalRuntime(numTasks, testFolder: testFolder);
+            CleanUp(testFolder);
         }
 
         [Fact(Skip = "Requires Yarn")]
         public void TestBroadcastAndReduceOnYarn()
         {
             int numTasks = 9;
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
+            string testFolder = DefaultRuntimeFolder + TestId + "Yarn";
             TestBroadcastAndReduce(true, numTasks, testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/PipelinedBroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/PipelinedBroadcastReduceTest.cs
@@ -34,26 +34,21 @@ namespace Org.Apache.REEF.Tests.Functional.Group
     [Collection("FunctionalTests")]
     public class PipelinedBroadcastReduceTest : ReefFunctionalTest
     {
-        public PipelinedBroadcastReduceTest()
-        {
-            CleanUp();
-        }
-
         [Fact]
         public void TestPipelinedBroadcastAndReduceOnLocalRuntime()
         {
             const int numTasks = 9;
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestBroadcastAndReduce(false, numTasks, testFolder);
             ValidateSuccessForLocalRuntime(numTasks, testFolder: testFolder);
+            CleanUp(testFolder);
         }
 
         [Fact(Skip = "Requires Yarn")]
         public void TestPipelinedBroadcastAndReduceOnYarn()
         {
             const int numTasks = 9;
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
+            string testFolder = DefaultRuntimeFolder + TestId + "Yarn";
             TestBroadcastAndReduce(true, numTasks, testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
@@ -34,27 +34,21 @@ namespace Org.Apache.REEF.Tests.Functional.Group
     [Collection("FunctionalTests")]
     public class ScatterReduceTest : ReefFunctionalTest
     {
-        public ScatterReduceTest()
-        {
-            CleanUp();
-        }
-
         [Fact]
         public void TestScatterAndReduceOnLocalRuntime()
         {
             int numTasks = 5;
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestScatterAndReduce(false, numTasks, testFolder);
             ValidateSuccessForLocalRuntime(numTasks, testFolder: testFolder);
+            CleanUp(testFolder);
         }
 
         [Fact(Skip = "Requires Yarn")]
         public void TestScatterAndReduceOnYarn()
         {
             int numTasks = 5;
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId + "Yarn";
             TestScatterAndReduce(true, numTasks, testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
@@ -115,10 +115,10 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
         public void TestKMeansOnLocalRuntimeWithGroupCommunications()
         {
             IsOnLocalRuntime = true;
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(DriverConfiguration(), typeof(KMeansDriverHandlers), Partitions + 1, "KMeansDriverHandlers", "local", testFolder);
             ValidateSuccessForLocalRuntime(Partitions + 1, testFolder: testFolder);
+            CleanUp(testFolder);
         }
 
         [Fact(Skip = "TODO[JIRA REEF-1183] Requires data files not present in enlistment")]
@@ -128,7 +128,7 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
         //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestKMeansOnYarnOneBoxWithGroupCommunications()
         {
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
+            string testFolder = DefaultRuntimeFolder + TestId + "Yarn";
             TestRun(DriverConfiguration(), typeof(KMeansDriverHandlers), Partitions + 1, "KMeansDriverHandlers", "yarn", testFolder);
             Assert.NotNull("BreakPointChecker");
         }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/TestTaskMessage.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/TestTaskMessage.cs
@@ -34,12 +34,6 @@ namespace Org.Apache.REEF.Tests.Functional.Messaging
     [Collection("FunctionalTests")]
     public class TestTaskMessage : ReefFunctionalTest
     {
-        public TestTaskMessage()
-        {
-            CleanUp();
-            Init();
-        }
-
         /// <summary>
         /// This test is to test both task message and driver message. The messages are sent 
         /// from one side and received in the corresponding handlers and verified in the test 
@@ -51,8 +45,7 @@ namespace Org.Apache.REEF.Tests.Functional.Messaging
         //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestSendTaskMessage()
         {
-            string testFolder = DefaultRuntimeFolder + Guid.NewGuid();
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(DriverConfigurations(), typeof(MessageDriver), 1, "simpleHandler", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder: testFolder);
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -46,7 +46,6 @@ namespace Org.Apache.REEF.Tests.Functional
         protected const string CmdFile = "run.cmd";
         protected const string BinFolder = ".";
 
-        protected static int TestNumber = 1;
         protected const string DefaultRuntimeFolder = "REEF_LOCAL_RUNTIME";
 
         private const string Local = "local";
@@ -77,6 +76,11 @@ namespace Org.Apache.REEF.Tests.Functional
         {
             get { return _onLocalRuntime; }
             set { _onLocalRuntime = value; }
+        }
+
+        public ReefFunctionalTest()
+        {
+            Init();
         }
 
         public void Init()
@@ -111,15 +115,18 @@ namespace Org.Apache.REEF.Tests.Functional
         {
             Console.WriteLine("Cleaning up test.");
 
-            if (TimerTask != null)
+            if (_enableRealtimeLogUpload)
             {
-                TestTimer.Stop();
-                TimerTask.Dispose();
-                TimerTask = null;
+                if (TimerTask != null)
+                {
+                    TestTimer.Stop();
+                    TimerTask.Dispose();
+                    TimerTask = null;
+                }
+
+                // Wait for file upload task to complete
+                Thread.Sleep(500);
             }
-            
-            // Wait for file upload task to complete
-            Thread.Sleep(500);
 
             string dir = Path.Combine(Directory.GetCurrentDirectory(), testFolder);
             try

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTest.cs
@@ -32,11 +32,6 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
     [Collection("FunctionalTests")]
     public class RuntimeNameTest : ReefFunctionalTest
     {
-        public RuntimeNameTest()
-        {
-            CleanUp();
-        }
-
         /// <summary>
         /// This is to test DriverTestStartHandler. No evaluator and tasks are involved.
         /// </summary>
@@ -47,8 +42,7 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
         //// TODO[JIRA REEF-1184]: add timeout 180 sec
         public void TestRuntimeName()
         {
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
-            CleanUp(testFolder);
+            string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(DriverConfigurationsWithEvaluatorRequest(), typeof(EvaluatorRequestingDriver), 1, "EvaluatorRequestingDriver", "local", testFolder);
             ValidateMessageSuccessfullyLoggedForDriver("Runtime Name: Local", testFolder, 2);
             CleanUp(testFolder);


### PR DESCRIPTION
This change:
 * unifies randomized runtime folder naming across all tests
 * makes Thread.Sleep() in CleanUp conditional to speed up execution
 * removes CleanUp calls before test execution
 * removes individual constructors of the tests and replaces them
   with constructor in ReefFunctionalTest

JIRA:
  [REEF-1265](https://issues.apache.org/jira/browse/REEF-1265)

Pull request:
  This closes #