### PR TITLE
[REEF-1351] Optional parameter returns IsPresent true after assigning…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -107,6 +107,7 @@ under the License.
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utility\TestDriverConfigGenerator.cs" />
     <Compile Include="Utility\TestExceptions.cs" />
+    <Compile Include="Utility\TestOptional.cs" />
     <Compile Include="Utility\TestPriorityQueue.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Tests/Utility/TestOptional.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Utility/TestOptional.cs
@@ -1,0 +1,169 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using Org.Apache.REEF.Utilities;
+using Xunit;
+
+namespace Org.Apache.REEF.Tests.Utility
+{
+    public sealed class TestOptional
+    {
+        [Fact]
+        public void TestOptionalNullableThrowsWhenNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => Optional<TestClass>.Of(null));
+        }
+
+        [Fact]
+        public void TestOptionalNullableOfNullableNotPresent()
+        {
+            var optional = Optional<TestClass>.OfNullable(null);
+            Assert.False(optional.IsPresent());
+        }
+
+        [Fact]
+        public void TestOptionalNullableValuePresent()
+        {
+            const int expected = 1;
+            var optional = Optional<TestClass>.Of(new TestClass(expected));
+            Assert.True(optional.IsPresent());
+            Assert.Equal(expected, optional.Value.Integer);
+        }
+
+        [Fact]
+        public void TestOptionalNullableEquality()
+        {
+            const int intVal = 1;
+            var optional1 = Optional<TestClass>.Of(new TestClass(intVal));
+            var optional2 = Optional<TestClass>.Of(new TestClass(intVal));
+            Assert.Equal(optional1, optional2);
+            Assert.Equal(optional1.GetHashCode(), optional2.GetHashCode());
+        }
+
+        [Fact]
+        public void TestOptionalNullableEmpty()
+        {
+            var empty1 = Optional<TestClass>.Empty();
+            var empty2 = Optional<TestClass>.Empty();
+            Assert.Equal(null, empty1.Value);
+            Assert.False(empty1.IsPresent());
+            Assert.Equal(empty1, empty2);
+            Assert.Equal(empty1.GetHashCode(), empty2.GetHashCode());
+        }
+
+        [Fact]
+        public void TestOptionalNullableOrElse()
+        {
+            const int expectedInt = 1;
+            var srcObj = new TestClass(expectedInt);
+            var elseObj = Optional<TestClass>.Empty().OrElse(srcObj);
+            Assert.Equal(srcObj, elseObj);
+            Assert.Equal(expectedInt, elseObj.Integer);
+            Assert.True(ReferenceEquals(srcObj, elseObj));
+            Assert.Null(Optional<TestClass>.Empty().OrElse(null));
+
+            const int unexpectedInt = 2;
+            var unexpectedObj = new TestClass(unexpectedInt);
+            var ifObj = Optional<TestClass>.Of(srcObj).OrElse(unexpectedObj);
+            Assert.NotNull(ifObj);
+            Assert.NotEqual(unexpectedObj, ifObj);
+            Assert.NotEqual(unexpectedInt, ifObj.Integer);
+            Assert.Equal(expectedInt, ifObj.Integer);
+            Assert.Equal(srcObj, ifObj);
+            Assert.True(ReferenceEquals(srcObj, ifObj));
+        }
+
+        [Fact]
+        public void TestOptionalNotNullableIsPresent()
+        {
+            Assert.True(Optional<int>.Of(default(int)).IsPresent());
+            Assert.True(Optional<int>.Of(1).IsPresent());
+        }
+
+        [Fact]
+        public void TestOptionalNotNullableEmpty()
+        {
+            var empty = Optional<int>.Empty();
+            Assert.False(empty.IsPresent());
+            Assert.Equal(default(int), empty.Value);
+        }
+
+        [Fact]
+        public void TestOptionalNotNullableEquality()
+        {
+            var optional1 = Optional<int>.Of(1);
+            var optional1Equiv = Optional<int>.Of(1);
+            var optional1OfNullableEquiv = Optional<int>.OfNullable(1);
+            var optional2 = Optional<int>.Of(2);
+
+            Assert.Equal(optional1, optional1Equiv);
+            Assert.Equal(optional1.GetHashCode(), optional1Equiv.GetHashCode());
+            Assert.Equal(optional1, optional1OfNullableEquiv);
+            Assert.Equal(optional1.GetHashCode(), optional1OfNullableEquiv.GetHashCode());
+            Assert.NotEqual(optional1, optional2);
+
+            var empty1 = Optional<int>.Empty();
+            var empty2 = Optional<int>.Empty();
+            Assert.Equal(empty1, empty2);
+            Assert.Equal(empty1.Value, empty2.Value);
+            Assert.Equal(empty1.GetHashCode(), empty2.GetHashCode());
+        }
+
+        [Fact]
+        public void TestOptionalNotNullableOrElse()
+        {
+            const int defaultInt = default(int);
+            const int expectedInt = 1;
+            const int notExpectedInt = 2;
+            Assert.Equal(defaultInt, Optional<int>.Of(defaultInt).OrElse(notExpectedInt));
+            Assert.Equal(expectedInt, Optional<int>.Of(expectedInt).OrElse(notExpectedInt));
+            Assert.Equal(expectedInt, Optional<int>.Empty().OrElse(expectedInt));
+        }
+
+        private sealed class TestClass
+        {
+            private readonly int _i;
+
+            public TestClass(int i)
+            {
+                _i = i;
+            }
+
+            public int Integer
+            {
+                get { return _i; }
+            }
+
+            private bool Equals(TestClass other)
+            {
+                return _i == other._i;
+            }
+
+            public override bool Equals(object obj)
+            {
+                var that = obj as TestClass;
+                return that != null && Equals(that);
+            }
+
+            public override int GetHashCode()
+            {
+                return _i;
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Utilities/Optional.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Optional.cs
@@ -20,13 +20,19 @@ using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Utilities
 {
+    /// <summary>
+    /// A convenience class that indicates whether a variable is set or not.
+    /// The generic type T can either be of nullable or non-nullable type.
+    /// </summary>
     [Serializable]
     public sealed class Optional<T>
     {
+        private readonly bool _isSet = false;
         private readonly T _value;
 
         private Optional(T value)
         {
+            _isSet = true;
             _value = value;
         }
 
@@ -35,11 +41,21 @@ namespace Org.Apache.REEF.Utilities
             _value = default(T);
         }
 
+        /// <summary>
+        /// Gets the Value associated with the <see cref="Optional{T}"/> object.
+        /// If empty and <see cref="T"/> is nullable, the Value will return null.
+        /// If empty and <see cref="T"/> is non-nullable, the Value will return default(T).
+        /// </summary>
         public T Value 
         {
             get { return _value; }
         }
 
+        /// <summary>
+        /// Creates an <see cref="Optional{T}"/> with <see cref="Value"/> of parameter <see cref="value"/>.
+        /// If <see cref="T"/> is nullable and null is passed in, an <see cref="ArgumentNullException"/> will be thrown.
+        /// If <see cref="T"/> is non-nullable and default(T) is passed in, a non-empty <see cref="Optional{T}"/> object will be returned.
+        /// </summary>
         public static Optional<T> Of(T value)
         {
             if (value == null)
@@ -49,11 +65,19 @@ namespace Org.Apache.REEF.Utilities
             return new Optional<T>(value);
         }
 
+        /// <summary>
+        /// Creates an empty <see cref="Optional{T}"/>.
+        /// </summary>
         public static Optional<T> Empty()
         {
             return new Optional<T>();
         }
 
+        /// <summary>
+        /// Creates an <see cref="Optional{T}"/> with <see cref="Value"/> of parameter <see cref="value"/>.
+        /// If <see cref="T"/> is nullable and null is passed in, an empty <see cref="Optional{T}"/> will be returned.
+        /// If <see cref="T"/> is non-nullable and default(T) is passed in, a non-empty <see cref="Optional{T}"/> object will be returned.
+        /// </summary>
         public static Optional<T> OfNullable(T value)
         {
             if (value == null)
@@ -66,6 +90,9 @@ namespace Org.Apache.REEF.Utilities
             }
         }
 
+        /// <summary>
+        /// Returns <see cref="other"/> if the current <see cref="Optional{T}"/> is empty.
+        /// </summary>
         public T OrElse(T other)
         {
             if (IsPresent())
@@ -78,11 +105,20 @@ namespace Org.Apache.REEF.Utilities
             }
         }
 
+        /// <summary>
+        /// Returns true if the current <see cref="Optional{T}"/> is empty, false otherwise.
+        /// For nullable <see cref="T"/>, the <see cref="Optional{T}"/> is empty if <see cref="Value"/> is null.
+        /// For non-nullable <see cref="T"/>, the <see cref="Optional{T}"/> is empty if <see cref="Optional{T}"/> 
+        /// is created with <see cref="Empty"/>.
+        /// </summary>
         public bool IsPresent()
         {
-            return _value != null;
+            return _isSet && _value != null;
         }
 
+        /// <summary>
+        /// Tests the equality of the underlying <see cref="Value"/>.
+        /// </summary>
         public override bool Equals(object obj)
         {
             if (this == obj)
@@ -101,6 +137,10 @@ namespace Org.Apache.REEF.Utilities
             return true;
         }
 
+        /// <summary>
+        /// Gets the hashcode of the underlying <see cref="Value"/>.
+        /// </summary>
+        /// <returns></returns>
         public override int GetHashCode()
         {
             return _value != null ? _value.GetHashCode() : 0;


### PR DESCRIPTION
… Empty value

This addressed the issue by
  * Adding proper support for Non-Nullable types for Optional.
  * Adding documentation to the Optional class.
  * Adding tests to the Optional class for both Nullable and Non-Nullable types.

JIRA:
  [REEF-1351](https://issues.apache.org/jira/browse/REEF-1351)