### PR TITLE
[REEF-1311] Exclude StreamingRemoteManagerTest from AppVeyor coverage temporarily

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,8 +31,19 @@ install:
 build_script:
   - cmd: msbuild .\lang\cs\Org.Apache.REEF.sln /p:Configuration="Debug" /p:Platform="x64" /m
 
+# test script temporarily excludes StreamingRemoteManagerTest (see REEF-1311)
+# to be reverted as part of REEF-1243
 test_script:
-  - cmd: msbuild .\lang\cs\TestRunner.proj /p:Configuration="Debug" /p:Platform="x64"
+  - cmd: cd .\lang\cs
+  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Client.Tests\Org.Apache.REEF.Client.Tests.dll
+  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Common.Tests\Org.Apache.REEF.Common.Tests.dll
+  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Evaluator.Tests\Org.Apache.REEF.Evaluator.Tests.dll
+  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.IMRU.Tests\Org.Apache.REEF.IMRU.Tests.dll
+  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.IO.Tests\Org.Apache.REEF.IO.Tests.dll
+  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Network.Tests\Org.Apache.REEF.Network.Tests.dll
+  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Tang.Tests\Org.Apache.REEF.Tang.Tests.dll
+  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Tests\Org.Apache.REEF.Tests.dll
+  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Wake.Tests\Org.Apache.REEF.Wake.Tests.dll -class Org.Apache.REEF.Wake.Tests.ClockTest -class Org.Apache.REEF.Wake.Tests.MultiCodecTest -class Org.Apache.REEF.Wake.Tests.PubSubSubjectTest -class Org.Apache.REEF.Wake.Tests.RemoteManagerTest -class Org.Apache.REEF.Wake.Tests.StreamingTransportTest -class Org.Apache.REEF.Wake.Tests.TimeTest -class Org.Apache.REEF.Wake.Tests.TransportTest
 
 notifications:
   - provider: Email

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -139,7 +139,11 @@ namespace Org.Apache.REEF.Tests.Functional
             catch (IOException)
             {
                 // do not fail if clean up is unsuccessful
-            }   
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // do not fail if clean up is unsuccessful
+            }
         }
 
         public void Dispose() 


### PR DESCRIPTION
This change:
 * excludes StreamingRemoteManagerTest from AppVeyor test
 * ignores UnauthorizedAccessException thrown in ReefFunctionalTests when deleting temp folder

JIRA:
  [REEF-1311](https://issues.apache.org/jira/browse/REEF-1311)

Pull request:
  This closes #