### PR TITLE
[REEF-1364] C# Evaluator should attempt to send a failure message bac…

### DIFF
--- a/lang/cs/App.config
+++ b/lang/cs/App.config
@@ -28,5 +28,6 @@ under the License.
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
+    <ThrowUnobservedTaskExceptions enabled="true"/>
   </runtime>
 </configuration>

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
@@ -66,14 +66,14 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                 _evaluatorControlChannel = remoteManager.RegisterObserver(driverObserver);
 
                 AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionHandler;
-                TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
+                TaskScheduler.UnobservedTaskException += UnobservedTaskException;
 
                 // start the heart beat
                 _clock.ScheduleAlarm(0, _heartBeatManager);
             }
         }
 
-        void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+        private void UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
         {
             OnException(e.Exception);
         }

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Globalization;
+using System.Threading.Tasks;
 using Org.Apache.REEF.Common.Protobuf.ReefProtocol;
 using Org.Apache.REEF.Common.Runtime.Evaluator.Context;
 using Org.Apache.REEF.Tang.Annotations;
@@ -64,9 +65,17 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                 // register the driver observer
                 _evaluatorControlChannel = remoteManager.RegisterObserver(driverObserver);
 
+                AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionHandler;
+                TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
+
                 // start the heart beat
                 _clock.ScheduleAlarm(0, _heartBeatManager);
             }
+        }
+
+        void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+        {
+            OnException(e.Exception);
         }
 
         public State State
@@ -239,6 +248,11 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                 _heartBeatManager.OnNext(evaluatorStatusProto);
                 _contextManager.Dispose();
             }
+        }
+
+        private void UnhandledExceptionHandler(object sender, UnhandledExceptionEventArgs e)
+        {
+            OnException((Exception)e.ExceptionObject);
         }
 
         public void OnError(Exception error)

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
@@ -129,18 +129,20 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                                 "Task running result:\r\n" + System.Text.Encoding.Default.GetString(result));
                         }
                     }
-                    catch (Exception)
-                    {
-                        // TODO[JIRA REEF-1364]: Properly handle Exceptions and send a message to the Driver.
-                        Logger.Log(Level.Error, "Received uncaught System Exception, force shutting down the Evaluator.");
-
-                        Environment.Exit(1);
-                    }
                     finally
                     {
-                        if (_userTask != null)
+                        try
                         {
-                            _userTask.Dispose();
+                            if (_userTask != null)
+                            {
+                                _userTask.Dispose();
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            Utilities.Diagnostics.Exceptions.Caught(
+                                e, Level.Error, 
+                                "User's ITask.Dispose() threw an Exception. Ignoring as the Task has already completed." , Logger);
                         }
 
                         runTask.Dispose();

--- a/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
@@ -22,6 +22,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Org.Apache.REEF.Common.Runtime.Evaluator;
 using Org.Apache.REEF.Common.Runtime.Evaluator.Utils;
 using Org.Apache.REEF.Driver.Bridge;
@@ -64,6 +65,9 @@ namespace Org.Apache.REEF.Evaluator
         {
             try
             {
+                AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionHandler;
+                TaskScheduler.UnobservedTaskException += UnobservedTaskException;
+
                 if (args.Count() != 1)
                 {
                     var e = new InvalidOperationException("Must supply only the evaluator.config file!");
@@ -74,7 +78,6 @@ namespace Org.Apache.REEF.Evaluator
                 {
                     AttachDebugger();
                 }
-                AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionHandler;
 
                 var fullEvaluatorConfiguration = ReadEvaluatorConfiguration(args[0]);
                 var injector = TangFactory.GetTang().NewInjector(fullEvaluatorConfiguration);
@@ -165,6 +168,11 @@ namespace Org.Apache.REEF.Evaluator
         private static void UnhandledExceptionHandler(object sender, UnhandledExceptionEventArgs e)
         {
             Fail((Exception)e.ExceptionObject);
+        }
+
+        private static void UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+        {
+            Fail(e.Exception);
         }
 
         private static void Fail(Exception ex)


### PR DESCRIPTION
…k to the Driver on an unhandled Exception

This addressed the issue by
  * Use TaskScheduler.UnobservedTaskException and AppDomain.CurrentDomain.UnhandledException to Dispose EvaluatorRuntime on unhandled Exceptions.

JIRA:
  [REEF-1364](https://issues.apache.org/jira/browse/REEF-1364)