### PR TITLE
[REEF-1362] Deprecate DriverBridgeConfigurationOptions.SetOfAssemblies

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfigurationOptions.cs
@@ -165,6 +165,7 @@ namespace Org.Apache.REEF.Driver.Bridge
         }
 
         [NamedParameter]
+        [Obsolete("Deprecated in 0.15, will be removed.")]
         public class SetOfAssemblies : Name<ISet<string>>
         {
         }

--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
@@ -71,13 +71,8 @@ namespace Org.Apache.REEF.Examples.AllHandlers
                 .Set(DriverConfiguration.OnDriverRestartTaskRunning, GenericType<HelloDriverRestartRunningTaskHandler>.Class)
                 .Build();
 
-            var driverConfig = TangFactory.GetTang().NewConfigurationBuilder(helloDriverConfiguration)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(HelloTask).Assembly.GetName().Name)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
-                .Build();
-
             var helloJobSubmission = _jobRequestBuilder
-                .AddDriverConfiguration(driverConfig)
+                .AddDriverConfiguration(helloDriverConfiguration)
                 .AddGlobalAssemblyForType(typeof(HelloDriverStartHandler))
                 .SetJobIdentifier("HelloDriver")
                 .Build();

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/BroadcastAndReduceClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/BroadcastAndReduceClient.cs
@@ -81,13 +81,6 @@ namespace Org.Apache.REEF.Network.Examples.Client
 
             IConfiguration merged = Configurations.Merge(driverConfig, groupCommDriverConfig);
 
-            IConfiguration taskConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(MasterTask).Assembly.GetName().Name)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
-                .Build();
-
-            merged = Configurations.Merge(merged, taskConfig);
-
             string runPlatform = runOnYarn ? "yarn" : "local";
             TestRun(merged, typeof(BroadcastReduceDriver), numTasks, "BroadcastReduceDriver", runPlatform);
         }

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/PipelineBroadcastAndReduceClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/PipelineBroadcastAndReduceClient.cs
@@ -72,14 +72,6 @@ namespace Org.Apache.REEF.Network.Examples.Client
 
             IConfiguration merged = Configurations.Merge(driverConfig, groupCommDriverConfig);
 
-            IConfiguration taskConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(PipelinedMasterTask).Assembly.GetName().Name)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(PipelinedSlaveTask).Assembly.GetName().Name)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
-                .Build();
-
-            merged = Configurations.Merge(merged, taskConfig);
-
             string runPlatform = runOnYarn ? "yarn" : "local";
             BroadcastAndReduceClient.TestRun(merged, typeof(PipelinedBroadcastReduceDriver), numTasks, "PipelinedBroadcastReduceDriver", runPlatform);
         }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
@@ -50,16 +50,12 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             CleanUp(testFolder);
         }
 
-        public IConfiguration DriverConfigurations()
+        private IConfiguration DriverConfigurations()
         {
-            var driverConfig = DriverConfiguration.ConfigurationModule
+            return DriverConfiguration.ConfigurationModule
                 .Set(DriverConfiguration.OnDriverStarted, GenericType<FailedTaskDriver>.Class)
                 .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<FailedTaskDriver>.Class)
                 .Set(DriverConfiguration.OnTaskFailed, GenericType<FailedTaskDriver>.Class)
-                .Build();
-
-            return TangFactory.GetTang().NewConfigurationBuilder(driverConfig)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(FailTask).Assembly.GetName().Name)
                 .Build();
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
@@ -48,7 +48,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             CleanUp(testFolder);
         }
 
-        public IConfiguration DriverConfigurations()
+        private IConfiguration DriverConfigurations()
         {
             var helloDriverConfiguration = REEF.Driver.DriverConfiguration.ConfigurationModule
                 .Set(REEF.Driver.DriverConfiguration.OnDriverStarted, GenericType<HelloSimpleEventHandlers>.Class)
@@ -67,8 +67,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
                 .Build();
 
             return TangFactory.GetTang().NewConfigurationBuilder(helloDriverConfiguration)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(HelloTask).Assembly.GetName().Name)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
                 .BindNamedParameter<IsRetain, bool>(GenericType<IsRetain>.Class, "false")
                 .BindNamedParameter<NumberOfEvaluators, int>(GenericType<NumberOfEvaluators>.Class, "1")
                 .Build();

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/BroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/BroadcastReduceTest.cs
@@ -58,7 +58,7 @@ namespace Org.Apache.REEF.Tests.Functional.Group
             TestRun(DriverConfigurations(numTasks), typeof(BroadcastReduceDriver), numTasks, "BroadcastReduceDriver", runPlatform, testFolder);
         }
 
-        public IConfiguration DriverConfigurations(int numTasks)
+        private IConfiguration DriverConfigurations(int numTasks)
         {
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
                 DriverConfiguration.ConfigurationModule
@@ -84,14 +84,7 @@ namespace Org.Apache.REEF.Tests.Functional.Group
                 .BindIntNamedParam<GroupCommConfigurationOptions.NumberOfTasks>(numTasks.ToString(CultureInfo.InvariantCulture))
                 .Build();
 
-            IConfiguration merged = Configurations.Merge(driverConfig, groupCommDriverConfig);
-
-            IConfiguration taskConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(MasterTask).Assembly.GetName().Name)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
-                .Build();
-
-            return Configurations.Merge(merged, taskConfig);
+            return Configurations.Merge(driverConfig, groupCommDriverConfig);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/PipelinedBroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/PipelinedBroadcastReduceTest.cs
@@ -58,7 +58,7 @@ namespace Org.Apache.REEF.Tests.Functional.Group
             TestRun(DriverConfigurations(numTasks), typeof(PipelinedBroadcastReduceDriver), numTasks, "PipelinedBroadcastReduceDriver", runPlatform, testFolder);
         }
 
