### PR TITLE
[REEF-217] Evaluator reads the driver configuration (it shouldn't)

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
@@ -106,10 +106,6 @@ namespace Org.Apache.REEF.Client.Common
 
             _configurationSerializer.ToFile(driverConfiguration,
                 Path.Combine(driverFolderPath, _fileNames.GetClrDriverConfigurationPath()));
-
-            // TODO: Remove once we cleaned up the Evaluator to not expect this [REEF-217]
-            _configurationSerializer.ToFile(driverConfiguration,
-                Path.Combine(driverFolderPath, _fileNames.GetGlobalFolderPath(), _fileNames.GetClrBridgeConfigurationName()));
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultYarnClusterHttpDriverConnection.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultYarnClusterHttpDriverConnection.cs
@@ -17,6 +17,7 @@
 
 using System;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities;
 
 namespace Org.Apache.REEF.Common.Evaluator
 {
@@ -28,14 +29,15 @@ namespace Org.Apache.REEF.Common.Evaluator
         private DefaultYarnClusterHttpDriverConnection()
         {
             _applicationId = Environment.GetEnvironmentVariable(Constants.ReefYarnApplicationIdEnvironmentVariable);
-            if (_applicationId == null)
-            {
-                throw new ApplicationException("Could not fetch the application ID from YARN's container environment variables.");
-            }
         }
 
         public DriverInformation GetDriverInformation()
         {
+            if (string.IsNullOrWhiteSpace(_applicationId))
+            {
+                throw new ApplicationException("Could not fetch the application ID from YARN's container environment variables.");
+            }
+
             // e.g., http://headnodehost:9014/proxy/application_1407519727821_0012/reef/v1/driver
             Uri queryUri = new Uri(
                 string.Concat(

--- a/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultYarnOneBoxHttpDriverConnection.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultYarnOneBoxHttpDriverConnection.cs
@@ -29,14 +29,15 @@ namespace Org.Apache.REEF.Common.Evaluator
         private DefaultYarnOneBoxHttpDriverConnection()
         {
             _applicationId = Environment.GetEnvironmentVariable(Constants.ReefYarnApplicationIdEnvironmentVariable);
-            if (_applicationId == null)
-            {
-                throw new ApplicationException("Could not fetch the application ID from YARN's container environment variables.");
-            }
         }
 
         public DriverInformation GetDriverInformation()
         {
+            if (string.IsNullOrWhiteSpace(_applicationId))
+            {
+                throw new ApplicationException("Could not fetch the application ID from YARN's container environment variables.");
+            }
+
             // e.g., http://yingdac1:8088/proxy/application_1407519727821_0012/reef/v1/driver
             string oneBoxHost = string.Format(CultureInfo.InvariantCulture, "http://{0}:8088/proxy/", Environment.MachineName);
             Uri queryUri = new Uri(

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextRuntime.cs
@@ -193,11 +193,9 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
 
         /// <summary>
         /// Launches an Task on this context.
-        /// TODO[JIRA REEF-217]: Remove heartBeatManager from argument.
         /// </summary>
         /// <param name="taskConfiguration"></param>
-        /// <param name="heartBeatManager"></param>
-        public void StartTask(IConfiguration taskConfiguration, IHeartBeatManager heartBeatManager)
+        public void StartTask(IConfiguration taskConfiguration)
         {
             lock (_contextLifeCycle)
             {

--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/ContextRuntimeTests.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/ContextRuntimeTests.cs
@@ -211,7 +211,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
                 {
                     var hbMgr = Substitute.For<IHeartBeatManager>();
                     contextRuntime.ContextInjector.BindVolatileInstance(GenericType<IHeartBeatManager>.Class, hbMgr);
-                    contextRuntime.StartTask(taskConfig, hbMgr);
+                    contextRuntime.StartTask(taskConfig);
 
                     Assert.True(contextRuntime.TaskRuntime.IsPresent());
                     Assert.True(contextRuntime.GetTaskStatus().IsPresent());
@@ -255,14 +255,14 @@ namespace Org.Apache.REEF.Evaluator.Tests
                 {
                     var hbMgr = Substitute.For<IHeartBeatManager>();
                     contextRuntime.ContextInjector.BindVolatileInstance(GenericType<IHeartBeatManager>.Class, hbMgr);
-                    contextRuntime.StartTask(taskConfig, hbMgr);
+                    contextRuntime.StartTask(taskConfig);
 
                     Assert.True(contextRuntime.TaskRuntime.IsPresent());
                     Assert.True(contextRuntime.GetTaskStatus().IsPresent());
                     Assert.Equal(contextRuntime.GetTaskStatus().Value.state, State.RUNNING);
 
                     Assert.Throws<InvalidOperationException>(
-                        () => contextRuntime.StartTask(taskConfig, hbMgr));
+                        () => contextRuntime.StartTask(taskConfig));
                 }
                 finally
                 {
@@ -296,7 +296,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
 
                 var hbMgr = Substitute.For<IHeartBeatManager>();
                 contextRuntime.ContextInjector.BindVolatileInstance(GenericType<IHeartBeatManager>.Class, hbMgr);
-                contextRuntime.StartTask(taskConfig, hbMgr);
+                contextRuntime.StartTask(taskConfig);
                 var testTask = contextRuntime.TaskRuntime.Value.Task as TestTask;
                 if (testTask == null)
                 {
@@ -308,7 +308,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
                 Assert.False(contextRuntime.GetTaskStatus().IsPresent());
                 testTask.DisposedEvent.Wait();
 
-                contextRuntime.StartTask(taskConfig, hbMgr);
+                contextRuntime.StartTask(taskConfig);
                 Assert.Equal(contextRuntime.GetTaskStatus().Value.state, State.RUNNING);
 
                 var secondTestTask = contextRuntime.TaskRuntime.Value.Task as TestTask;

--- a/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
@@ -22,11 +22,9 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using Org.Apache.REEF.Common.Files;
 using Org.Apache.REEF.Common.Runtime.Evaluator;
 using Org.Apache.REEF.Common.Runtime.Evaluator.Utils;
 using Org.Apache.REEF.Driver.Bridge;
-using Org.Apache.REEF.Evaluator.Exceptions;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Implementations.InjectionPlan;
@@ -85,10 +83,7 @@ namespace Org.Apache.REEF.Evaluator
                 var serializer = injector.GetInstance<AvroConfigurationSerializer>();
                 var rootEvaluatorConfiguration =
                     serializer.FromString(injector.GetNamedInstance<EvaluatorConfiguration, string>());
-                var evaluator = injector.ForkInjector(
-                    ReadClrBridgeConfiguration(),
-                    rootEvaluatorConfiguration)
-                    .GetInstance<Evaluator>();
+                var evaluator = injector.ForkInjector(rootEvaluatorConfiguration).GetInstance<Evaluator>();
 
                 evaluator.Run();
                 logger.Log(Level.Info, "Evaluator is returned from Run()");
@@ -125,36 +120,6 @@ namespace Org.Apache.REEF.Evaluator
 
                 logger.Log(Level.Info, "Evaluator in debug mode, waiting for debugger to be attached...");
                 Thread.Sleep(2000);
-            }
-        }
-
-        /// <summary>
-        /// Reads the Evaluator Configuration.
-        /// </summary>
-        /// <exception cref="EvaluatorConfigurationFileNotFoundException">When the configuration file cannot be found.</exception>
-        /// <exception cref="EvaluatorConfigurationParseException">When the configuration file exists, but can't be deserialized.</exception>
-        /// <returns></returns>
-        //// TODO[JIRA REEF-217]: Remove this method.
-        private static IConfiguration ReadClrBridgeConfiguration()
-        {
-            var clrRuntimeConfigurationFile = Path.Combine(Directory.GetCurrentDirectory(), "reef", "global",
-                new REEFFileNames().GetClrBridgeConfigurationName());
-
-            if (!File.Exists(clrRuntimeConfigurationFile))
-            {
-                throw new EvaluatorConfigurationFileNotFoundException(clrRuntimeConfigurationFile);
-            }
-            
-            try
-            {
-                var clrDriverConfig = new AvroConfigurationSerializer().FromFile(clrRuntimeConfigurationFile);
-                logger.Log(Level.Info, 
-                    string.Format(CultureInfo.CurrentCulture, "Clr Driver Configuration is deserialized from file {0}:", clrRuntimeConfigurationFile));
-                return clrDriverConfig;
-            }
-            catch (Exception e)
-            {
-                throw new EvaluatorConfigurationParseException(e);
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Examples.DriverRestart/DriverRestart.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.DriverRestart/DriverRestart.cs
@@ -63,8 +63,7 @@ namespace Org.Apache.REEF.Examples.DriverRestart
                 .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<HelloRestartDriver>.Class)
                 .Set(DriverConfiguration.OnEvaluatorFailed, GenericType<HelloRestartDriver>.Class)
                 .Set(DriverConfiguration.OnDriverRestartEvaluatorFailed, GenericType<HelloRestartDriver>.Class)
-                .Set(DriverConfiguration.DriverReconnectionConfigurationProvider, 
-                    GenericType<YarnClusterHttpDriverReconnConfigProvider>.Class)
+                .Set(DriverConfiguration.OnDriverReconnect, GenericType<DefaultYarnClusterHttpDriverConnection>.Class)
                 .Set(DriverConfiguration.DriverRestartEvaluatorRecoverySeconds, (5 * 60).ToString())
                 .Build();
 


### PR DESCRIPTION
This addressed the issue by
  * Fork Evaluators off of the main EvaluatorConfiguration.
  * Fix up configuration parameters that used to depend on DriverConfiguration.

JIRA:
  [REEF-217](https://issues.apache.org/jira/browse/REEF-217)