### PR TITLE
[REEF-1258] Populate Task Exception data properly

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
+++ b/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
@@ -121,6 +121,7 @@ namespace Org {
 
                         public ref class FailedTaskClr2Java : public IFailedTaskClr2Java {
                             jobject  _jobjectFailedTask = NULL;
+                            array<byte>^ _errorBytes = nullptr;
                             JavaVM* _jvm;
                         public:
                             FailedTaskClr2Java(JNIEnv *env, jobject jfailedTask);
@@ -129,6 +130,7 @@ namespace Org {
                             virtual void OnError(String^ message);
                             virtual IActiveContextClr2Java^ GetActiveContext();
                             virtual String^ GetString();
+                            virtual array<byte>^ GetFailedTaskBytes();
                         };
 
                         public ref class RunningTaskClr2Java : public IRunningTaskClr2Java {

--- a/lang/cs/Org.Apache.REEF.Bridge/FailedTaskClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/FailedTaskClr2Java.cpp
@@ -35,7 +35,11 @@ namespace Org {
 							  ManagedLog::LOGGER->LogError("Failed to get JavaVM", nullptr);
 						  }
 						  _jobjectFailedTask = reinterpret_cast<jobject>(env->NewGlobalRef(jobjectFailedTask));
-						  ManagedLog::LOGGER->LogStop("FailedTaskClr2Java::AllocatedEvaluatorClr2Java");
+
+                          jclass jclassFailedTask = env->GetObjectClass(_jobjectFailedTask);
+                          jmethodID jmidGetFailedTaskBytes = env->GetMethodID(jclassFailedTask, "getFailedTaskBytes", "()[B");
+                          jbyteArray jarrayErrorBytes = CommonUtilities::CallGetMethodNewGlobalRef<jbyteArray>(env, _jobjectFailedTask, jmidGetFailedTaskBytes);
+                          _errorBytes = ManagedByteArrayFromJavaByteArray(env, jarrayErrorBytes);
 					  }
 
 					  FailedTaskClr2Java::~FailedTaskClr2Java() {
@@ -43,8 +47,9 @@ namespace Org {
 					  }
 
 					  FailedTaskClr2Java::!FailedTaskClr2Java() {
+                          JNIEnv *env = RetrieveEnv(_jvm);
+
 						  if (_jobjectFailedTask != NULL) {
-							  JNIEnv *env = RetrieveEnv(_jvm);
 							  env->DeleteGlobalRef(_jobjectFailedTask);
 						  }
 					  }
@@ -84,6 +89,10 @@ namespace Org {
 						  ManagedLog::LOGGER->LogStop("FailedTaskClr2Java::GetString");
 						  return ManagedStringFromJavaString(env, jFailedTaskString);
 					  }
+
+                      array<byte>^ FailedTaskClr2Java::GetFailedTaskBytes() {
+                          return _errorBytes;
+                      }
 
 					  void FailedTaskClr2Java::OnError(String^ message) {
 						  ManagedLog::LOGGER->Log("FailedTaskClr2Java::OnError");

--- a/lang/cs/Org.Apache.REEF.Common/Exceptions/JavaTaskException.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Exceptions/JavaTaskException.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,28 +16,26 @@
 // under the License.
 
 using System;
-using System.Text;
 
-namespace Org.Apache.REEF.Utilities
+namespace Org.Apache.REEF.Common.Exceptions
 {
-    public static class ByteUtilities
+    /// <summary>
+    /// A Task Exception from the Java side. Generally not expected.
+    /// </summary>
+    public sealed class JavaTaskException : Exception
     {
-        public static byte[] StringToByteArrays(string s)
+        public JavaTaskException()
         {
-            return Encoding.UTF8.GetBytes(s);
         }
 
-        public static string ByteArraysToString(byte[] b)
+        public JavaTaskException(string message)
+            : base(message)
         {
-            return Encoding.UTF8.GetString(b);
         }
 
-        public static byte[] CopyBytesFrom(byte[] from)
+        public JavaTaskException(string message, Exception inner)
+            : base(message, inner)
         {
-            int length = Buffer.ByteLength(from);
-            byte[] to = new byte[length];
-            Buffer.BlockCopy(from, 0, to, 0, length);
-            return to;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Common/Exceptions/NonSerializableTaskException.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Exceptions/NonSerializableTaskException.cs
@@ -16,28 +16,26 @@
 // under the License.
 
 using System;
-using System.Text;
 
-namespace Org.Apache.REEF.Utilities
+namespace Org.Apache.REEF.Common.Exceptions
 {
-    public static class ByteUtilities
+    /// <summary>
+    /// An Exception from a REEF Task that was not Serializable to the Job Driver.
+    /// </summary>
+    public sealed class NonSerializableTaskException : Exception
     {
-        public static byte[] StringToByteArrays(string s)
+        public NonSerializableTaskException()
         {
-            return Encoding.UTF8.GetBytes(s);
         }
 
-        public static string ByteArraysToString(byte[] b)
+        public NonSerializableTaskException(string message)
+            : base(message)
         {
-            return Encoding.UTF8.GetString(b);
         }
 
-        public static byte[] CopyBytesFrom(byte[] from)
+        public NonSerializableTaskException(string message, Exception inner)
+            : base(message, inner)
         {
-            int length = Buffer.ByteLength(from);
-            byte[] to = new byte[length];
-            Buffer.BlockCopy(from, 0, to, 0, length);
-            return to;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -105,7 +105,9 @@ under the License.
     <Compile Include="Evaluator\DriverConnectionConfigurationProviders\YarnClusterHttpDriverReconnConfigProvider.cs" />
     <Compile Include="Events\IContextStart.cs" />
     <Compile Include="Events\IContextStop.cs" />
+    <Compile Include="Exceptions\JavaTaskException.cs" />
     <Compile Include="Exceptions\JobException.cs" />
+    <Compile Include="Exceptions\NonSerializableTaskException.cs" />
     <Compile Include="Files\PathUtilities.cs" />
     <Compile Include="IContextAndTaskSubmittable.cs" />
     <Compile Include="IContextSubmittable.cs" />

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IFailedTaskClr2Java.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IFailedTaskClr2Java.cs
@@ -25,5 +25,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Clr2java
         IActiveContextClr2Java GetActiveContext();
 
         string GetString();
+
+        byte[] GetFailedTaskBytes();
     }
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedTaskBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedTaskBridge.java
@@ -71,6 +71,14 @@ public final class FailedTaskBridge extends NativeBridge {
     return poorSerializedString;
   }
 
+  public byte[] getFailedTaskBytes() {
+    if (jfailedTask.getData().isPresent()) {
+      return jfailedTask.getData().get();
+    }
+
+    return null;
+  }
+
   @Override
   public void close() {
   }


### PR DESCRIPTION
This addressed the issue by
  * Allow Task Exceptions to be serialized across C# boundaries.

JIRA:
  [REEF-1258](https://issues.apache.org/jira/browse/REEF-1258)