### PR TITLE
[REEF-796] Do Avro (de)serialization for FailedTask in bridge

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
+++ b/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
@@ -128,7 +128,7 @@ namespace Org {
                             !FailedTaskClr2Java();
                             virtual void OnError(String^ message);
                             virtual IActiveContextClr2Java^ GetActiveContext();
-                            virtual String^ GetString();
+                            virtual array<byte>^ GetFailedTaskSerializedAvro();
                         };
 
                         public ref class RunningTaskClr2Java : public IRunningTaskClr2Java {

--- a/lang/cs/Org.Apache.REEF.Bridge/FailedTaskClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/FailedTaskClr2Java.cpp
@@ -60,29 +60,29 @@ namespace Org {
 
 						  ManagedLog::LOGGER->LogStop("FailedTaskClr2Java::GetActiveContext");
 
-                          if (jobjectActiveContext == NULL) {
-                              return nullptr;
-                          }
+						  if (jobjectActiveContext == NULL) {
+							  return nullptr;
+						  }
 
 						  return gcnew ActiveContextClr2Java(env, jobjectActiveContext);
 					  }
 
-					  String^ FailedTaskClr2Java::GetString() {
-						  ManagedLog::LOGGER->LogStart("FailedTaskClr2Java::GetString");
+					  array<byte>^ FailedTaskClr2Java::GetFailedTaskSerializedAvro() {
+						  ManagedLog::LOGGER->LogStart("FailedTaskClr2Java::GetFailedTaskSerializedAvro");
 						  JNIEnv *env = RetrieveEnv(_jvm);
 
 						  jclass jclassFailedTask = env->GetObjectClass(_jobjectFailedTask);
-						  jmethodID jmidGetFailedTaskString = env->GetMethodID(jclassFailedTask, "getFailedTaskString", "()Ljava/lang/String;");
+						  jmethodID jmidGetFailedTaskSerializedAvro = env->GetMethodID(jclassFailedTask, "getFailedTaskSerializedAvro", "()[B");
 
-						  if (jmidGetFailedTaskString == NULL) {
-							  ManagedLog::LOGGER->LogStart("jmidGetFailedTaskString is NULL");
+						  if (jmidGetFailedTaskSerializedAvro == NULL) {
+							  ManagedLog::LOGGER->LogStart("jmidGetFailedTaskSerializedAvro is NULL");
 							  return nullptr;
 						  }
-						  jstring jFailedTaskString = (jstring)env->CallObjectMethod(
+						  jbyteArray jFailedTaskSerializedAvro = (jbyteArray)env->CallObjectMethod(
 							  _jobjectFailedTask,
-							  jmidGetFailedTaskString);
-						  ManagedLog::LOGGER->LogStop("FailedTaskClr2Java::GetString");
-						  return ManagedStringFromJavaString(env, jFailedTaskString);
+							  jmidGetFailedTaskSerializedAvro);
+						  ManagedLog::LOGGER->LogStop("FailedTaskClr2Java::GetFailedTaskSerializedAvro");
+						  return ManagedByteArrayFromJavaByteArray(env, jFailedTaskSerializedAvro);
 					  }
 
 					  void FailedTaskClr2Java::OnError(String^ message) {

--- a/lang/cs/Org.Apache.REEF.Client/Avro/README.md
+++ b/lang/cs/Org.Apache.REEF.Client/Avro/README.md
@@ -7,7 +7,7 @@ unless there is absolutely a reason to!
 
 Instructions On C# Code-Generation
 ----------------------------------
-To code-generate thes files, please use instructions on how 
+To code-generate these files, please use instructions on how 
 to use Microsoft.Hadoop.Avro.Tools.exe as provided 
 [here](https://azure.microsoft.com/en-us/documentation/articles/hdinsight-dotnet-avro-serialization/)
 on the files in lang/java/reef-bridge-client/src/avro.

--- a/lang/cs/Org.Apache.REEF.Common/Avro/AvroFailedTask.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Avro/AvroFailedTask.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Runtime.Serialization;
+using Org.Apache.REEF.Utilities.Attributes;
+
+namespace Org.Apache.REEF.Common.Avro
+{
+    /// <summary>
+    /// Used to serialize and deserialize Avro record org.apache.reef.javabridge.avro.AvroFailedTask.
+    /// This is a (mostly) auto-generated class. For instructions on how to regenerate, please view the README.md in the same folder.
+    /// </summary>
+    [Private]
+    [DataContract(Namespace = "org.apache.reef.javabridge.avro")]
+    public sealed class AvroFailedTask
+    {
+        private const string JsonSchema = @"{""type"":""record"",""name"":""org.apache.reef.javabridge.avro.AvroFailedTask"",""doc"":""Defines the schema for the failed task."",""fields"":[{""name"":""identifier"",""type"":""string""},{""name"":""data"",""type"":""bytes""},{""name"":""cause"",""type"":""bytes""},{""name"":""message"",""type"":""string""}]}";
+
+        /// <summary>
+        /// Gets the schema.
+        /// </summary>
+        public static string Schema
+        {
+            get
+            {
+                return JsonSchema;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the identifier field.
+        /// </summary>
+        [DataMember]
+        public string identifier { get; set; }
+
+        /// <summary>
+        /// Gets or sets the data field.
+        /// </summary>
+        [DataMember]
+        public byte[] data { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cause field.
+        /// </summary>
+        [DataMember]
+        public byte[] cause { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message field.
+        /// </summary>
+        [DataMember]
+        public string message { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AvroFailedTask"/> class.
+        /// </summary>
+        public AvroFailedTask()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AvroFailedTask"/> class.
+        /// </summary>
+        /// <param name="identifier">The identifier.</param>
+        /// <param name="data">The data.</param>
+        /// <param name="cause">The cause.</param>
+        /// <param name="message">The message.</param>
+        public AvroFailedTask(string identifier, byte[] data, byte[] cause, string message)
+        {
+            this.identifier = identifier;
+            this.data = data;
+            this.cause = cause;
+            this.message = message;
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Common/Avro/README.md
+++ b/lang/cs/Org.Apache.REEF.Common/Avro/README.md
@@ -1,0 +1,19 @@
+﻿C# Avro Code-Generated Files
+============================
+The files here are code-generated with modifications. The code
+generation is based on the Avro schemas defined in the folder
+lang/java/reef-bridge-client/src/avro. Please do not modify them 
+unless there is absolutely a reason to!
+
+Instructions On C# Code-Generation
+----------------------------------
+To code-generate thes files, please use instructions on how 
+to use Microsoft.Hadoop.Avro.Tools.exe as provided 
+[here](https://azure.microsoft.com/en-us/documentation/articles/hdinsight-dotnet-avro-serialization/)
+on the files in lang/java/reef-bridge-client/src/avro.
+Note that as of the time of writing (11/10/2015), the 
+Microsoft Azure HDInsight Avro Library NuGet does not include 
+Microsoft.Hadoop.Avro.Tools.exe. To build it directly from source,
+please download the source code [here](http://hadoopsdk.codeplex.com/SourceControl/latest) 
+and run msbuild. More information on how to build is available 
+on the official documentation provided above.

--- a/lang/cs/Org.Apache.REEF.Common/Avro/README.md
+++ b/lang/cs/Org.Apache.REEF.Common/Avro/README.md
@@ -7,7 +7,7 @@ unless there is absolutely a reason to!
 
 Instructions On C# Code-Generation
 ----------------------------------
-To code-generate thes files, please use instructions on how 
+To code-generate these files, please use instructions on how 
 to use Microsoft.Hadoop.Avro.Tools.exe as provided 
 [here](https://azure.microsoft.com/en-us/documentation/articles/hdinsight-dotnet-avro-serialization/)
 on the files in lang/java/reef-bridge-client/src/avro.

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -57,6 +57,7 @@ under the License.
     <Compile Include="Avro\AvroDriverInfo.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Avro\AvroFailedTask.cs" />
     <Compile Include="Avro\AvroHttpRequest.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -191,6 +192,7 @@ under the License.
     <Compile Include="Tasks\TaskMessage.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Avro\README.md" />
     <None Include="Org.Apache.REEF.Common.nuspec" />
     <None Include="packages.config" />
     <None Include="Protobuf\Proto\client_runtime.proto" />

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using Org.Apache.REEF.Common.Protobuf.ReefProtocol;
 using Org.Apache.REEF.Common.Tasks;
@@ -47,7 +46,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
         [Inject]
         private TaskRuntime(
             ITask userTask,
-            IDriverMessageHandler driverMessageHandler,
+            IDriverMessageHandler driverMessageHandler, 
             IDriverConnectionMessageHandler driverConnectionMessageHandler,
             TaskStatus taskStatus,
             [Parameter(typeof(TaskConfigurationOptions.SuspendHandler))] IInjectionFuture<IObserver<ISuspendEvent>> suspendHandlerFuture,
@@ -75,8 +74,8 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
         /// For testing only!
         /// </summary>
         [Testing]
-        internal ITask Task
-        {
+        internal ITask Task 
+        { 
             get { return _userTask; }
         }
 
@@ -99,43 +98,46 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                 Logger.Log(Level.Info, "Calling into user's task.");
                 return _userTask.Call(null);
             }).ContinueWith((System.Threading.Tasks.Task<byte[]> runTask) =>
-            {
-                try
                 {
-                    // Task failed.
-                    if (runTask.IsFaulted)
+                    try
                     {
-                        OnTaskFailure(runTask);
-                        return;
-                    }
+                        // Task failed.
+                        if (runTask.IsFaulted)
+                        {
+                            OnTaskFailure(runTask);
+                            return;
+                        }
 
-                    if (runTask.IsCanceled)
-                    {
-                        Logger.Log(Level.Error,
-                            string.Format(CultureInfo.InvariantCulture, "Task failed caused by System.Threading.Task cancellation"));
-                        OnTaskFailure(runTask);
-                        return;
-                    }
+                        if (runTask.IsCanceled)
+                        {
+                            Logger.Log(Level.Error,
+                                string.Format(CultureInfo.InvariantCulture, "Task failed caused by System.Threading.Task cancellation"));
+                            OnTaskFailure(runTask);
+                            return;
+                        }
 
-                    // Task completed.
-                    var result = runTask.Result;
-                    Logger.Log(Level.Info, "Task Call Finished");
-                    _currentStatus.SetResult(result);
-                    if (result != null && result.Length > 0)
-                    {
-                        Logger.Log(Level.Info, "Task running result:\r\n" + System.Text.Encoding.Default.GetString(result));
-                    }
-                }
-                finally
-                {
-                    if (_userTask != null)
-                    {
-                        _userTask.Dispose();
-                    }
+                        // Task completed.
+                        var result = runTask.Result;
+                        Logger.Log(Level.Info, "Task Call Finished");
+                        _currentStatus.SetResult(result);
 
-                    runTask.Dispose();
-                }
-            });
+                        const Level resultLogLevel = Level.Verbose;
+
+                        if (Logger.CustomLevel >= resultLogLevel && result != null && result.Length > 0)
+                        {
+                            Logger.Log(resultLogLevel, "Task running result:\r\n" + System.Text.Encoding.Default.GetString(result));
+                        }
+                    }
+                    finally
+                    {
+                        if (_userTask != null)
+                        {
+                            _userTask.Dispose();
+                        }
+
+                        runTask.Dispose();
+                    }
+                });
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStatus.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStatus.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Org.Apache.REEF.Common.Avro;
 using Org.Apache.REEF.Common.Context;
 using Org.Apache.REEF.Common.Protobuf.ReefProtocol;
 using Org.Apache.REEF.Common.Tasks;
@@ -246,8 +247,17 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                 }
                 else if (_lastException.IsPresent())
                 {
-                    byte[] error = ByteUtilities.StringToByteArrays(_lastException.Value.ToString());
-                    taskStatusProto.result = ByteUtilities.CopyBytesFrom(error);
+                    var avroFailedTask = new AvroFailedTask
+                    {
+                        identifier = _taskId,
+                        
+                        // TODO[JIRA REEF-1258]: Serialize Exception properly.
+                        cause = new byte[0],
+                        data = ByteUtilities.StringToByteArrays(_lastException.Value.ToString()),
+                        message = _lastException.Value.Message
+                    };
+
+                    taskStatusProto.result = AvroJsonSerializer<AvroFailedTask>.ToBytes(avroFailedTask);
                 }
                 else if (_state == TaskState.Running)
                 {

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStatus.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStatus.cs
@@ -23,7 +23,6 @@ using Org.Apache.REEF.Common.Context;
 using Org.Apache.REEF.Common.Protobuf.ReefProtocol;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Utilities.Logging;
 

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Avro/README.md
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Avro/README.md
@@ -1,0 +1,19 @@
+﻿C# Avro Code-Generated Files
+============================
+The files here are code-generated with modifications. The code
+generation is based on the Avro schemas defined in the folder
+lang/java/reef-bridge-client/src/avro. Please do not modify them 
+unless there is absolutely a reason to!
+
+Instructions On C# Code-Generation
+----------------------------------
+To code-generate thes files, please use instructions on how 
+to use Microsoft.Hadoop.Avro.Tools.exe as provided 
+[here](https://azure.microsoft.com/en-us/documentation/articles/hdinsight-dotnet-avro-serialization/)
+on the files in lang/java/reef-bridge-client/src/avro.
+Note that as of the time of writing (11/10/2015), the 
+Microsoft Azure HDInsight Avro Library NuGet does not include 
+Microsoft.Hadoop.Avro.Tools.exe. To build it directly from source,
+please download the source code [here](http://hadoopsdk.codeplex.com/SourceControl/latest) 
+and run msbuild. More information on how to build is available 
+on the official documentation provided above.

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Avro/README.md
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Avro/README.md
@@ -7,7 +7,7 @@ unless there is absolutely a reason to!
 
 Instructions On C# Code-Generation
 ----------------------------------
-To code-generate thes files, please use instructions on how 
+To code-generate these files, please use instructions on how 
 to use Microsoft.Hadoop.Avro.Tools.exe as provided 
 [here](https://azure.microsoft.com/en-us/documentation/articles/hdinsight-dotnet-avro-serialization/)
 on the files in lang/java/reef-bridge-client/src/avro.

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IFailedTaskClr2Java.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IFailedTaskClr2Java.cs
@@ -24,6 +24,6 @@ namespace Org.Apache.REEF.Driver.Bridge.Clr2java
     {
         IActiveContextClr2Java GetActiveContext();
 
-        string GetString();
+        byte[] GetFailedTaskSerializedAvro();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
+++ b/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
@@ -151,6 +151,7 @@ under the License.
     <Compile Include="Task\ITaskMessage.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Bridge\Avro\README.md" />
     <None Include="Org.Apache.REEF.Driver.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
@@ -66,6 +66,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         private sealed class FailedTaskDriver : IObserver<IDriverStarted>, IObserver<IAllocatedEvaluator>, 
             IObserver<IFailedTask>, IObserver<ICompletedTask>
         {
+            private const string TaskId = "1234567";
             private static readonly Logger Logger = Logger.GetLogger(typeof(FailedTaskDriver));
 
             private readonly IEvaluatorRequestor _requestor;
@@ -84,7 +85,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             public void OnNext(IAllocatedEvaluator value)
             {
                 value.SubmitTask(TaskConfiguration.ConfigurationModule
-                    .Set(TaskConfiguration.Identifier, "1234567")
+                    .Set(TaskConfiguration.Identifier, TaskId)
                     .Set(TaskConfiguration.Task, GenericType<FailTask>.Class)
                     .Build());
             }
@@ -95,6 +96,11 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
                 if (value.Message == null || value.Message != ExpectedExceptionMessage)
                 {
                     throw new Exception("Exception message not properly propagated. Received message " + value.Message);
+                }
+
+                if (value.Id != TaskId)
+                {
+                    throw new Exception("Received Task ID " + value.Id + " instead of the expected Task ID " + TaskId);
                 }
 
                 value.GetActiveContext().Value.Dispose();

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
@@ -34,6 +34,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
     public sealed class TestFailedTaskEventHandler : ReefFunctionalTest
     {
         private const string FailedTaskMessage = "I have successfully seen a failed task.";
+        private const string ExpectedExceptionMessage = "Expected exception.";
 
         [Fact]
         [Trait("Priority", "1")]
@@ -91,6 +92,11 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             public void OnNext(IFailedTask value)
             {
                 Logger.Log(Level.Error, FailedTaskMessage);
+                if (value.Message == null || value.Message != ExpectedExceptionMessage)
+                {
+                    throw new Exception("Exception message not properly propagated. Received message " + value.Message);
+                }
+
                 value.GetActiveContext().Value.Dispose();
             }
 
@@ -123,7 +129,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
 
             public byte[] Call(byte[] memento)
             {
-                throw new Exception("Expected exception.");
+                throw new Exception(ExpectedExceptionMessage);
             }
         }
     }

--- a/lang/java/reef-bridge-java/src/main/avro/Bridge.avsc
+++ b/lang/java/reef-bridge-java/src/main/avro/Bridge.avsc
@@ -24,12 +24,28 @@
     "namespace":"org.apache.reef.javabridge.avro",
     "type":"record",
     "name":"AvroFailedTask",
-    "doc":"Defines the schema for the failed task.",
+    "doc":"Defines the schema for failed task. Tunnels Task failures from C# Evaluator to Java Driver to C# Driver.",
     "fields":[
-      {"name":"identifier", "type":"string"},
-      {"name":"data", "type":"bytes"},
-      {"name":"cause", "type":"bytes"},
-      {"name":"message", "type":"string"}
+      {
+        "name":"identifier",
+        "doc":"The Task ID of the failed Task.",
+        "type":"string"
+      },
+      {
+        "name":"data",
+        "doc":"The data passed back from the Failed Task, if any.",
+        "type":"bytes"
+      },
+      {
+        "name":"cause",
+        "doc":"The serialized Exception of that caused the Task failure.",
+        "type":"bytes"
+      },
+      {
+        "name":"message",
+        "doc":"The message of the Task failure, if any.",
+        "type":"string"
+      }
     ]
   }
 ]

--- a/lang/java/reef-bridge-java/src/main/avro/Bridge.avsc
+++ b/lang/java/reef-bridge-java/src/main/avro/Bridge.avsc
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ [
+/*
+ * Defines the schema for Bridge classes such that information can be passed from C# Evaluator to C# Driver.
+ */
+ {
+    "namespace":"org.apache.reef.javabridge.avro",
+    "type":"record",
+    "name":"AvroFailedTask",
+    "doc":"Defines the schema for the failed task.",
+    "fields":[
+      {"name":"identifier", "type":"string"},
+      {"name":"data", "type":"bytes"},
+      {"name":"cause", "type":"bytes"},
+      {"name":"message", "type":"string"}
+    ]
+  }
+]


### PR DESCRIPTION
This addressed the issue by
  * Add AvroFailedTask.
  * Serialize and deserialize info from C# properly without using ad-hoc serialization.

JIRA:
  [REEF-796](https://issues.apache.org/jira/browse/REEF-796)