### PR TITLE
[REEF-1315] Logs are shown with Verbose level irrespective of level set

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/EvaluatorLogLevelProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/EvaluatorLogLevelProvider.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
+
+namespace Org.Apache.REEF.Driver.Bridge
+{
+    /// <summary>
+    /// Provides the log level for the Evaluator, based on the log level specified in the Driver.
+    /// </summary>
+    internal sealed class EvaluatorLogLevelProvider : IConfigurationProvider
+    {
+        private readonly string _traceLevel;
+
+        [Inject]
+        private EvaluatorLogLevelProvider([Parameter(Value = typeof(DriverBridgeConfigurationOptions.TraceLevel))] string traceLevel)
+        {
+            _traceLevel = traceLevel;
+        }
+
+        public IConfiguration GetConfiguration()
+        {
+            return TangFactory.GetTang().NewConfigurationBuilder()
+                .BindNamedParameter<DriverBridgeConfigurationOptions.TraceLevel, string>(
+                    GenericType<DriverBridgeConfigurationOptions.TraceLevel>.Class, _traceLevel)
+                .Build();
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Driver/DriverConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/DriverConfiguration.cs
@@ -26,6 +26,7 @@ using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Evaluator;
 using Org.Apache.REEF.Driver.Task;
 using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Attributes;
 
@@ -240,6 +241,8 @@ namespace Org.Apache.REEF.Driver
                     .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.TraceLevel>.Class, CustomTraceLevel)
                     .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.DriverRestartEvaluatorRecoverySeconds>.Class,
                         DriverRestartEvaluatorRecoverySeconds)
+                    .BindSetEntry<EvaluatorConfigurationProviders, EvaluatorLogLevelProvider, IConfigurationProvider>(
+                        GenericType<EvaluatorConfigurationProviders>.Class, GenericType<EvaluatorLogLevelProvider>.Class)
 
                     // TODO[JIRA REEF-1306]: Bind DriverReconnectionConfigurationProvider into EvaluatorConfigurationProviders.
                     .BindImplementation(GenericType<IDriverReconnConfigProvider>.Class, DriverReconnectionConfigurationProvider)

--- a/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
+++ b/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
@@ -68,6 +68,7 @@ under the License.
     <Compile Include="Bridge\CustomTraceListeners.cs" />
     <Compile Include="Bridge\DriverBridge.cs" />
     <Compile Include="Bridge\DriverBridgeConfigurationOptions.cs" />
+    <Compile Include="Bridge\EvaluatorLogLevelProvider.cs" />
     <Compile Include="Bridge\Events\ActiveContext.cs" />
     <Compile Include="Bridge\Events\AllocatedEvaluator.cs" />
     <Compile Include="Bridge\Events\ClosedContext.cs" />


### PR DESCRIPTION
This addressed the issue by
  * Add a new EvaluatorLogLevelProvider to provide log level configuration for Evaluators.

JIRA:
  [REEF-1315](https://issues.apache.org/jira/browse/REEF-1315)