-        public IConfiguration DriverConfigurations(int numTasks)
+        private IConfiguration DriverConfigurations(int numTasks)
         {
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
                 DriverConfiguration.ConfigurationModule
@@ -87,14 +87,7 @@ namespace Org.Apache.REEF.Tests.Functional.Group
                 .BindIntNamedParam<GroupCommConfigurationOptions.NumberOfTasks>(numTasks.ToString(CultureInfo.InvariantCulture))
                 .Build();
 
-            IConfiguration merged = Configurations.Merge(driverConfig, groupCommDriverConfig);
-
-            IConfiguration taskConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(PipelinedMasterTask).Assembly.GetName().Name)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
-                .Build();
-
-            return Configurations.Merge(merged, taskConfig);
+            return Configurations.Merge(driverConfig, groupCommDriverConfig);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
@@ -58,7 +58,7 @@ namespace Org.Apache.REEF.Tests.Functional.Group
             TestRun(DriverConfigurations(numTasks), typeof(ScatterReduceDriver), numTasks, "ScatterReduceDriver", runPlatform, testFolder);
         }
 
-        public IConfiguration DriverConfigurations(int numTasks)
+        private IConfiguration DriverConfigurations(int numTasks)
         {
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
                DriverConfiguration.ConfigurationModule
@@ -81,14 +81,7 @@ namespace Org.Apache.REEF.Tests.Functional.Group
                .BindIntNamedParam<GroupCommConfigurationOptions.NumberOfTasks>(numTasks.ToString())
                .Build();
 
-            IConfiguration merged = Configurations.Merge(driverConfig, groupCommDriverConfig);
-
-            IConfiguration taskConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(MasterTask).Assembly.GetName().Name)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
-                .Build();
-
-            return Configurations.Merge(merged, taskConfig);
+            return Configurations.Merge(driverConfig, groupCommDriverConfig);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
@@ -158,14 +158,7 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
                 .BindIntNamedParam<GroupCommConfigurationOptions.NumberOfTasks>(totalEvaluators.ToString())
                 .Build();
 
-            IConfiguration merged = Configurations.Merge(driverConfig, groupCommunicationDriverConfig);
-
-            IConfiguration taskConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(KMeansMasterTask).Assembly.GetName().Name)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
-                .Build();
-
-            return Configurations.Merge(merged, taskConfig);
+            return Configurations.Merge(driverConfig, groupCommunicationDriverConfig);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/TestTaskMessage.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/TestTaskMessage.cs
@@ -63,9 +63,9 @@ namespace Org.Apache.REEF.Tests.Functional.Messaging
             CleanUp(testFolder);
         }
 
-        public IConfiguration DriverConfigurations()
+        private IConfiguration DriverConfigurations()
         {
-            IConfiguration driverConfig = DriverConfiguration.ConfigurationModule
+            return DriverConfiguration.ConfigurationModule
             .Set(DriverConfiguration.OnDriverStarted, GenericType<MessageDriver>.Class)
             .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<MessageDriver>.Class)
             .Set(DriverConfiguration.OnTaskMessage, GenericType<MessageDriver>.Class)
@@ -73,13 +73,6 @@ namespace Org.Apache.REEF.Tests.Functional.Messaging
             .Set(DriverConfiguration.CustomTraceListeners, GenericType<DefaultCustomTraceListener>.Class)
             .Set(DriverConfiguration.CustomTraceLevel, Level.Info.ToString())
             .Build();
-
-            IConfiguration taskConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(MessageTask).Assembly.GetName().Name)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
-                .Build();
-
-            return Configurations.Merge(driverConfig, taskConfig);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTest.cs
@@ -99,23 +99,16 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
             CleanUp(testFolder);
         }
 
-        public IConfiguration DriverConfigurationsWithEvaluatorRequest<T>(GenericType<T> type) 
+        private IConfiguration DriverConfigurationsWithEvaluatorRequest<T>(GenericType<T> type)
             where T : IObserver<IAllocatedEvaluator>, IObserver<IDriverStarted>, IObserver<IRunningTask>
         {
-            IConfiguration driverConfig = DriverConfiguration.ConfigurationModule
+            return DriverConfiguration.ConfigurationModule
                 .Set(DriverConfiguration.OnDriverStarted, type)
                 .Set(DriverConfiguration.OnEvaluatorAllocated, type)
                 .Set(DriverConfiguration.OnTaskRunning, type)
                 .Set(DriverConfiguration.CustomTraceListeners, GenericType<DefaultCustomTraceListener>.Class)
                 .Set(DriverConfiguration.CustomTraceLevel, Level.Info.ToString())
                 .Build();
-
-            IConfiguration taskConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(RuntimeNameTask).Assembly.GetName().Name)
-                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
-                .Build();
-
-            return Configurations.Merge(driverConfig, taskConfig);
         }
     }
 }


### PR DESCRIPTION
This change
 * marks DriverBridgeConfigurationOptions.SetOfAssemblies as deprecated
 * removes its uses from tests and examples

JIRA:
  [REEF-1362](https://issues.apache.org/jira/browse/REEF-1362)

Pull request:
  This closes #