### PR TITLE
[REEF-1057] Enable several StyleCop.CSharp.NamingRules and fix violations, part 1

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Catalog/ResourceCatalogImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Catalog/ResourceCatalogImpl.cs
@@ -30,7 +30,7 @@ namespace Org.Apache.REEF.Common.Catalog
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(ResourceCatalogImpl));
         
-        private static readonly string defaultRackName = "default-rack";
+        private static readonly string DefaultRackName = "default-rack";
 
         private readonly Dictionary<string, RackDescriptorImpl> _racks = new Dictionary<string, RackDescriptorImpl>();
  
@@ -51,7 +51,7 @@ namespace Org.Apache.REEF.Common.Catalog
 
         public void Handle(NodeDescriptorProto node)
         {
-            string rackName = node.rack_name == null ? node.rack_name : defaultRackName;
+            string rackName = node.rack_name == null ? node.rack_name : DefaultRackName;
             string message = string.Format(
                 CultureInfo.InvariantCulture,
                 "Catalog new node: id[{0}], rack[{1}], host[{2}], port[{3}], memory[{4}]",

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/MachineStatus.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/MachineStatus.cs
@@ -24,36 +24,36 @@ namespace Org.Apache.REEF.Common.Runtime
 {
     public class MachineStatus
     {
-        private static readonly PerformanceCounter _cpuCounter;
+        private static readonly PerformanceCounter CpuCounter;
 
-        private static readonly PerformanceCounter _ramCounter;
+        private static readonly PerformanceCounter RamCounter;
 
-        private static readonly PerformanceCounter _processCpuCounter;
+        private static readonly PerformanceCounter ProcessCpuCounter;
 
-        private static readonly Process _process;
+        private static readonly Process Process;
 
         private static bool _checkStatus;
 
         static MachineStatus()
         {
             _checkStatus = true;
-            _process = Process.GetCurrentProcess();
-            string processName = _process.ProcessName;
+            Process = Process.GetCurrentProcess();
+            string processName = Process.ProcessName;
 
-            _cpuCounter = _cpuCounter ?? new PerformanceCounter()
+            CpuCounter = CpuCounter ?? new PerformanceCounter()
             {
                 CategoryName = "Processor",
                 CounterName = "% Processor Time",
                 InstanceName = "_Total",
             };
 
-            _ramCounter = _ramCounter ?? new PerformanceCounter()
+            RamCounter = RamCounter ?? new PerformanceCounter()
             {
                 CategoryName = "Memory",
                 CounterName = "Available MBytes"
             };
 
-            _processCpuCounter = _processCpuCounter ?? new PerformanceCounter()
+            ProcessCpuCounter = ProcessCpuCounter ?? new PerformanceCounter()
             {
                 CategoryName = "Process",
                 CounterName = "% Processor Time",
@@ -65,7 +65,7 @@ namespace Org.Apache.REEF.Common.Runtime
         {
             get
             {
-                return _cpuCounter.NextValue() + "%";
+                return CpuCounter.NextValue() + "%";
             }
         }
 
@@ -73,7 +73,7 @@ namespace Org.Apache.REEF.Common.Runtime
         {
             get
             {
-                return _ramCounter.NextValue() + "MB";
+                return RamCounter.NextValue() + "MB";
             }
         }
 
@@ -81,7 +81,7 @@ namespace Org.Apache.REEF.Common.Runtime
         {
             get
             {
-                return ((float)_process.WorkingSet64 / 1000000.0).ToString(CultureInfo.InvariantCulture) + "MB";
+                return ((float)Process.WorkingSet64 / 1000000.0).ToString(CultureInfo.InvariantCulture) + "MB";
             }
         }
 
@@ -89,7 +89,7 @@ namespace Org.Apache.REEF.Common.Runtime
         {
             get
             {
-                return ((float)_process.PeakWorkingSet64 / 1000000.0).ToString(CultureInfo.InvariantCulture) + "MB";
+                return ((float)Process.PeakWorkingSet64 / 1000000.0).ToString(CultureInfo.InvariantCulture) + "MB";
             }
         }
 
@@ -98,7 +98,7 @@ namespace Org.Apache.REEF.Common.Runtime
         {
             get
             {
-                return ((float)_processCpuCounter.RawValue / 1000000.0) + "%";
+                return ((float)ProcessCpuCounter.RawValue / 1000000.0) + "%";
             }
         }
 
@@ -109,7 +109,7 @@ namespace Org.Apache.REEF.Common.Runtime
             {
                 try
                 {
-                    _process.Refresh();
+                    Process.Refresh();
                     info = string.Format(
                     CultureInfo.InvariantCulture,
                     "current node is running at [{0}] CPU usage and with [{1}] memory available.{2}             current evaluator process is using [{3}] of CPU and [{4}] of memory, with a peak memory usage of [{5}]",

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/BridgeConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/BridgeConfigurationProvider.cs
@@ -40,8 +40,8 @@ namespace Org.Apache.REEF.Driver.Bridge
         private static readonly Logger Logger = Logger.GetLogger(typeof(BridgeConfigurationProvider));
         private static readonly object LockObject = new object();
 
-        private static IConfiguration BridgeConfiguration = null;
-        private static IInjector BridgeInjector = null;
+        private static IConfiguration bridgeConfiguration = null;
+        private static IInjector bridgeInjector = null;
 
         private readonly REEFFileNames _fileNames;
 
@@ -126,12 +126,12 @@ namespace Org.Apache.REEF.Driver.Bridge
         {
             lock (LockObject)
             {
-                if (BridgeConfiguration == null)
+                if (bridgeConfiguration == null)
                 {
-                    BridgeConfiguration = new BridgeConfigurationProvider(new REEFFileNames()).LoadBridgeConfiguration();
+                    bridgeConfiguration = new BridgeConfigurationProvider(new REEFFileNames()).LoadBridgeConfiguration();
                 }
 
-                return BridgeConfiguration;
+                return bridgeConfiguration;
             }
         }
 
@@ -143,16 +143,16 @@ namespace Org.Apache.REEF.Driver.Bridge
         {
             lock (LockObject)
             {
-                if (BridgeInjector == null)
+                if (bridgeInjector == null)
                 {
-                    BridgeInjector = TangFactory.GetTang().NewInjector(GetBridgeConfiguration());
+                    bridgeInjector = TangFactory.GetTang().NewInjector(GetBridgeConfiguration());
                     if (evaluatorRequestor != null)
                     {
-                        BridgeInjector.BindVolatileInstance(GenericType<IEvaluatorRequestor>.Class, evaluatorRequestor);
+                        bridgeInjector.BindVolatileInstance(GenericType<IEvaluatorRequestor>.Class, evaluatorRequestor);
                     }
                 }
 
-                return BridgeInjector;
+                return bridgeInjector;
             }
         }
     }

--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/HelloFailedEvaluatorHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/HelloFailedEvaluatorHandler.cs
@@ -28,7 +28,7 @@ namespace Org.Apache.REEF.Examples.AllHandlers
     {
         private static int _failureCount = 0;
 
-        private static readonly int _maxTrial = 2;
+        private static readonly int MaxTrial = 2;
 
         private readonly IEvaluatorRequestor _evaluatorRequestor;
 
@@ -45,7 +45,7 @@ namespace Org.Apache.REEF.Examples.AllHandlers
         public void OnNext(IFailedEvaluator failedEvaluator)
         {
             Console.WriteLine("Receive a failed evaluator: " + failedEvaluator.Id);
-            if (++_failureCount < _maxTrial)
+            if (++_failureCount < MaxTrial)
             {
                 Console.WriteLine("Requesting another evaluator");
                 var newRequest =

--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansMasterTask.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansMasterTask.cs
@@ -31,7 +31,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
 {
     public class KMeansMasterTask : ITask
     {
-        private static readonly Logger _logger = Logger.GetLogger(typeof(KMeansMasterTask));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(KMeansMasterTask));
 
         private int _iteration = 0;
 
@@ -49,7 +49,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
             [Parameter(Value = typeof(KMeansConfiguratioinOptions.ExecutionDirectory))] string executionDirectory,
             IGroupCommClient groupCommClient)
         {
-            using (_logger.LogFunction("KMeansMasterTask"))
+            using (Logger.LogFunction("KMeansMasterTask"))
             {
                 if (totalNumEvaluators <= 1)
                 {
@@ -78,16 +78,16 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
                 if (_isInitialIteration)
                 {
                     // broadcast initial centroids to all slave nodes
-                    _logger.Log(Level.Info, "Broadcasting INITIAL centroids to all slave nodes: " + _centroids);
+                    Logger.Log(Level.Info, "Broadcasting INITIAL centroids to all slave nodes: " + _centroids);
                     _isInitialIteration = false;
                 }
                 else
                 {
                     ProcessedResults results = _meansReducerReceiver.Reduce();
                     _centroids = new Centroids(results.Means.Select(m => m.Mean).ToList());
-                    _logger.Log(Level.Info, "Broadcasting new centroids to all slave nodes: " + _centroids);
+                    Logger.Log(Level.Info, "Broadcasting new centroids to all slave nodes: " + _centroids);
                     newLoss = results.Loss;
-                    _logger.Log(Level.Info, string.Format(CultureInfo.InvariantCulture, "The new loss value {0} at iteration {1} ", newLoss, _iteration));
+                    Logger.Log(Level.Info, string.Format(CultureInfo.InvariantCulture, "The new loss value {0} at iteration {1} ", newLoss, _iteration));
                     if (newLoss > loss)
                     {
                         _controlBroadcastSender.Send(ControlMessage.STOP);
@@ -96,7 +96,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
                     }
                     else if (newLoss.Equals(loss))
                     {
-                        _logger.Log(Level.Info, string.Format(CultureInfo.InvariantCulture, "KMeans clustering has converged with a loss value of {0} at iteration {1} ", newLoss, _iteration));
+                        Logger.Log(Level.Info, string.Format(CultureInfo.InvariantCulture, "KMeans clustering has converged with a loss value of {0} at iteration {1} ", newLoss, _iteration));
                         break;
                     }
                     else
@@ -145,7 +145,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
 
                 ProcessedResults returnMeans = new ProcessedResults(aggregatedMeans, aggregatedLoss);
 
-                _logger.Log(Level.Info, "The true means aggregated by the reduce function: " + returnMeans);
+                Logger.Log(Level.Info, "The true means aggregated by the reduce function: " + returnMeans);
                 return returnMeans;
             }
         }

--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansSlaveTask.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansSlaveTask.cs
@@ -28,7 +28,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
 {
     public class KMeansSlaveTask : ITask
     {
-        private static readonly Logger _logger = Logger.GetLogger(typeof(KMeansSlaveTask));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(KMeansSlaveTask));
         private readonly int _clustersNum;
         private readonly IGroupCommClient _groupCommClient;
         private readonly ICommunicationGroupClient _commGroup;
@@ -43,7 +43,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
             [Parameter(typeof(KMeansConfiguratioinOptions.TotalNumEvaluators))] int clustersNumber,
             IGroupCommClient groupCommClient)
         {
-            using (_logger.LogFunction("KMeansSlaveTask::KMeansSlaveTask"))
+            using (Logger.LogFunction("KMeansSlaveTask::KMeansSlaveTask"))
             {
                 _dataPartition = dataPartition;
                 _groupCommClient = groupCommClient;
@@ -67,10 +67,10 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
 
                 // we compute the loss here before data is relabled, this does not reflect the latest clustering result at the end of current iteration, 
                 // but it will save another round of group communications in each iteration
-                _logger.Log(Level.Info, "Received centroids from master: " + centroids);
+                Logger.Log(Level.Info, "Received centroids from master: " + centroids);
                 _dataPartition.LabelData(centroids);
                 ProcessedResults partialMeans = new ProcessedResults(ComputePartialMeans(), ComputeLossFunction(centroids, _dataPartition.DataVectors));
-                _logger.Log(Level.Info, "Sending partial means: " + partialMeans);
+                Logger.Log(Level.Info, "Sending partial means: " + partialMeans);
                 _partialMeansSender.Send(partialMeans);
             }
 
@@ -84,7 +84,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
 
         private List<PartialMean> ComputePartialMeans()
         {
-            _logger.Log(Level.Verbose, "cluster number " + _clustersNum);
+            Logger.Log(Level.Verbose, "cluster number " + _clustersNum);
             List<PartialMean> partialMeans = new PartialMean[_clustersNum].ToList();
             for (int i = 0; i < _clustersNum; i++)
             {
@@ -97,7 +97,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
                 }
                 average.Label = i;
                 partialMeans[i] = new PartialMean(average, slices.Count);
-                _logger.Log(Level.Info, "Adding to partial means list: " + partialMeans[i]);
+                Logger.Log(Level.Info, "Adding to partial means list: " + partialMeans[i]);
             }
             return partialMeans;
         }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/MapInputWithControlMessage/MapInputWithControlMessageCodec.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/MapInputWithControlMessage/MapInputWithControlMessageCodec.cs
@@ -32,7 +32,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.MapInputWithControlMessage
     /// <typeparam name="TMapInput"></typeparam>
     internal sealed class MapInputWithControlMessageCodec<TMapInput> : IStreamingCodec<MapInputWithControlMessage<TMapInput>>
     {
-        private static Logger Logger = Logger.GetLogger(typeof(MapInputWithControlMessage<>));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(MapInputWithControlMessage<>));
         private readonly IStreamingCodec<TMapInput> _baseCodec;
 
         [Inject]

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/MasterTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/MasterTask.cs
@@ -27,7 +27,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.ScatterReduceDrive
 {
     public class MasterTask : ITask
     {
-        private static readonly Logger _logger = Logger.GetLogger(typeof(MasterTask));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(MasterTask));
 
         private readonly IGroupCommClient _groupCommClient;
         private readonly ICommunicationGroupClient _commGroup;
@@ -37,7 +37,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.ScatterReduceDrive
         [Inject]
         public MasterTask(IGroupCommClient groupCommClient)
         {
-            _logger.Log(Level.Info, "Hello from master task");
+            Logger.Log(Level.Info, "Hello from master task");
             _groupCommClient = groupCommClient;
 
             _commGroup = groupCommClient.GetCommunicationGroup(GroupTestConstants.GroupName);
@@ -51,7 +51,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.ScatterReduceDrive
             _scatterSender.Send(data);
 
             int sum = _sumReducer.Reduce();
-            _logger.Log(Level.Info, "Received sum: {0}", sum);
+            Logger.Log(Level.Info, "Received sum: {0}", sum);
 
             return null;
         }

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/SlaveTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/SlaveTask.cs
@@ -27,7 +27,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.ScatterReduceDrive
 {
     public class SlaveTask : ITask
     {
-        private static readonly Logger _logger = Logger.GetLogger(typeof(SlaveTask));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(SlaveTask));
 
         private readonly IGroupCommClient _groupCommClient;
         private readonly ICommunicationGroupClient _commGroup;
@@ -37,7 +37,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.ScatterReduceDrive
         [Inject]
         public SlaveTask(IGroupCommClient groupCommClient)
         {
-            _logger.Log(Level.Info, "Hello from slave task");
+            Logger.Log(Level.Info, "Hello from slave task");
 
             _groupCommClient = groupCommClient;
             _commGroup = _groupCommClient.GetCommunicationGroup(GroupTestConstants.GroupName);
@@ -48,10 +48,10 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.ScatterReduceDrive
         public byte[] Call(byte[] memento)
         {
             List<int> data = _scatterReceiver.Receive();
-            _logger.Log(Level.Info, "Received data: {0}", string.Join(" ", data));
+            Logger.Log(Level.Info, "Received data: {0}", string.Join(" ", data));
 
             int sum = data.Sum();
-            _logger.Log(Level.Info, "Sending back sum: {0}", sum);
+            Logger.Log(Level.Info, "Sending back sum: {0}", sum);
             _sumSender.Send(sum);
 
             return null;

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommDriver.cs
@@ -47,7 +47,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         private const string MasterTaskContextName = "MasterTaskContext";
         private const string SlaveTaskContextName = "SlaveTaskContext";
 
-        private static Logger Logger = Logger.GetLogger(typeof(GroupCommDriver));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(GroupCommDriver));
 
         private readonly string _driverId;
         private readonly string _nameServerAddr;

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupClient.cs
@@ -35,7 +35,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
     /// </summary>
     internal sealed class CommunicationGroupClient : ICommunicationGroupClientInternal
     {
-        private readonly Logger LOGGER = Logger.GetLogger(typeof(CommunicationGroupClient));
+        private static readonly Logger LOGGER = Logger.GetLogger(typeof(CommunicationGroupClient));
         private readonly Dictionary<string, object> _operators;
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Naming/NameClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/NameClient.cs
@@ -42,7 +42,7 @@ namespace Org.Apache.REEF.Network.Naming
     /// </summary>
     public sealed class NameClient : INameClient
     {
-        private static readonly Logger _logger = Logger.GetLogger(typeof(NameClient));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(NameClient));
 
         private BlockingCollection<NamingLookupResponse> _lookupResponseQueue;
         private BlockingCollection<NamingGetAllResponse> _getAllResponseQueue;
@@ -110,14 +110,14 @@ namespace Org.Apache.REEF.Network.Naming
         {
             if (id == null)
             {
-                Exceptions.Throw(new ArgumentNullException("id"), _logger);
+                Exceptions.Throw(new ArgumentNullException("id"), Logger);
             }
             if (endpoint == null)
             {
-                Exceptions.Throw(new ArgumentNullException("endpoint"), _logger);
+                Exceptions.Throw(new ArgumentNullException("endpoint"), Logger);
             }
 
-            _logger.Log(Level.Info, "Registering id: " + id + ", and endpoint: " + endpoint);
+            Logger.Log(Level.Info, "Registering id: " + id + ", and endpoint: " + endpoint);
             _registerClient.Register(id, endpoint);
         }
 
@@ -129,10 +129,10 @@ namespace Org.Apache.REEF.Network.Naming
         {
             if (id == null)
             {
-                Exceptions.Throw(new ArgumentNullException("id"), _logger);
+                Exceptions.Throw(new ArgumentNullException("id"), Logger);
             }
 
-            _logger.Log(Level.Info, "Unregistering id: " + id);
+            Logger.Log(Level.Info, "Unregistering id: " + id);
             _registerClient.Unregister(id);
         }
 
@@ -147,7 +147,7 @@ namespace Org.Apache.REEF.Network.Naming
         {
             if (id == null)
             {
-                Exceptions.Throw(new ArgumentNullException("id"), _logger);
+                Exceptions.Throw(new ArgumentNullException("id"), Logger);
             }
 
             IPEndPoint value = _cache.Get(id);
@@ -171,7 +171,7 @@ namespace Org.Apache.REEF.Network.Naming
         {
             if (id == null)
             {
-                Exceptions.Throw(new ArgumentNullException("id"), _logger);
+                Exceptions.Throw(new ArgumentNullException("id"), Logger);
             }
 
             List<NameAssignment> assignments = Lookup(new List<string> { id });
@@ -197,16 +197,16 @@ namespace Org.Apache.REEF.Network.Naming
         {
             if (ids == null || ids.Count == 0)
             {
-                Exceptions.Throw(new ArgumentNullException("ids cannot be null or empty"), _logger);
+                Exceptions.Throw(new ArgumentNullException("ids cannot be null or empty"), Logger);
             }
 
-            _logger.Log(Level.Verbose, "Looking up ids");
+            Logger.Log(Level.Verbose, "Looking up ids");
             List<NameAssignment> assignments = _lookupClient.Lookup(ids);
             if (assignments != null)
             {
                 return assignments;
             }
-            Exceptions.Throw(new WakeRuntimeException("NameClient failed to look up ids."), _logger);
+            Exceptions.Throw(new WakeRuntimeException("NameClient failed to look up ids."), Logger);
             return null;  // above line will throw exception. So null will never be returned.
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/Naming/NameServer.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/NameServer.cs
@@ -40,7 +40,7 @@ namespace Org.Apache.REEF.Network.Naming
     /// </summary>
     public sealed class NameServer : INameServer
     {
-        private static readonly Logger _logger = Logger.GetLogger(typeof(NameServer));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(NameServer));
 
         private readonly TransportServer<NamingEvent> _server;
         private readonly Dictionary<string, IPEndPoint> _idToAddrMap;
@@ -64,7 +64,7 @@ namespace Org.Apache.REEF.Network.Naming
             ICodec<NamingEvent> codec = CreateServerCodec();
 
             // Start transport server, get listening IP endpoint
-            _logger.Log(Level.Info, "Starting naming server");
+            Logger.Log(Level.Info, "Starting naming server");
             _server = new TransportServer<NamingEvent>(
                 new IPEndPoint(addressProvider.LocalAddress, port), handler, 
                 codec, tcpPortProvider);
@@ -84,7 +84,7 @@ namespace Org.Apache.REEF.Network.Naming
         {
             if (ids == null)
             {
-                Exceptions.Throw(new ArgumentNullException("ids"), _logger);
+                Exceptions.Throw(new ArgumentNullException("ids"), Logger);
             }
 
             return ids.Where(id => _idToAddrMap.ContainsKey(id))
@@ -111,14 +111,14 @@ namespace Org.Apache.REEF.Network.Naming
         {
             if (id == null)
             {
-                Exceptions.Throw(new ArgumentNullException("id"), _logger);
+                Exceptions.Throw(new ArgumentNullException("id"), Logger);
             }
             if (endpoint == null)
             {
-                Exceptions.Throw(new ArgumentNullException("endpoint"), _logger);
+                Exceptions.Throw(new ArgumentNullException("endpoint"), Logger);
             }
 
-            _logger.Log(Level.Info, "Registering id: " + id + ", and endpoint: " + endpoint);
+            Logger.Log(Level.Info, "Registering id: " + id + ", and endpoint: " + endpoint);
             _idToAddrMap[id] = endpoint;
         }
 
@@ -130,10 +130,10 @@ namespace Org.Apache.REEF.Network.Naming
         {
             if (id == null)
             {
-                Exceptions.Throw(new ArgumentNullException("id"), _logger);
+                Exceptions.Throw(new ArgumentNullException("id"), Logger);
             }
 
-            _logger.Log(Level.Info, "Unregistering id: " + id);
+            Logger.Log(Level.Info, "Unregistering id: " + id);
             _idToAddrMap.Remove(id);
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkService.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkService.cs
@@ -34,7 +34,7 @@ namespace Org.Apache.REEF.Network.NetworkService
     /// <typeparam name="T">The message type</typeparam>
     public class NetworkService<T> : INetworkService<T>
     {
-        private readonly Logger LOGGER = Logger.GetLogger(typeof(NetworkService<>));
+        private static readonly Logger LOGGER = Logger.GetLogger(typeof(NetworkService<>));
 
         private readonly IRemoteManager<NsMessage<T>> _remoteManager;
         private readonly IObserver<NsMessage<T>> _messageHandler; 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestSerilization.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestSerilization.cs
@@ -52,27 +52,27 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         public void TestDeSerializeClassHierarchy()
         {
             Type timerType = typeof(Timer);
-            Type SecondType = typeof(Timer.Seconds);
+            Type secondType = typeof(Timer.Seconds);
             Type simpleCOnstuctorType = typeof(SimpleConstructors);
 
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Timer).Assembly.GetName().Name });
             IClassNode timerClassNode = (IClassNode)ns.GetNode(timerType.AssemblyQualifiedName);
-            INode secondNode = (INode)ns.GetNode(SecondType.AssemblyQualifiedName);
-            IClassNode SimpleConstructorsClassNode = (IClassNode)ns.GetNode(simpleCOnstuctorType.AssemblyQualifiedName);
+            INode secondNode = (INode)ns.GetNode(secondType.AssemblyQualifiedName);
+            IClassNode simpleConstructorsClassNode = (IClassNode)ns.GetNode(simpleCOnstuctorType.AssemblyQualifiedName);
 
             ProtocolBufferClassHierarchy.Serialize("node.bin", ns);
             IClassHierarchy ch = ProtocolBufferClassHierarchy.DeSerialize("node.bin");
 
             IClassNode timerClassNode2 = (IClassNode)ch.GetNode(timerType.AssemblyQualifiedName);
-            INode secondNode2 = ch.GetNode(SecondType.AssemblyQualifiedName);
-            IClassNode SimpleConstructorsClassNode2 = (IClassNode)ch.GetNode(simpleCOnstuctorType.AssemblyQualifiedName);
+            INode secondNode2 = ch.GetNode(secondType.AssemblyQualifiedName);
+            IClassNode simpleConstructorsClassNode2 = (IClassNode)ch.GetNode(simpleCOnstuctorType.AssemblyQualifiedName);
 
             Assert.Equal(timerClassNode.GetFullName(), timerClassNode2.GetFullName());
             Assert.Equal(secondNode.GetFullName(), secondNode2.GetFullName());
-            Assert.Equal(SimpleConstructorsClassNode.GetFullName(), SimpleConstructorsClassNode2.GetFullName());
+            Assert.Equal(simpleConstructorsClassNode.GetFullName(), simpleConstructorsClassNode2.GetFullName());
 
-            Assert.True(SimpleConstructorsClassNode2.GetChildren().Count == 0);
-            IList<IConstructorDef> def = SimpleConstructorsClassNode2.GetInjectableConstructors();
+            Assert.True(simpleConstructorsClassNode2.GetChildren().Count == 0);
+            IList<IConstructorDef> def = simpleConstructorsClassNode2.GetInjectableConstructors();
             Assert.Equal(3, def.Count);
         }
 
@@ -83,16 +83,16 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Type helloTaskType = typeof(HelloTask);
 
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(HelloTask).Assembly.GetName().Name });
-            IClassNode StreamTask1ClassNode = (IClassNode)ns.GetNode(streamTask1Type.AssemblyQualifiedName);
-            IClassNode HelloTaskClassNode = (IClassNode)ns.GetNode(helloTaskType.AssemblyQualifiedName);
+            IClassNode streamTask1ClassNode = (IClassNode)ns.GetNode(streamTask1Type.AssemblyQualifiedName);
+            IClassNode helloTaskClassNode = (IClassNode)ns.GetNode(helloTaskType.AssemblyQualifiedName);
 
             ProtocolBufferClassHierarchy.Serialize("task.bin", ns);
             IClassHierarchy ch = ProtocolBufferClassHierarchy.DeSerialize("task.bin");
-            IClassNode StreamTask1ClassNode2 = (IClassNode)ch.GetNode(streamTask1Type.AssemblyQualifiedName);
-            IClassNode HelloTaskClassNode2 = (IClassNode)ch.GetNode(helloTaskType.AssemblyQualifiedName);
+            IClassNode streamTask1ClassNode2 = (IClassNode)ch.GetNode(streamTask1Type.AssemblyQualifiedName);
+            IClassNode helloTaskClassNode2 = (IClassNode)ch.GetNode(helloTaskType.AssemblyQualifiedName);
 
-            Assert.Equal(StreamTask1ClassNode.GetFullName(), StreamTask1ClassNode2.GetFullName());
-            Assert.Equal(HelloTaskClassNode.GetFullName(), HelloTaskClassNode2.GetFullName());
+            Assert.Equal(streamTask1ClassNode.GetFullName(), streamTask1ClassNode2.GetFullName());
+            Assert.Equal(helloTaskClassNode.GetFullName(), helloTaskClassNode2.GetFullName());
         }
 
         [Fact]
@@ -122,16 +122,16 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Type helloTaskType = typeof(HelloTask);
 
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(HelloTask).Assembly.GetName().Name });
-            IClassNode StreamTask1ClassNode = (IClassNode)ns.GetNode(streamTask1Type.AssemblyQualifiedName);
-            IClassNode HelloTaskClassNode = (IClassNode)ns.GetNode(helloTaskType.AssemblyQualifiedName);
+            IClassNode streamTask1ClassNode = (IClassNode)ns.GetNode(streamTask1Type.AssemblyQualifiedName);
+            IClassNode helloTaskClassNode = (IClassNode)ns.GetNode(helloTaskType.AssemblyQualifiedName);
 
             ProtocolBufferClassHierarchy.Serialize("task.bin", ns);
             IClassHierarchy ch = ProtocolBufferClassHierarchy.DeSerialize("task.bin");
-            IClassNode StreamTask1ClassNode2 = (IClassNode)ch.GetNode(streamTask1Type.AssemblyQualifiedName);
-            IClassNode HelloTaskClassNode2 = (IClassNode)ch.GetNode(helloTaskType.AssemblyQualifiedName);
+            IClassNode streamTask1ClassNode2 = (IClassNode)ch.GetNode(streamTask1Type.AssemblyQualifiedName);
+            IClassNode helloTaskClassNode2 = (IClassNode)ch.GetNode(helloTaskType.AssemblyQualifiedName);
 
-            Assert.Equal(StreamTask1ClassNode.GetName(), StreamTask1ClassNode2.GetName());
-            Assert.Equal(HelloTaskClassNode.GetName(), HelloTaskClassNode2.GetName());
+            Assert.Equal(streamTask1ClassNode.GetName(), streamTask1ClassNode2.GetName());
+            Assert.Equal(helloTaskClassNode.GetName(), helloTaskClassNode2.GetName());
 
             // have to use original class hierarchy for the merge. ClassHierarchy from ProtoBuffer doesn't support merge. 
             IConfigurationBuilder cb = TangFactory.GetTang()
@@ -185,11 +185,11 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Timer).Assembly.GetName().Name });
 
             Type t = typeof(Timer);
-            IClassNode EventClassNode = (IClassNode)ns.GetNode(t.AssemblyQualifiedName);
+            IClassNode eventClassNode = (IClassNode)ns.GetNode(t.AssemblyQualifiedName);
             ProtocolBufferClassHierarchy.Serialize("event.bin", ns);
             IClassHierarchy ch = ProtocolBufferClassHierarchy.DeSerialize("event.bin");
-            IClassNode EventClassNode1 = (IClassNode)ns.GetNode(t.AssemblyQualifiedName);
-            Assert.Equal(EventClassNode.GetName(), EventClassNode1.GetName());
+            IClassNode eventClassNode1 = (IClassNode)ns.GetNode(t.AssemblyQualifiedName);
+            Assert.Equal(eventClassNode.GetName(), eventClassNode1.GetName());
         }
 
         [Fact]

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Utilities/TestUtilities.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Utilities/TestUtilities.cs
@@ -87,18 +87,18 @@ namespace Org.Apache.REEF.Tang.Tests.Utilities
         public void TestGetName()
         {
             var asm = Assembly.Load(FileNames.Examples);
-            Type B2 = asm.GetType(FileNames.B2);
+            Type b2 = asm.GetType(FileNames.B2);
 
-            string n = ReflectionUtilities.GetName(B2);
-            Assert.Equal(n, B2.FullName);
+            string n = ReflectionUtilities.GetName(b2);
+            Assert.Equal(n, b2.FullName);
         }
 
         [Fact]
         public void TestGetEnclosingTypesInclusive()
         {
             var asm = Assembly.Load(FileNames.Examples);
-            Type B2 = asm.GetType(FileNames.B2);
-            Type[] ts = ReflectionUtilities.GetEnclosingClasses(B2);
+            Type b2 = asm.GetType(FileNames.B2);
+            Type[] ts = ReflectionUtilities.GetEnclosingClasses(b2);
             Assert.Equal(ts[0], asm.GetType(FileNames.B));
             Assert.Equal(ts[1], asm.GetType(FileNames.B1));
             Assert.Equal(ts[2], asm.GetType(FileNames.B2));

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the Apache Software Foundation (ASF) under one
+﻿﻿// Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBroadcastReduceTest.cs
@@ -27,7 +27,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(IMRUMapperCountTest));
 
-        private static readonly int numNodes = 4;
+        private static readonly int NumNodes = 4;
 
         [Fact]
         [Trait("Description", "Run IMRU broadcast and reduce example as test.")]
@@ -35,7 +35,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
         {
             string testFolder = DefaultRuntimeFolder + TestId;
             TestIMRUBroadcastReduce(false, testFolder);
-            ValidateSuccessForLocalRuntime(numNodes, testFolder: testFolder);
+            ValidateSuccessForLocalRuntime(NumNodes, testFolder: testFolder);
             CleanUp(testFolder);
         }
 
@@ -52,7 +52,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .Set(TcpPortConfigurationModule.PortRangeStart, "8900")
                 .Set(TcpPortConfigurationModule.PortRangeCount, "1000")
                 .Build();
-            Run.RunBroadcastReduceTest(tcpPortConfig, runOnYarn, numNodes, new string[0], testFolder);
+            Run.RunBroadcastReduceTest(tcpPortConfig, runOnYarn, NumNodes, new string[0], testFolder);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUMapperCountTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUMapperCountTest.cs
@@ -27,7 +27,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(IMRUMapperCountTest));
 
-        private static readonly int numNodes = 4;
+        private static readonly int NumNodes = 4;
 
         [Fact]
         [Trait("Description", "Run IMRU mapper count example as test.")]
@@ -35,7 +35,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
         {
             string testFolder = DefaultRuntimeFolder + TestId;
             TestIMRUMapperCount(false, testFolder);
-            ValidateSuccessForLocalRuntime(numNodes, testFolder: testFolder);
+            ValidateSuccessForLocalRuntime(NumNodes, testFolder: testFolder);
             CleanUp(testFolder);
         }
 
@@ -52,7 +52,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .Set(TcpPortConfigurationModule.PortRangeStart, "8900")
                 .Set(TcpPortConfigurationModule.PortRangeCount, "1000")
                 .Build();
-            Run.RunMapperTest(tcpPortConfig, runOnYarn, numNodes, " ", testFolder);
+            Run.RunMapperTest(tcpPortConfig, runOnYarn, NumNodes, " ", testFolder);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
@@ -137,7 +137,7 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
         {
             int fanOut = 2;
             int totalEvaluators = Partitions + 1;
-            string Identifier = "KMeansDriverId";
+            string identifier = "KMeansDriverId";
 
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
                 Org.Apache.REEF.Driver.DriverConfiguration.ConfigurationModule
@@ -151,7 +151,7 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
                 .Build();
 
             IConfiguration groupCommunicationDriverConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindStringNamedParam<GroupCommConfigurationOptions.DriverId>(Identifier)
+                .BindStringNamedParam<GroupCommConfigurationOptions.DriverId>(identifier)
                 .BindStringNamedParam<GroupCommConfigurationOptions.MasterTaskId>(Constants.MasterTaskId)
                 .BindStringNamedParam<GroupCommConfigurationOptions.GroupName>(Constants.KMeansCommunicationGroupName)
                 .BindIntNamedParam<GroupCommConfigurationOptions.FanOut>(fanOut.ToString(CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture))

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/MultiEncoder.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/MultiEncoder.cs
@@ -29,7 +29,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
     /// </summary>
     public class MultiEncoder<T> : IEncoder<T>
     {
-        private static readonly Logger _logger = Logger.GetLogger(typeof(MultiEncoder<>));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(MultiEncoder<>));
         private readonly Dictionary<Type, object> _encoderMap;
         private readonly Dictionary<Type, string> _nameMap;
 
@@ -52,7 +52,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         {
             _encoderMap[typeof(U)] = encoder;
             _nameMap[typeof(U)] = name;
-            _logger.Log(Level.Verbose, "Registering name for " + name);
+            Logger.Log(Level.Verbose, "Registering name for " + name);
         }
 
         /// <summary>Encodes an object to a byte array</summary>
@@ -75,7 +75,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
             // To decode, deserialize the tuple, get object type, and look up the
             // decoder for that type
             string name = _nameMap[obj.GetType()];
-            _logger.Log(Level.Verbose, "Encoding name for " + name);
+            Logger.Log(Level.Verbose, "Encoding name for " + name);
             WakeTuplePBuf pbuf = new WakeTuplePBuf { className = name, data = data };
             pbuf.className = name;
             pbuf.data = data; 

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Runtime/RuntimeClock.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Runtime/RuntimeClock.cs
@@ -34,7 +34,7 @@ namespace Org.Apache.REEF.Wake.Time.Runtime
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(RuntimeClock));
 
-        private static int NumberOfInstantiations = 0;
+        private static int numberOfInstantiations = 0;
         private readonly ITimer _timer;
         private readonly PubSubSubject<Time> _handlers;
         private readonly PriorityQueue<Time> _schedule;
@@ -74,10 +74,10 @@ namespace Org.Apache.REEF.Wake.Time.Runtime
             _runtimeStartHandler = runtimeStartHandler;
             _runtimeStopHandler = runtimeStopHandler;
             _idleHandler = idleHandler;
-            ++NumberOfInstantiations;
-            if (NumberOfInstantiations > 1)
+            ++numberOfInstantiations;
+            if (numberOfInstantiations > 1)
             {
-                LOGGER.Log(Level.Warning, "Instantiated `RuntimeClock` instance number " + NumberOfInstantiations);
+                LOGGER.Log(Level.Warning, "Instantiated `RuntimeClock` instance number " + numberOfInstantiations);
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Wake/Util/NetworkUtils.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Util/NetworkUtils.cs
@@ -25,7 +25,7 @@ namespace Org.Apache.REEF.Wake.Util
     public static class NetworkUtils
     {
         private static IPAddress _localAddress;
-        private static readonly Random _random = new Random();
+        private static readonly Random Random = new Random();
 
         /// <summary>
         /// Returns the first usable IP Address for the machine.
@@ -55,7 +55,7 @@ namespace Org.Apache.REEF.Wake.Util
         /// <returns>The randomly generated port</returns>
         public static int GenerateRandomPort(int low, int high)
         {
-            return _random.Next(low, high);
+            return Random.Next(low, high);
         }
     }
 }

--- a/lang/cs/Settings.StyleCop
+++ b/lang/cs/Settings.StyleCop
@@ -412,7 +412,7 @@ under the License.
         </Rule>
         <Rule Name="ElementMustBeginWithLowerCaseLetter">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="InterfaceNamesMustBeginWithI">
@@ -437,7 +437,7 @@ under the License.
         </Rule>
         <Rule Name="FieldNamesMustBeginWithLowerCaseLetter">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="AccessibleFieldsMustBeginWithUpperCaseLetter">
@@ -447,7 +447,7 @@ under the License.
         </Rule>
         <Rule Name="VariableNamesMustNotBePrefixed">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="FieldNamesMustNotBeginWithUnderscore">
@@ -462,7 +462,7 @@ under the License.
         </Rule>
         <Rule Name="StaticReadonlyFieldsMustBeginWithUpperCaseLetter">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
       </Rules>


### PR DESCRIPTION
This change enables the following NamingRules:
 * ElementMustBeginWithLowerCaseLetter
 * FieldNamesMustBeginWithLowerCaseLetter
 * VariableNamesMustNotBePrefixed
 * StaticReadonlyFieldsMustBeginWithUpperCaseLetter

This change does not resolve associated JIRA.

JIRA:
  [REEF-1057](https://issues.apache.org/jira/browse/REEF-1057)

Pull request:
  This closes #