### PR TITLE
[REEF-1331] Reduce amount of logs written by .NET tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,8 +43,8 @@ test_script:
   - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.IO.Tests\Org.Apache.REEF.IO.Tests.dll
   - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Network.Tests\Org.Apache.REEF.Network.Tests.dll
   - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Tang.Tests\Org.Apache.REEF.Tang.Tests.dll
-  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Tests\Org.Apache.REEF.Tests.dll
   - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Wake.Tests\Org.Apache.REEF.Wake.Tests.dll -class Org.Apache.REEF.Wake.Tests.ClockTest -class Org.Apache.REEF.Wake.Tests.MultiCodecTest -class Org.Apache.REEF.Wake.Tests.PubSubSubjectTest -class Org.Apache.REEF.Wake.Tests.RemoteManagerTest -class Org.Apache.REEF.Wake.Tests.StreamingTransportTest -class Org.Apache.REEF.Wake.Tests.TimeTest -class Org.Apache.REEF.Wake.Tests.TransportTest
+  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Tests\Org.Apache.REEF.Tests.dll
 
 notifications:
   - provider: Email

--- a/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
@@ -81,7 +81,7 @@ namespace Org.Apache.REEF.Client.Common
         /// <param name="driverFolderPath"></param>
         internal void PrepareDriverFolder(AppParameters appParameters, string driverFolderPath)
         {
-            Logger.Log(Level.Info, "Preparing Driver filesystem layout in " + driverFolderPath);
+            Logger.Log(Level.Verbose, "Preparing Driver filesystem layout in " + driverFolderPath);
 
             // Setup the folder structure
             CreateDefaultFolderStructure(appParameters, driverFolderPath);

--- a/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
@@ -195,10 +195,10 @@ namespace Org.Apache.REEF.Client.Common
                 try
                 {
                     string strResult = null;
-                    LOGGER.Log(Level.Warning, "Try url [" + commandUri + "] connectAttemptCount " + connectAttemptCount + ".");
+                    LOGGER.Log(Level.Verbose, "Try url [" + commandUri + "] connectAttemptCount " + connectAttemptCount + ".");
                     strResult = await _client.GetStringAsync(commandUri);
                     result = CommandSucceeded(strResult);
-                    LOGGER.Log(Level.Warning, "Connection succeeded. connectAttemptCount was " + connectAttemptCount + ".");
+                    LOGGER.Log(Level.Verbose, "Connection succeeded. connectAttemptCount was " + connectAttemptCount + ".");
                     break;
                 }
                 catch (HttpRequestException httpRequestException)
@@ -242,7 +242,7 @@ namespace Org.Apache.REEF.Client.Common
                 try
                 {
                     var strResult = await _client.GetStringAsync(commandUri);
-                    LOGGER.Log(Level.Info,
+                    LOGGER.Log(Level.Verbose,
                         "Connection succeeded. connectAttemptCount was " + connectAttemptCount + ".");
                 }
                 catch (HttpRequestException httpRequestException)

--- a/lang/cs/Org.Apache.REEF.Client/Local/LocalClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Local/LocalClient.cs
@@ -154,7 +154,7 @@ namespace Org.Apache.REEF.Client.Local
             // Prepare the job submission folder
             var jobFolder = CreateJobFolder(jobRequest.JobIdentifier);
             var driverFolder = Path.Combine(jobFolder, DriverFolderName);
-            Logger.Log(Level.Info, "Preparing driver folder in " + driverFolder);
+            Logger.Log(Level.Verbose, "Preparing driver folder in " + driverFolder);
 
             _driverFolderPreparationHelper.PrepareDriverFolder(jobRequest.AppParameters, driverFolder);
 

--- a/lang/cs/Org.Apache.REEF.Client/Local/LocalJobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Local/LocalJobSubmissionResult.cs
@@ -65,20 +65,20 @@ namespace Org.Apache.REEF.Client.Local
             string httpServerIpAndPort = null;
             try
             {
-                LOGGER.Log(Level.Info, "try open " + fileName);
+                LOGGER.Log(Level.Verbose, "try open " + fileName);
                 using (var rdr = new StreamReader(File.OpenRead(fileName)))
                 {
                     httpServerIpAndPort = rdr.ReadLine();
-                    LOGGER.Log(Level.Info, "httpServerIpAndPort is " + httpServerIpAndPort);
+                    LOGGER.Log(Level.Verbose, "httpServerIpAndPort is " + httpServerIpAndPort);
                 }
             }
             catch (FileNotFoundException)
             {
-                LOGGER.Log(Level.Info, "File does not exist: " + fileName);
+                LOGGER.Log(Level.Verbose, "File does not exist: " + fileName);
             }
             catch (IOException)
             {
-                LOGGER.Log(Level.Info, "Encountered IOException on reading " + fileName + ".");
+                LOGGER.Log(Level.Verbose, "Encountered IOException on reading " + fileName + ".");
             }
 
             return httpServerIpAndPort;

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
@@ -66,7 +66,7 @@ namespace Org.Apache.REEF.Client.Yarn
         {
             // Prepare the job submission folder
             var driverFolderPath = CreateDriverFolder(jobRequest.JobIdentifier);
-            Logger.Log(Level.Info, "Preparing driver folder in " + driverFolderPath);
+            Logger.Log(Level.Verbose, "Preparing driver folder in " + driverFolderPath);
 
             Launch(jobRequest, driverFolderPath);
         }
@@ -75,7 +75,7 @@ namespace Org.Apache.REEF.Client.Yarn
         {
             // Prepare the job submission folder
             var driverFolderPath = CreateDriverFolder(jobRequest.JobIdentifier);
-            Logger.Log(Level.Info, "Preparing driver folder in " + driverFolderPath);
+            Logger.Log(Level.Verbose, "Preparing driver folder in " + driverFolderPath);
 
             Launch(jobRequest, driverFolderPath);
 

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkService.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkService.cs
@@ -72,7 +72,7 @@ namespace Org.Apache.REEF.Network.NetworkService
             NamingClient = nameClient;
             _connectionMap = new Dictionary<IIdentifier, IConnection<T>>();
 
-            LOGGER.Log(Level.Info, "Started network service");
+            LOGGER.Log(Level.Verbose, "Started network service");
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Org.Apache.REEF.Network.NetworkService
         /// <param name="id">The identifier to register</param>
         public void Register(IIdentifier id)
         {
-            LOGGER.Log(Level.Info, "Registering id {0} with network service.", id);
+            LOGGER.Log(Level.Verbose, "Registering id {0} with network service.", id);
 
             _localIdentifier = id;
             NamingClient.Register(id.ToString(), _remoteManager.LocalEndpoint);
@@ -121,7 +121,7 @@ namespace Org.Apache.REEF.Network.NetworkService
             var anyEndpoint = new IPEndPoint(IPAddress.Any, 0);
             _messageHandlerDisposable = _remoteManager.RegisterObserver(anyEndpoint, _messageHandler);
 
-            LOGGER.Log(Level.Info, "End of Registering id {0} with network service.", id);
+            LOGGER.Log(Level.Verbose, "End of Registering id {0} with network service.", id);
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace Org.Apache.REEF.Network.NetworkService
             NamingClient.Dispose();
             _remoteManager.Dispose();
 
-            LOGGER.Log(Level.Info, "Disposed of network service");
+            LOGGER.Log(Level.Verbose, "Disposed of network service");
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/StreamingNetworkService.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/StreamingNetworkService.cs
@@ -77,7 +77,7 @@ namespace Org.Apache.REEF.Network.NetworkService
             _nameClient = nameClient;
             _connectionMap = new Dictionary<IIdentifier, IConnection<T>>();
 
-            Logger.Log(Level.Info, "Started network service");
+            Logger.Log(Level.Verbose, "Started network service");
         }
 
         /// <summary>
@@ -122,12 +122,12 @@ namespace Org.Apache.REEF.Network.NetworkService
         /// <param name="id">The identifier to register</param>
         public void Register(IIdentifier id)
         {
-            Logger.Log(Level.Info, "Registering id {0} with network service.", id);
+            Logger.Log(Level.Verbose, "Registering id {0} with network service.", id);
 
             _localIdentifier = id;
             NamingClient.Register(id.ToString(), _remoteManager.LocalEndpoint);
 
-            Logger.Log(Level.Info, "End of Registering id {0} with network service.", id);
+            Logger.Log(Level.Verbose, "End of Registering id {0} with network service.", id);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace Org.Apache.REEF.Network.NetworkService
             NamingClient.Dispose();
             _remoteManager.Dispose();
 
-            Logger.Log(Level.Info, "Disposed of network service");
+            Logger.Log(Level.Verbose, "Disposed of network service");
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -86,7 +86,7 @@ namespace Org.Apache.REEF.Tests.Functional
         public void Init()
         {
             TestId = Guid.NewGuid().ToString("N").Substring(0, 8);
-            Console.WriteLine("Running test " + TestId + ". If failed AND log uploaded is enabled, log can be find in " + Path.Combine(DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), TestId));
+            Logger.Log(Level.Info, "Running test " + TestId + ". If failed AND log uploaded is enabled, log can be find in " + Path.Combine(DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), TestId));
             if (_enableRealtimeLogUpload)
             {
                 TimerTask = new Task(() =>
@@ -113,7 +113,7 @@ namespace Org.Apache.REEF.Tests.Functional
 
         protected void CleanUp(string testFolder = DefaultRuntimeFolder)
         {
-            Console.WriteLine("Cleaning up test.");
+            Logger.Log(Level.Verbose, "Cleaning up test.");
 
             if (_enableRealtimeLogUpload)
             {
@@ -172,7 +172,7 @@ namespace Org.Apache.REEF.Tests.Functional
 
             if (lines != null)
             {
-                Console.WriteLine("Lines read from log file : " + lines.Count());
+                Logger.Log(Level.Verbose, "Lines read from log file : " + lines.Count());
                 string[] successIndicators = lines.Where(s => s.Contains(successIndication)).ToArray();
                 string[] failedTaskIndicators = lines.Where(s => s.Contains(failedTaskIndication)).ToArray();
                 string[] failedEvaluatorIndicators = lines.Where(s => s.Contains(failedEvaluatorIndication)).ToArray();
@@ -219,7 +219,7 @@ namespace Org.Apache.REEF.Tests.Functional
                 }
                 catch (Exception e)
                 {
-                    Console.Write(e.ToString());
+                    Logger.Log(Level.Verbose, e.ToString());
                     Thread.Sleep(SleepTime);
                 }
             }
@@ -266,7 +266,7 @@ namespace Org.Apache.REEF.Tests.Functional
         protected string GetLogFile(string logFileName, string subfolder = "driver", string testFolder = DefaultRuntimeFolder)
         {
             string driverContainerDirectory = Directory.GetDirectories(Path.Combine(Directory.GetCurrentDirectory(), testFolder), subfolder, SearchOption.AllDirectories).SingleOrDefault();
-            Console.WriteLine("GetLogFile, driverContainerDirectory:" + driverContainerDirectory);
+            Logger.Log(Level.Verbose, "GetLogFile, driverContainerDirectory:" + driverContainerDirectory);
 
             if (string.IsNullOrWhiteSpace(driverContainerDirectory))
             {

--- a/lang/cs/Org.Apache.REEF.Utilities/Logging/Logger.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Logging/Logger.cs
@@ -47,7 +47,7 @@ namespace Org.Apache.REEF.Utilities.Logging
                         { Level.Verbose, TraceEventType.Verbose },
                     };
 
-        private static Level _customLevel = Level.Verbose;
+        private static Level _customLevel = Level.Info;
 
         private static List<TraceListener> _traceListeners;
 

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TcpClientConnectionFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TcpClientConnectionFactory.cs
@@ -59,7 +59,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
                     client.Connect(endPoint);
                 });
                 var msg = string.Format("Connection to endpoint {0} established", endPoint);
-                Logger.Log(Level.Info, msg);
+                Logger.Log(Level.Verbose, msg);
                 return client;
             }
             catch (Exception e)


### PR DESCRIPTION
This change:
 * reorders test invocations in appveyor.yml so that Wake tests are called.
 * increases default log lever from verbose to info.
 * reduces log level for several messages which log progress of some typical
   processes from info to verbose.

JIRA:
  [REEF-1331](https://issues.apache.org/jira/browse/REEF-1331)

Pull request:
  This closes #