### PR TITLE
[REEF-1367] REEF c# does not write PID for Evaluators

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Files/REEFFileNames.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Files/REEFFileNames.cs
@@ -60,6 +60,7 @@ namespace Org.Apache.REEF.Common.Files
         private const string YARN_DRIVER_STDOUT_PATH = YARN_DEFAULT_DRIVER_OUT_VAR + "/driver.stdout";
         private const string YARN_DRIVER_STDERR_PATH = YARN_DEFAULT_DRIVER_OUT_VAR + "/driver.stderr";
         private const string DRIVER_COMMAND_LOGGING_CONFIG = "1> <LOG_DIR>/driver.stdout 2> <LOG_DIR>/driver.stderr";
+        private const string PID_FILE_NAME = "PID.txt";
 
         [Inject]
         public REEFFileNames()
@@ -323,6 +324,15 @@ namespace Org.Apache.REEF.Common.Files
         public string GetSecurityTokenPasswordFileName()
         {
             return SECURITY_TOKEN_PASSWORD_FILE;
+        }
+
+        /// <summary>
+        /// The file name of the PID file created in the current working directory of the process.
+        /// This is similar to the file name in the PIDStoreHandler.java
+        /// </summary>
+        public string GetPidFileName()
+        {
+            return PID_FILE_NAME;
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -153,6 +153,7 @@ under the License.
     <Compile Include="Runtime\Evaluator\IHeartBeatManager.cs" />
     <Compile Include="Runtime\Evaluator\Parameters\EvaluatorHeartbeatPeriodInMs.cs" />
     <Compile Include="Runtime\Evaluator\Parameters\HeartbeatMaxRetry.cs" />
+    <Compile Include="Runtime\Evaluator\PIDStoreHandler.cs" />
     <Compile Include="Runtime\Evaluator\ReefMessageProtoObserver.cs" />
     <Compile Include="Runtime\Evaluator\Task\CloseEventImpl.cs" />
     <Compile Include="Runtime\Evaluator\Task\DriverMessageImpl.cs" />

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
@@ -155,7 +155,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
             {
                 try
                 {
-                    Logger.Log(Level.Error, "Runtime start");
+                    Logger.Log(Level.Info, "Runtime start");
                     _pidStoreHelper.WritePID();
                     if (_state != State.INIT)
                     {

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
@@ -39,10 +39,13 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
 
         private State _state = State.INIT;
 
+        private PIDStoreHandler _pidStoreHelper;
+
         [Inject]
         public EvaluatorRuntime(
             ContextManager contextManager,
-            IHeartBeatManager heartBeatManager)
+            IHeartBeatManager heartBeatManager,
+            PIDStoreHandler pidStoreHelper)
         {
             using (Logger.LogFunction("EvaluatorRuntime::EvaluatorRuntime"))
             {
@@ -50,6 +53,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                 _clock = _heartBeatManager.EvaluatorSettings.RuntimeClock;
                 _contextManager = contextManager;
                 _evaluatorId = _heartBeatManager.EvaluatorSettings.EvalutorId;
+                _pidStoreHelper = pidStoreHelper;
                 var remoteManager = _heartBeatManager.EvaluatorSettings.RemoteManager;
 
                 ReefMessageProtoObserver driverObserver = new ReefMessageProtoObserver();
@@ -151,7 +155,8 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
             {
                 try
                 {
-                    Logger.Log(Level.Info, "Runtime start");
+                    Logger.Log(Level.Error, "Runtime start");
+                    _pidStoreHelper.WritePID();
                     if (_state != State.INIT)
                     {
                         var e = new InvalidOperationException("State should be init.");

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/PIDStoreHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/PIDStoreHandler.cs
@@ -28,7 +28,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
     /// <summary>
     /// A PID store handler for c# evaluator
     /// </summary>
-    public sealed class PIDStoreHandler
+    internal sealed class PIDStoreHandler
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(PIDStoreHandler));
 
@@ -47,7 +47,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
         /// <summary>
         /// Writes PID to the runtime folder
         /// </summary>
-        public void WritePID()
+        internal void WritePID()
         {
             lock (lockObject)
             {

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/PIDStoreHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/PIDStoreHandler.cs
@@ -32,11 +32,11 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(PIDStoreHandler));
 
+        private readonly object _lockObject = new object();
+
+        private readonly REEFFileNames _reefFileNames;
+
         private bool _pidIsWritten = false;
-
-        private object lockObject = new object();
-
-        private REEFFileNames _reefFileNames;
 
         [Inject]
         private PIDStoreHandler(REEFFileNames reefFileNames)
@@ -49,7 +49,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
         /// </summary>
         internal void WritePID()
         {
-            lock (lockObject)
+            lock (_lockObject)
             {
                 if (!_pidIsWritten)
                 {
@@ -68,9 +68,9 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                         Logger.Log(Level.Verbose, "Writing PID {0} to file {1}", pid, path);
                         _pidIsWritten = true;
                     }
-                    catch (Exception e)
+                    catch (IOException e)
                     {
-                        Logger.Log(Level.Error, "Failed writing PID with exception {0}", e);                        
+                        Utilities.Diagnostics.Exceptions.Caught(e, Level.Error, Logger);
                     }
                 }
             }

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/PIDStoreHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/PIDStoreHandler.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Diagnostics;
+using System.IO;
+
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities.Logging;
+
+namespace Org.Apache.REEF.Common.Runtime.Evaluator
+{
+    /// <summary>
+    /// A PID store handler for c# evaluator
+    /// </summary>
+    public sealed class PIDStoreHandler
+    {
+        private static readonly Logger Logger = Logger.GetLogger(typeof(PIDStoreHandler));
+
+        /// <summary>
+        /// The file name of the PID file created in the current working directory of the process.
+        /// This is similar to the file name in teh PIDStoreHandler.java
+        /// </summary>
+        public const string PidFileName = "PID.txt";
+
+        private bool _pidIsWritten = false;
+
+        [Inject]
+        private PIDStoreHandler()
+        {
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void WritePID()
+        {
+            lock (this)
+            {
+                if (!_pidIsWritten)
+                {
+                    string currentDirectory = Directory.GetCurrentDirectory();
+                    string path = currentDirectory + @"\" + PidFileName;
+                    var pid = Process.GetCurrentProcess().Id;
+                    using (StreamWriter sw = File.CreateText(path))
+                    {
+                        sw.WriteLine(pid);
+                        sw.Flush();
+                    }
+
+                    Logger.Log(Level.Error, "Writing PID {0} to file {1}", pid, path);
+                    _pidIsWritten = true;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
 This addresses the issue by adding PIDStoreHandler to the c# .NET and using it from EvaluatorRuntime.cs
JIRA:
[REEF-1367](https://issues.apache.org/jira/browse/REEF-1367)