### PR TITLE
[REEF-1293] Fix test failures during file extraction from jar

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
@@ -127,7 +127,10 @@ namespace Org.Apache.REEF.Client.Common
                 {
                     fileName = Path.Combine(driverFolderPath, _fileNames.GetBridgeExePath());
                 }
-                File.WriteAllBytes(fileName, resourceHelper.GetBytes(fileResources.Value));
+                if (!File.Exists(fileName))
+                {
+                    File.WriteAllBytes(fileName, resourceHelper.GetBytes(fileResources.Value));
+                }
             }
             
             // generate .config file for bridge executable

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/FaultTolerant/TestContextStart.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/FaultTolerant/TestContextStart.cs
@@ -35,6 +35,7 @@ namespace Org.Apache.REEF.Tests.Functional.FaultTolerant
     /// <summary>
     /// This test case servers as an example to put data downloading at part of the ContextStartHandler
     /// </summary>
+    [Collection("FunctionalTests")]
     public class TestContextStart : ReefFunctionalTest
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(TestContextStart));

--- a/lang/cs/Org.Apache.REEF.Tests/Utility/TestDriverConfigGenerator.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Utility/TestDriverConfigGenerator.cs
@@ -24,6 +24,7 @@ using Xunit;
 
 namespace Org.Apache.REEF.Tests.Utility
 {
+    [Collection("FunctionalTests")]
     public class TestDriverConfigGenerator
     {
         public TestDriverConfigGenerator()


### PR DESCRIPTION
This change:
 * adds TestContextStart and TestDriverConfigGenerator to REEF functional which tests run in sequence instead of in parallel.
 * stops extracting .jar file by a test if it's already been extracted by another one.

JIRA:
  [REEF-1293](https://issues.apache.org/jira/browse/REEF-1293)

Pull request:
  This closes #