### PR TITLE
[REEF-1309] Add a short name for JVMHeapSlack option.

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/parameters/JVMHeapSlack.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/parameters/JVMHeapSlack.java
@@ -24,6 +24,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
 /**
  * The fraction of the container memory NOT to use for the Java Heap.
  */
-@NamedParameter(doc = "The fraction of the container memory NOT to use for the Java Heap.", default_value = "0.0")
+@NamedParameter(doc = "The fraction of the container memory NOT to use for the Java Heap.",
+    short_name = "jvm_heap_slack", default_value = "0.0")
 public final class JVMHeapSlack implements Name<Double> {
 }


### PR DESCRIPTION
This change adds a short name for JVMHeapSlack option to configure it via command line.

JIRA:
  [REEF-1309](https://issues.apache.org/jira/browse/REEF-1309)

Pull request:
  This closes #