### PR TITLE
[REEF-1294] Consider race condition in Evaluator.SetRuntimeHandlers

### DIFF
--- a/lang/cs/Org.Apache.REEF.Wake/Time/Runtime/RuntimeClock.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Runtime/RuntimeClock.cs
@@ -81,18 +81,6 @@ namespace Org.Apache.REEF.Wake.Time.Runtime
             }
         }
 
-        public IInjectionFuture<ISet<IObserver<RuntimeStart>>> InjectedRuntimeStartHandler
-        {
-            get { return _runtimeStartHandler; }
-            set { _runtimeStartHandler = value; }
-        }
-
-        public IInjectionFuture<ISet<IObserver<RuntimeStop>>> InjectedRuntimeStopHandler
-        {
-            get { return _runtimeStopHandler; }
-            set { _runtimeStopHandler = value; }
-        }
-
         /// <summary>
         /// Schedule a TimerEvent at the given future offset
         /// </summary>


### PR DESCRIPTION
This addressed the issue by
  * Remove the use of InjectedRuntimeStartHandlers and InjectedRuntimeStopHandlers.
  * Inject EvaluatorRuntime properly via creating a configuration for it.

JIRA:
  [REEF-1294](https://issues.apache.org/jira/browse/REEF-1294)