### PR TITLE
[REEF-1324] TcpConnectionRetryTest.TestConnectionRetries fails in com…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
@@ -70,6 +70,7 @@ under the License.
     <Compile Include="IObserverFactory.cs" />
     <Compile Include="IStage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Remote\Impl\TcpClientConnectionException.cs" />
     <Compile Include="Remote\IRemoteObserver.cs" />
     <Compile Include="Remote\Impl\TcpClientConnectionFactory.cs" />
     <Compile Include="Remote\ITcpClientConnectionFactory.cs" />

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TcpClientConnectionException.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TcpClientConnectionException.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+
+namespace Org.Apache.REEF.Wake.Remote.Impl
+{
+    /// <summary>
+    /// Exception class for the case when Tcp Client connection fails 
+    /// after trying for some finite number of times.
+    /// For example, see TcpClientConnectionFactory.cs
+    /// </summary>
+    public sealed class TcpClientConnectionException : Exception
+    {
+        /// <summary>
+        /// Number of retries done before exception was thrown
+        /// </summary>
+        public int RetriesDone { get; private set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="message">The user message for exception</param>
+        /// <param name="retriesDone">Number of retries</param>
+        public TcpClientConnectionException(string message, int retriesDone)
+            : base(message)
+        {
+            RetriesDone = retriesDone;
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="message">The user message for exception</param>
+        /// <param name="inner">The actual exception message due to which connection failed</param>
+        /// <param name="retriesDone">Number of retries</param>
+        public TcpClientConnectionException(string message, Exception inner, int retriesDone)
+            : base(message, inner)
+        {
+            RetriesDone = retriesDone;
+        }
+    }
+}


### PR DESCRIPTION
…mand line

This addressed the issue by
  * introducing customized TcpClientConnectionException.cs class that has retries as field inside
  * catching this exception in test and comparing retry values

JIRA:
  [REEF-1324](https://issues.apache.org/jira/browse/REEF-1324)