### PR TITLE
[REEF-1313] Change ProtocolBuffer download URL in Travis.CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ jdk:
   - oraclejdk8
   - openjdk7
 
-env: PATH=$PATH:$HOME/local/bin
+env: PATH=$PATH:$HOME/tools/bin
 
 cache:
   directories:
   - $HOME/.m2
-  - $HOME/local
+  - $HOME/tools
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ sudo: false
 
 language: java
 
-git:
-  depth: 150
-
 jdk:
   - oraclejdk7
   - oraclejdk8

--- a/dev/travis-install-dependencies.sh
+++ b/dev/travis-install-dependencies.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 PROTOBUF_VERSION=2.5.0
-INSTALL=${HOME}/local
+INSTALL=${HOME}/tools
 
 if [ ! -d ${INSTALL} ]; then
   echo "mkdir -p ${INSTALL}"
@@ -28,7 +28,7 @@ if [ ! -f ${INSTALL}/bin/protoc ]; then
   cd ${INSTALL}
   echo "Fetching protobuf"
   N="protobuf-${PROTOBUF_VERSION}"
-  wget -q https://protobuf.googlecode.com/files/${N}.tar.gz
+  wget -q https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/${N}.tar.gz
   tar -xzvf ${N}.tar.gz > /dev/null
   rm ${N}.tar.gz
 


### PR DESCRIPTION
GoogleCode site will shutdown in this year, but Travis.CI script still uses `https://protobuf.googlecode.com`. Our recent .Net CI on Appvoyer is already using new Github download links. This PR changes Travis.CI configuration according to Appvoyer configuration.

JIRA:
  [REEF-1313](https://issues.apache.org/jira/browse/REEF-1313)

Pull request:
  This closes #