### PR TITLE
[REEF-1314] Add explicit install of xunit console runner to temporary…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,10 +31,11 @@ install:
 build_script:
   - cmd: msbuild .\lang\cs\Org.Apache.REEF.sln /p:Configuration="Debug" /p:Platform="x64" /m
 
-# test script temporarily excludes StreamingRemoteManagerTest (see REEF-1311)
+# test script temporarily excludes StreamingRemoteManagerTest (see REEF-1311) and downloads xunit.runner.console
 # to be reverted as part of REEF-1243
 test_script:
   - cmd: cd .\lang\cs
+  - cmd: nuget restore .\.nuget\packages.config -o .\packages
   - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Client.Tests\Org.Apache.REEF.Client.Tests.dll
   - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Common.Tests\Org.Apache.REEF.Common.Tests.dll
   - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Evaluator.Tests\Org.Apache.REEF.Evaluator.Tests.dll


### PR DESCRIPTION
… part of AppVeyor script

This change adds nuget restore to test part of AppVeyor script.
We can't remove it completely yet since our AppVeyor test calls xunit directly instead
of via msbuild.
This change is to be reverted as part of REEF-1243.

JIRA:
  [REEF-1314](https://issues.apache.org/jira/browse/REEF-1314)

Pull request:
  This closes #