### PR TITLE
[REEF-1322] Allow Communication Group to be removed from IGroupCommDriver

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
@@ -165,16 +165,20 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         [Fact]
         public void TestRemoveCommunicationGroup()
         {
-            string groupName = "group1";
-            string groupName2 = "group2";
-            string masterTaskId = "task0";
-            string driverId = "Driver Id";
-            int numTasks = 3;
-            int fanOut = 2;
+            const string groupName = "group1";
+            const string groupName2 = "group2";
+            const string masterTaskId = "task0";
+            const string driverId = "Driver Id";
+            const int numTasks = 3;
+            const int fanOut = 2;
 
             var groupCommunicationDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
-            groupCommunicationDriver.NewCommunicationGroup(groupName2, 5);
+            var group = groupCommunicationDriver.NewCommunicationGroup(groupName2, 5);
+            Assert.NotNull(group);
             groupCommunicationDriver.RemoveCommunicationGroup(groupName2);
+
+            Action remove = () => groupCommunicationDriver.RemoveCommunicationGroup(groupName2);
+            Assert.Throws<ArgumentException>(remove);
         }
 
         /// <summary>
@@ -183,37 +187,33 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         [Fact]
         public void TestRemoveDefaultGroup()
         {
-            string groupName = "group1";
-            string masterTaskId = "task0";
-            string driverId = "Driver Id";
-            int numTasks = 3;
-            int fanOut = 2;
+            const string groupName = "group1";
+            const string masterTaskId = "task0";
+            const string driverId = "Driver Id";
+            const int numTasks = 3;
+            const int fanOut = 2;
 
             var groupCommunicationDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
-            ICommunicationGroupDriver group = groupCommunicationDriver.DefaultGroup;
+            var group = groupCommunicationDriver.DefaultGroup;
+            Assert.NotNull(group);
             groupCommunicationDriver.RemoveCommunicationGroup(groupName);
+
+            Action remove = () => groupCommunicationDriver.RemoveCommunicationGroup(groupName);
+            Assert.Throws<ArgumentException>(remove);
         }
 
         [Fact]
         public void TestRemoveNoExistGroup()
         {
-            string groupName = "group1";
-            string masterTaskId = "task0";
-            string driverId = "Driver Id";
-            int numTasks = 3;
-            int fanOut = 2;
-            string msg = null;
+            const string groupName = "group1";
+            const string masterTaskId = "task0";
+            const string driverId = "Driver Id";
+            const int numTasks = 3;
+            const int fanOut = 2;
 
             var groupCommunicationDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
-            try
-            {
-                groupCommunicationDriver.RemoveCommunicationGroup("group1");
-            }
-            catch (ArgumentException e)
-            {
-                msg = e.Message;
-            }
-            Assert.NotNull(msg);
+            Action remove = () => groupCommunicationDriver.RemoveCommunicationGroup(groupName);
+            Assert.Throws<ArgumentException>(remove);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
@@ -160,6 +160,63 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         }
 
         /// <summary>
+        /// Test create a new group then remove it from the GroupDriver
+        /// </summary>
+        [Fact]
+        public void TestRemoveCommunicationGroup()
+        {
+            string groupName = "group1";
+            string groupName2 = "group2";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 3;
+            int fanOut = 2;
+
+            var groupCommunicationDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
+            groupCommunicationDriver.NewCommunicationGroup(groupName2, 5);
+            groupCommunicationDriver.RemoveCommunicationGroup(groupName2);
+        }
+
+        /// <summary>
+        /// Test remove default group
+        /// </summary>
+        [Fact]
+        public void TestRemoveDefaultGroup()
+        {
+            string groupName = "group1";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 3;
+            int fanOut = 2;
+
+            var groupCommunicationDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
+            ICommunicationGroupDriver group = groupCommunicationDriver.DefaultGroup;
+            groupCommunicationDriver.RemoveCommunicationGroup(groupName);
+        }
+
+        [Fact]
+        public void TestRemoveNoExistGroup()
+        {
+            string groupName = "group1";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 3;
+            int fanOut = 2;
+            string msg = null;
+
+            var groupCommunicationDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
+            try
+            {
+                groupCommunicationDriver.RemoveCommunicationGroup("group1");
+            }
+            catch (ArgumentException e)
+            {
+                msg = e.Message;
+            }
+            Assert.NotNull(msg);
+        }
+
+        /// <summary>
         /// This is to test operator injection in CommunicationGroupClient with int[] as message type
         /// </summary>
         [Fact]

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/IGroupCommDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/IGroupCommDriver.cs
@@ -43,6 +43,7 @@ namespace Org.Apache.REEF.Network.Group.Driver
 
         /// <summary>
         /// remove a communication group
+        /// Throw ArgumentException if the group does not exist
         /// </summary>
         /// <param name="groupName"></param>
         void RemoveCommunicationGroup(string groupName);

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/IGroupCommDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/IGroupCommDriver.cs
@@ -42,6 +42,12 @@ namespace Org.Apache.REEF.Network.Group.Driver
         ICommunicationGroupDriver NewCommunicationGroup(string groupName, int numTasks);
 
         /// <summary>
+        /// remove a communication group
+        /// </summary>
+        /// <param name="groupName"></param>
+        void RemoveCommunicationGroup(string groupName);
+
+        /// <summary>
         /// Generates context configuration with a unique identifier.
         /// </summary>
         /// <returns>The configured context configuration</returns>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommDriver.cs
@@ -33,6 +33,7 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Utilities.Diagnostics;
 using ContextConfiguration = Org.Apache.REEF.Common.Context.ContextConfiguration;
 
 namespace Org.Apache.REEF.Network.Group.Driver.Impl
@@ -147,7 +148,8 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         }
 
         /// <summary>
-        /// Remove a group form the GroupCommDriver
+        /// Remove a group from the GroupCommDriver
+        /// Throw ArgumentException if the group does not exist
         /// </summary>
         /// <param name="groupName"></param>
         public void RemoveCommunicationGroup(string groupName)
@@ -156,7 +158,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
             {
                 if (!_commGroups.ContainsKey(groupName))
                 {
-                    REEF.Utilities.Diagnostics.Exceptions.Throw(new ArgumentException("Group Name is not registered with GroupCommunicationDriver"), LOGGER);
+                    Exceptions.Throw(new ArgumentException("Group Name is not registered with GroupCommunicationDriver"), LOGGER);
                 }
 
                 _commGroups.Remove(groupName);

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommDriver.cs
@@ -147,6 +147,23 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         }
 
         /// <summary>
+        /// Remove a group form the GroupCommDriver
+        /// </summary>
+        /// <param name="groupName"></param>
+        public void RemoveCommunicationGroup(string groupName)
+        {
+            lock (_groupsLock)
+            {
+                if (!_commGroups.ContainsKey(groupName))
+                {
+                    REEF.Utilities.Diagnostics.Exceptions.Throw(new ArgumentException("Group Name is not registered with GroupCommunicationDriver"), LOGGER);
+                }
+
+                _commGroups.Remove(groupName);
+            }
+        }
+
+        /// <summary>
         /// Generates context configuration with a unique identifier.
         /// </summary>
         /// <returns>The configured context configuration</returns>


### PR DESCRIPTION
The PR includes:

* Adding remove API in GroupCommunicationDriver
* Add test cases

JIRA: [REEF-1322](https://issues.apache.org/jira/browse/REEF-1322)
This closes #