### PR TITLE
[REEF-1368] Mark `RuntimeClock.RegisterObserver` as `[Obsolete]`

### DIFF
--- a/lang/cs/Org.Apache.REEF.Wake/Time/Runtime/RuntimeClock.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Runtime/RuntimeClock.cs
@@ -135,6 +135,7 @@ namespace Org.Apache.REEF.Wake.Time.Runtime
         /// Register the IObserver for the particular Time event.
         /// </summary>
         /// <param name="observer">The handler to register</param>
+        [Obsolete("Will be removed in REEF 0.16")]
         public void RegisterObserver<U>(IObserver<U> observer) where U : Time
         {
             if (_disposed)


### PR DESCRIPTION
JIRA:
  [REEF-1368](https://issues.apache.org/jira/browse/REEF-1368)

Pull Request:
  This closes #