### PR TITLE
[REEF-1339] Adding IInputPartition.Cache() for data download and cache

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartition.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartition.cs
@@ -144,11 +144,9 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
                     // For now, assume IFileDeSerializer is local.
                     return _fileSerializer.Deserialize(_localFiles.Value);
                 }
-                else
-                {
-                    // For now, assume IFileDeSerializer is remote.
-                    return _fileSerializer.Deserialize(_remoteFilePaths);
-                }
+
+                // For now, assume IFileDeSerializer is remote.
+                return _fileSerializer.Deserialize(_remoteFilePaths);
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/IFileDeSerializer.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/IFileDeSerializer.cs
@@ -42,7 +42,6 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         /// If there is any IO error, IOException could be thrown.
         /// </summary>
         /// <param name="filePaths"></param>
-        /// <param name="local"></param>
         /// <returns></returns>
         T Deserialize(ISet<string> filePaths);
     }

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/IInputPartition.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/IInputPartition.cs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System;
+using Org.Apache.REEF.Utilities.Attributes;
 
 namespace Org.Apache.REEF.IO.PartitionedData
 {
@@ -24,12 +24,18 @@ namespace Org.Apache.REEF.IO.PartitionedData
     /// </summary>
     /// <typeparam name="T">Generic Type representing data pointer.
     /// For example, for data in local file it can be file pointer </typeparam>
-    public interface IInputPartition<T> 
+    public interface IInputPartition<T>
     {
         /// <summary>
         /// The id of the partition.
         /// </summary>
         string Id { get; }
+
+        /// <summary>
+        /// Caches the data locally, cached location is based on the implementation.
+        /// </summary>
+        [Unstable("0.14", "Contract may change.")]
+        void Cache();
 
         /// <summary>
         /// Gives a pointer to the underlying partition.


### PR DESCRIPTION
This addressed the issue by
  * Adding an unstable Cache function.
  * Modify existing implementations of IInputPartition to allow them to cache only on invocation of Cache instead of on initialization.

JIRA:
  [REEF-1339](https://issues.apache.org/jira/browse/REEF-1339)