### PR TITLE
[REEF-1372] Create new named parameters for IClock

### DIFF
--- a/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
@@ -31,6 +31,7 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Utilities.Logging;
 using Org.Apache.REEF.Wake.Time;
+using Org.Apache.REEF.Wake.Time.Parameters;
 using Org.Apache.REEF.Wake.Time.Runtime;
 using Org.Apache.REEF.Wake.Time.Runtime.Event;
 
@@ -81,8 +82,8 @@ namespace Org.Apache.REEF.Evaluator
                 var serializer = injector.GetInstance<AvroConfigurationSerializer>();
                 var rootEvaluatorConfiguration = 
                     TangFactory.GetTang().NewConfigurationBuilder(serializer.FromString(injector.GetNamedInstance<EvaluatorConfiguration, string>()))
-                        .BindSetEntry<IClock.RuntimeStartHandler, EvaluatorRuntime, IObserver<RuntimeStart>>()
-                        .BindSetEntry<IClock.RuntimeStopHandler, EvaluatorRuntime, IObserver<RuntimeStop>>()
+                        .BindSetEntry<RuntimeStartHandler, EvaluatorRuntime, IObserver<RuntimeStart>>()
+                        .BindSetEntry<RuntimeStopHandler, EvaluatorRuntime, IObserver<RuntimeStop>>()
                         .Build();
                 var evaluator = injector.ForkInjector(rootEvaluatorConfiguration).GetInstance<Evaluator>();
 

--- a/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
@@ -154,6 +154,11 @@ under the License.
     <Compile Include="Time\Event\StartTime.cs" />
     <Compile Include="Time\Event\StopTime.cs" />
     <Compile Include="Time\IClock.cs" />
+    <Compile Include="Time\Parameters\IdleHandler.cs" />
+    <Compile Include="Time\Parameters\RuntimeStartHandler.cs" />
+    <Compile Include="Time\Parameters\RuntimeStopHandler.cs" />
+    <Compile Include="Time\Parameters\StartHandler.cs" />
+    <Compile Include="Time\Parameters\StopHandler.cs" />
     <Compile Include="Time\Runtime\Event\ClientAlarm.cs" />
     <Compile Include="Time\Runtime\Event\IdleClock.cs" />
     <Compile Include="Time\Runtime\Event\RuntimeAlarm.cs" />

--- a/lang/cs/Org.Apache.REEF.Wake/Time/IClock.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/IClock.cs
@@ -55,7 +55,8 @@ namespace Org.Apache.REEF.Wake.Time
         /// <summary>
         /// Bind this to an event handler to statically subscribe to the StartTime Event
         /// </summary>
-        [NamedParameter(documentation: "Will be called upon the start even", defaultClass: typeof(MissingStartHandlerHandler))]
+        [Obsolete("Will be removed in 0.16. See [REEF-1069]")]
+        [NamedParameter(documentation: "Will be called upon the start event")]
         public class StartHandler : Name<ISet<IObserver<StartTime>>>
         {
         }
@@ -63,7 +64,8 @@ namespace Org.Apache.REEF.Wake.Time
         /// <summary>
         /// Bind this to an event handler to statically subscribe to the StopTime Event
         /// </summary>
-        [NamedParameter(documentation: "Will be called upon the stop event", defaultClass: typeof(LoggingEventHandler<StopTime>))]
+        [Obsolete("Will be removed in 0.16. See [REEF-1069]")]
+        [NamedParameter(documentation: "Will be called upon the stop event")]
         public class StopHandler : Name<ISet<IObserver<StopTime>>>
         {
         }
@@ -71,7 +73,8 @@ namespace Org.Apache.REEF.Wake.Time
         /// <summary>
         /// Bind this to an event handler to statically subscribe to the RuntimeStart Event
         /// </summary>
-        [NamedParameter(documentation: "Will be called upon the runtime start event", defaultClass: typeof(LoggingEventHandler<RuntimeStart>))]
+        [Obsolete("Will be removed in 0.16. See [REEF-1069]")]
+        [NamedParameter(documentation: "Will be called upon the runtime start event")]
         public class RuntimeStartHandler : Name<ISet<IObserver<RuntimeStart>>>
         {
         }
@@ -79,7 +82,8 @@ namespace Org.Apache.REEF.Wake.Time
         /// <summary>
         /// Bind this to an event handler to statically subscribe to the RuntimeStop Event
         /// </summary>
