### PR TITLE
[REEF-1319] Create a test log when running tests from the command line

### DIFF
--- a/lang/cs/TestRunner.proj
+++ b/lang/cs/TestRunner.proj
@@ -27,6 +27,6 @@ under the License.
   </PropertyGroup>
   <Target Name="Test">
     <MSBuild Projects="@(ProjectReferences)"
-             Targets="Test" Properties="Configuration=$(Configuration);Platform=$(Platform)" StopOnFirstFailure="true" />
+             Targets="Test" Properties="Configuration=$(Configuration);Platform=$(Platform)" StopOnFirstFailure="false" />
   </Target>
 </Project>

--- a/lang/cs/xunit.targets
+++ b/lang/cs/xunit.targets
@@ -49,7 +49,7 @@ under the License.
     <Exec Command="$(SolutionDir)\.nuget\nuget.exe restore $(SolutionDir)\.nuget\packages.config -o $(PackagesDir)" />
   </Target>
   <Target Name="Test">
-    <Exec Command="$(PackagesDir)\xunit.runner.console.$(xUnitVersion)\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll"
+    <Exec Command="$(PackagesDir)\xunit.runner.console.$(xUnitVersion)\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll -html $(OutputPath)\xunit_report.html"
           IgnoreStandardErrorWarningFormat="true"
       />
   </Target>


### PR DESCRIPTION
This change:
 * adds -html option to xunit calls to enable log writing
 * sets StopOnFirstFailure flag to false, so that tests on all projects
   are executed even if one of the first projects fails.

JIRA:
  [REEF-1319](https://issues.apache.org/jira/browse/REEF-1319)

Pull request:
  This closes #