### PR TITLE
[REEF-1361] IFileDeSerializer does not have a Dispose function

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileInputPartitionTest.cs
+++ b/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileInputPartitionTest.cs
@@ -163,5 +163,12 @@ namespace Org.Apache.REEF.IO.TestClient
                 }
             }
         }
+
+        /// <summary>
+        /// Dispose logic for the class. In this case does nothing
+        /// </summary>
+        public void Dispose()
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
@@ -331,6 +331,13 @@ namespace Org.Apache.REEF.IO.Tests
                 }
             }
         }
+
+        /// <summary>
+        /// Dispose logic for the class. In this case does nothing
+        /// </summary>
+        public void Dispose()
+        {
+        }
     }
 
     public class Row
@@ -373,6 +380,13 @@ namespace Org.Apache.REEF.IO.Tests
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Dispose logic for the class. In this case does nothing
+        /// </summary>
+        public void Dispose()
+        {
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartition.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemInputPartition.cs
@@ -144,6 +144,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         /// </summary>
         public void Dispose()
         {
+            _fileSerializer.Dispose();
             if (_localFiles.Count > 0)
             {
                 foreach (var fileName in _localFiles)

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/IFileDeSerializer.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/IFileDeSerializer.cs
@@ -23,7 +23,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
     /// A interface for user to implement its deserializer.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public interface IFileDeSerializer<T>
+    public interface IFileDeSerializer<T> : IDisposable
     {
         /// <summary>
         /// The input is a set of file paths. 


### PR DESCRIPTION
This addressed the issue by
  * Making IFileDeSerializer inherit the IDisposable interface
  * Introducing this function in existing IFileDeSerializer implementations.

JIRA:
  [REEF-1361](https://issues.apache.org/jira/browse/REEF-1361)