### PR TITLE
[REEF-1314] Configure xunit.runner.console to be installed before test

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -58,8 +58,3 @@ Invoke-Expression "7z.exe x protoc.zip" | Out-Null
 $env:Path += ";$protocPath"
 
 Pop-Location
-
-# ========================== xUnit console runner
-$root = (Get-Item -Path "." -Verbose).FullName
-$packages = "$root\lang\cs\packages"
-Invoke-Expression "nuget install .\lang\cs\.nuget\packages.config -o $packages"

--- a/lang/cs/xunit.targets
+++ b/lang/cs/xunit.targets
@@ -45,6 +45,9 @@ under the License.
     <Error Condition="!Exists('$(PackagesDir)\xunit.core.$(xUnitVersion)\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(NuGetError)', '$(PackagesDir)\xunit.core.$(xUnitVersion)\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
     <Error Condition="!Exists('$(PackagesDir)\xunit.runner.visualstudio.$(xUnitVersion)\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(NuGetError)', '$(PackagesDir)\xunit.runner.visualstudio.$(xUnitVersion)\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
+  <Target Name="InstallXunitConsoleRunner" BeforeTargets="Test">
+    <Exec Command="$(SolutionDir)\.nuget\nuget.exe restore $(SolutionDir)\.nuget\packages.config -o $(PackagesDir)" />
+  </Target>
   <Target Name="Test">
     <Exec Command="$(PackagesDir)\xunit.runner.console.$(xUnitVersion)\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll"
           IgnoreStandardErrorWarningFormat="true"


### PR DESCRIPTION
This change adds explicit restore of solution-level packages
as a step before running test targets.
This also removes explicit install of xunit console runner from AppVeyor script.

JIRA:
  [REEF-1314](https://issues.apache.org/jira/browse/REEF-1314)

Pull request:
  This closes #