-        [NamedParameter(documentation: "Will be called upon the runtime stop event", defaultClass: typeof(LoggingEventHandler<RuntimeStop>))]
+        [Obsolete("Will be removed in 0.16. See [REEF-1069]")]
+        [NamedParameter(documentation: "Will be called upon the runtime stop event")]
         public class RuntimeStopHandler : Name<ISet<IObserver<RuntimeStop>>>
         {
         }
@@ -87,7 +91,8 @@ namespace Org.Apache.REEF.Wake.Time
         /// <summary>
         /// Bind this to an event handler to statically subscribe to the IdleClock Event
         /// </summary>
-        [NamedParameter(documentation: "Will be called upon the Idle event", defaultClass: typeof(LoggingEventHandler<IdleClock>))]
+        [Obsolete("Will be removed in 0.16. See [REEF-1069]")]
+        [NamedParameter(documentation: "Will be called upon the Idle event")]
         public class IdleHandler : Name<ISet<IObserver<IdleClock>>>
         {
         }

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/IdleHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/IdleHandler.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Impl;
+using Org.Apache.REEF.Wake.Time.Runtime.Event;
+
+namespace Org.Apache.REEF.Wake.Time.Parameters
+{
+    /// <summary>
+    /// Bind this to an event handler to statically subscribe to the IdleClock Event
+    /// </summary>
+    [NamedParameter(documentation: "Will be called upon the Idle event", defaultClass: typeof(LoggingEventHandler<IdleClock>))]
+    public sealed class IdleHandler : Name<ISet<IObserver<IdleClock>>>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/IdleHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/IdleHandler.cs
@@ -29,5 +29,9 @@ namespace Org.Apache.REEF.Wake.Time.Parameters
     [NamedParameter(documentation: "Will be called upon the Idle event", defaultClass: typeof(LoggingEventHandler<IdleClock>))]
     public sealed class IdleHandler : Name<ISet<IObserver<IdleClock>>>
     {
+        // This class is a named parameter and shall never be instantiated.
+        private IdleHandler()
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/RuntimeStartHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/RuntimeStartHandler.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Impl;
+using Org.Apache.REEF.Wake.Time.Runtime.Event;
+
+namespace Org.Apache.REEF.Wake.Time.Parameters
+{
+    /// <summary>
+    /// Bind this to an event handler to statically subscribe to the RuntimeStart Event
+    /// </summary>
+    [NamedParameter(documentation: "Will be called upon the runtime start event", defaultClass: typeof(LoggingEventHandler<RuntimeStart>))]
+    public sealed class RuntimeStartHandler : Name<ISet<IObserver<RuntimeStart>>>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/RuntimeStartHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/RuntimeStartHandler.cs
@@ -29,5 +29,9 @@ namespace Org.Apache.REEF.Wake.Time.Parameters
     [NamedParameter(documentation: "Will be called upon the runtime start event", defaultClass: typeof(LoggingEventHandler<RuntimeStart>))]
     public sealed class RuntimeStartHandler : Name<ISet<IObserver<RuntimeStart>>>
     {
+        // This class is a named parameter and shall never be instantiated.
+        private RuntimeStartHandler()
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/RuntimeStopHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/RuntimeStopHandler.cs
@@ -29,5 +29,9 @@ namespace Org.Apache.REEF.Wake.Time.Parameters
     [NamedParameter(documentation: "Will be called upon the runtime stop event", defaultClass: typeof(LoggingEventHandler<RuntimeStop>))]
     public sealed class RuntimeStopHandler : Name<ISet<IObserver<RuntimeStop>>>
     {
+        // This class is a named parameter and shall never be instantiated.
+        private RuntimeStopHandler()
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/RuntimeStopHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/RuntimeStopHandler.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Impl;
+using Org.Apache.REEF.Wake.Time.Runtime.Event;
+
+namespace Org.Apache.REEF.Wake.Time.Parameters
+{
+    /// <summary>
+    /// Bind this to an event handler to statically subscribe to the RuntimeStop Event
+    /// </summary>
+    [NamedParameter(documentation: "Will be called upon the runtime stop event", defaultClass: typeof(LoggingEventHandler<RuntimeStop>))]
+    public sealed class RuntimeStopHandler : Name<ISet<IObserver<RuntimeStop>>>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/StartHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/StartHandler.cs
@@ -29,5 +29,9 @@ namespace Org.Apache.REEF.Wake.Time.Parameters
     [NamedParameter(documentation: "Will be called upon the start event", defaultClass: typeof(MissingStartHandlerHandler))]
     public sealed class StartHandler : Name<ISet<IObserver<StartTime>>>
     {
+        // This class is a named parameter and shall never be instantiated.
+        private StartHandler()
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/StartHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/StartHandler.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Impl;
+using Org.Apache.REEF.Wake.Time.Event;
+
+namespace Org.Apache.REEF.Wake.Time.Parameters
+{
+    /// <summary>
+    /// Bind this to an event handler to statically subscribe to the StartTime Event
+    /// </summary>
+    [NamedParameter(documentation: "Will be called upon the start event", defaultClass: typeof(MissingStartHandlerHandler))]
+    public sealed class StartHandler : Name<ISet<IObserver<StartTime>>>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/StopHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/StopHandler.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Impl;
+using Org.Apache.REEF.Wake.Time.Event;
+
+namespace Org.Apache.REEF.Wake.Time.Parameters
+{
+    /// <summary>
+    /// Bind this to an event handler to statically subscribe to the StopTime Event
+    /// </summary>
+    [NamedParameter("Will be called upon the stop event", defaultClass: typeof(LoggingEventHandler<StopTime>))]
+    public sealed class StopHandler : Name<ISet<IObserver<StopTime>>>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/StopHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Parameters/StopHandler.cs
@@ -29,5 +29,9 @@ namespace Org.Apache.REEF.Wake.Time.Parameters
     [NamedParameter("Will be called upon the stop event", defaultClass: typeof(LoggingEventHandler<StopTime>))]
     public sealed class StopHandler : Name<ISet<IObserver<StopTime>>>
     {
+        // This class is a named parameter and shall never be instantiated.
+        private StopHandler()
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Time/Runtime/RuntimeClock.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Runtime/RuntimeClock.cs
@@ -40,14 +40,21 @@ namespace Org.Apache.REEF.Wake.Time.Runtime
         private readonly PubSubSubject<Time> _handlers;
         private readonly PriorityQueue<Time> _schedule;
 
+        // TODO[REEF-1373]: Remove the the _old* handlers
+        private readonly IInjectionFuture<ISet<IObserver<StartTime>>> _oldStartHandler;
+        private readonly IInjectionFuture<ISet<IObserver<StopTime>>> _oldStopHandler;
+        private readonly IInjectionFuture<ISet<IObserver<RuntimeStart>>> _oldRuntimeStartHandler;
+        private readonly IInjectionFuture<ISet<IObserver<RuntimeStop>>> _oldRuntimeStopHandler;
+        private readonly IInjectionFuture<ISet<IObserver<IdleClock>>> _oldIdleHandler;
+        
         private readonly IInjectionFuture<ISet<IObserver<StartTime>>> _startHandler;
         private readonly IInjectionFuture<ISet<IObserver<StopTime>>> _stopHandler;
-        private IInjectionFuture<ISet<IObserver<RuntimeStart>>> _runtimeStartHandler;
-        private IInjectionFuture<ISet<IObserver<RuntimeStop>>> _runtimeStopHandler;
+        private readonly IInjectionFuture<ISet<IObserver<RuntimeStart>>> _runtimeStartHandler;
+        private readonly IInjectionFuture<ISet<IObserver<RuntimeStop>>> _runtimeStopHandler;
         private readonly IInjectionFuture<ISet<IObserver<IdleClock>>> _idleHandler;
 
         private bool _disposed;
-            
+
         /// <summary>
         /// Create a new RuntimeClock with injectable IObservers
         /// </summary>
@@ -57,15 +64,30 @@ namespace Org.Apache.REEF.Wake.Time.Runtime
         /// <param name="runtimeStartHandler">The runtime start handler</param>
         /// <param name="runtimeStopHandler">The runtime stop handler</param>
         /// <param name="idleHandler">The idle handler</param>
+        /// <param name="oldStartHandler">Start handlers prior to REEF-1372</param>
+        /// <param name="oldStopHandler">Stop handlers prior to REEF-1372</param>
+        /// <param name="oldRuntimeStartHandler">Runtime start handlers prior to REEF-1372</param>
+        /// <param name="oldRuntimeStopHandler">Runtime stop handlers prior to REEF-1372</param>
+        /// <param name="oldIdleHandler">Idle handlers prior to REEF-1372</param>
+#pragma warning disable 618
         [Inject]
         private RuntimeClock(
             ITimer timer,
-            [Parameter(typeof(StartHandler))] IInjectionFuture<ISet<IObserver<StartTime>>> startHandler, 
-            [Parameter(typeof(StopHandler))] IInjectionFuture<ISet<IObserver<StopTime>>> stopHandler,
-            [Parameter(typeof(RuntimeStartHandler))] IInjectionFuture<ISet<IObserver<RuntimeStart>>> runtimeStartHandler,
-            [Parameter(typeof(RuntimeStopHandler))] IInjectionFuture<ISet<IObserver<RuntimeStop>>> runtimeStopHandler,
-            [Parameter(typeof(IdleHandler))] IInjectionFuture<ISet<IObserver<IdleClock>>> idleHandler)
+
+            // TODO[REEF-1373]: Remove the _old* handlers
+            [Parameter(typeof(StartHandler))] IInjectionFuture<ISet<IObserver<StartTime>>> oldStartHandler,
+            [Parameter(typeof(StopHandler))] IInjectionFuture<ISet<IObserver<StopTime>>> oldStopHandler,
+            [Parameter(typeof(RuntimeStartHandler))] IInjectionFuture<ISet<IObserver<RuntimeStart>>> oldRuntimeStartHandler,
+            [Parameter(typeof(RuntimeStopHandler))] IInjectionFuture<ISet<IObserver<RuntimeStop>>> oldRuntimeStopHandler,
+            [Parameter(typeof(IdleHandler))] IInjectionFuture<ISet<IObserver<IdleClock>>> oldIdleHandler,
+
+            [Parameter(typeof(Parameters.StartHandler))] IInjectionFuture<ISet<IObserver<StartTime>>> startHandler,
+            [Parameter(typeof(Parameters.StopHandler))] IInjectionFuture<ISet<IObserver<StopTime>>> stopHandler,
+            [Parameter(typeof(Parameters.RuntimeStartHandler))] IInjectionFuture<ISet<IObserver<RuntimeStart>>> runtimeStartHandler,
+            [Parameter(typeof(Parameters.RuntimeStopHandler))] IInjectionFuture<ISet<IObserver<RuntimeStop>>> runtimeStopHandler,
+            [Parameter(typeof(Parameters.IdleHandler))] IInjectionFuture<ISet<IObserver<IdleClock>>> idleHandler)
         {
+#pragma warning restore 618
             _timer = timer;
             _schedule = new PriorityQueue<Time>();
             _handlers = new PubSubSubject<Time>();
@@ -75,6 +97,14 @@ namespace Org.Apache.REEF.Wake.Time.Runtime
             _runtimeStartHandler = runtimeStartHandler;
             _runtimeStopHandler = runtimeStopHandler;
             _idleHandler = idleHandler;
+
+            // TODO[REEF-1373]: Remove the _old* handlers
+            _oldStartHandler = oldStartHandler;
+            _oldStopHandler = oldStopHandler;
+            _oldRuntimeStartHandler = oldRuntimeStartHandler;
+            _oldRuntimeStopHandler = oldRuntimeStopHandler;
+            _oldIdleHandler = oldIdleHandler;
+
             ++numberOfInstantiations;
             if (numberOfInstantiations > 1)
             {
@@ -197,6 +227,13 @@ namespace Org.Apache.REEF.Wake.Time.Runtime
         /// </summary>
         private void SubscribeHandlers()
         {
+            // TODO[REEF-1373]: Remove the subscriptions of the _old* handlers
+            Subscribe(_oldStartHandler.Get());
+            Subscribe(_oldStopHandler.Get());
+            Subscribe(_oldRuntimeStartHandler.Get());
+            Subscribe(_oldRuntimeStopHandler.Get());
+            Subscribe(_oldIdleHandler.Get());
+
             Subscribe(_startHandler.Get());
             Subscribe(_stopHandler.Get());
             Subscribe(_runtimeStartHandler.Get());


### PR DESCRIPTION
This change

  * deprecates the named parameters in `IClock` and removes their defaults,
  * adds new named parameters in `Org.Apache.REEF.Wake.Time.Parameters`,
  * uses those new parameters in `Evaluator` and
  * makes sure that both the obsolete and the new parameters are used in
    `RuntimeClock`.

JIRA:
  [REEF-1372](https://issues.apache.org/jira/browse/REEF-1372)