### PR TITLE
[REEF-1305] Moving the communication group creation before submitting…

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -288,30 +288,31 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             //// The lock might be move to IFailedEvaluator handler when working on REEF-1251
             lock (_lock)
             {
-                if (value.FailedContexts == null)
+                if (value.FailedContexts != null && value.FailedContexts.Count > 0)
                 {
-                    Exceptions.Throw(new SystemException("There is no context attached with failed evaluator."), Logger);
-                }
-                else if (value.FailedContexts.Count == 1)
-                {
-                    var failedContextId = value.FailedContexts[0].Id;
-                    if (!_activeContexts.ContainsKey(failedContextId))
+                    if (value.FailedContexts.Count == 1)
                     {
-                        var msg = string.Format(CultureInfo.InvariantCulture,
-                       "The active context [{0}] attached in IFailedEvaluator [{1}] is not in the _activeContexts", failedContextId, value.Id);
-                        Exceptions.Throw(new SystemException(msg), Logger);
+                        var failedContextId = value.FailedContexts[0].Id;
+                        if (!_activeContexts.ContainsKey(failedContextId))
+                        {
+                            var msg = string.Format(CultureInfo.InvariantCulture,
+                                "The active context [{0}] attached in IFailedEvaluator [{1}] is not in the Active Contexts collection.",
+                                failedContextId,
+                                value.Id);
+                            Exceptions.Throw(new SystemException(msg), Logger);
+                        }
+                        else
+                        {
+                            _activeContexts.Remove(failedContextId);
+                        }
                     }
                     else
                     {
-                        _activeContexts.Remove(value.FailedContexts[0].Id);
+                        var msg = string.Format(CultureInfo.InvariantCulture,
+                            "There are [{0}] contexts attached in the failed evaluator. Expected number is 1.",
+                            value.FailedContexts.Count);
+                        Exceptions.Throw(new IMRUSystemException(msg), Logger);
                     }
-                }
-                else
-                {
-                    var msg = string.Format(CultureInfo.InvariantCulture,
-                        "There are [{0}] contexts attached in the failed evaluator. Expected number is 1.",
-                        value.FailedContexts.Count);
-                    Exceptions.Throw(new IMRUSystemException(msg), Logger);
                 }
             }
         }


### PR DESCRIPTION
… tasks and decouple evaluator/context requests from task creation in IMRU driver

This PR refactor IMRUDriver little bit to prepare for tolerant. It mainly
Moved the communication group creation before submitting tasks
Decoupled evaluator/context requests from task creation

JIRA: [REEF-1305](https://issues.apache.org/jira/browse/REEF-1305)
This closes