### PR TITLE
[REEF-1286] Forward .NET Exceptions from the Evaluator to the Driver

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
+++ b/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
@@ -158,12 +158,11 @@ namespace Org {
                             virtual void OnError(String^ message);
                             virtual IEvaluatorRequestorClr2Java^ GetEvaluatorRequestor();
                             virtual String^ GetId();
-                            virtual EvaluatorException^ GetException();
                             virtual array<IFailedContextClr2Java^>^ GetFailedContextsClr2Java();
                             virtual IFailedTaskClr2Java^ GetFailedTaskClr2Java();
-                        private:
-                            String^ GetCause();
-                            String^ GetStackTrace();
+                            virtual array<byte>^ GetErrorBytes();
+                            virtual String^ GetJavaCause();
+                            virtual String^ GetJavaStackTrace();
                         };
 
                         public ref class HttpServerClr2Java : public IHttpServerBridgeClr2Java {

--- a/lang/cs/Org.Apache.REEF.Bridge/FailedEvaluatorClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/FailedEvaluatorClr2Java.cpp
@@ -76,11 +76,13 @@ namespace Org {
 						  return ManagedStringFromJavaString(env, _jstringId);
 					  }
 
+                      /*
                       EvaluatorException^ FailedEvaluatorClr2Java::GetException() {
                           String^ cause = this->GetCause();
                           String^ stackTrace = this->GetStackTrace();
                           return gcnew EvaluatorException(this->GetId(), cause, stackTrace);
                       }
+                      */
 
                       array<IFailedContextClr2Java^>^ FailedEvaluatorClr2Java::GetFailedContextsClr2Java() {
                           JNIEnv *env = RetrieveEnv(_jvm);
@@ -122,7 +124,20 @@ namespace Org {
 						  HandleClr2JavaError(env, message, _jobjectFailedEvaluator);
 					  }
 
-                      String^ FailedEvaluatorClr2Java::GetCause() {
+                      array<byte>^ FailedEvaluatorClr2Java::GetErrorBytes() {
+                          JNIEnv *env = RetrieveEnv(_jvm);
+                          jclass jclassFailedEvaluator = env->GetObjectClass(_jobjectFailedEvaluator);
+                          jmethodID jmidGetError = env->GetMethodID(jclassFailedEvaluator, "getErrorBytes", "()[B");
+                          jobject methodCallReturn = env->CallObjectMethod(_jobjectFailedEvaluator, jmidGetError);
+                          if (methodCallReturn == NULL) {
+                              return nullptr;
+                          }
+
+                          jbyteArray error = reinterpret_cast<jbyteArray>(methodCallReturn);
+                          return ManagedByteArrayFromJavaByteArray(env, error);
+                      }
+
+                      String^ FailedEvaluatorClr2Java::GetJavaCause() {
                           JNIEnv *env = RetrieveEnv(_jvm);
                           jclass jclassFailedEvaluator = env->GetObjectClass(_jobjectFailedEvaluator);
                           jmethodID jmidGetCause = env->GetMethodID(jclassFailedEvaluator, "getCause", "()Ljava/lang/String;");
@@ -135,7 +150,7 @@ namespace Org {
                           return ManagedStringFromJavaString(env, cause);
                       }
 
-                      String^ FailedEvaluatorClr2Java::GetStackTrace() {
+                      String^ FailedEvaluatorClr2Java::GetJavaStackTrace() {
                           JNIEnv *env = RetrieveEnv(_jvm);
                           jclass jclassFailedEvaluator = env->GetObjectClass(_jobjectFailedEvaluator);
                           jmethodID jmidGetStackTrace = env->GetMethodID(jclassFailedEvaluator, "getStackTrace", "()Ljava/lang/String;");

--- a/lang/cs/Org.Apache.REEF.Bridge/FailedEvaluatorClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/FailedEvaluatorClr2Java.cpp
@@ -76,14 +76,6 @@ namespace Org {
 						  return ManagedStringFromJavaString(env, _jstringId);
 					  }
 
-                      /*
-                      EvaluatorException^ FailedEvaluatorClr2Java::GetException() {
-                          String^ cause = this->GetCause();
-                          String^ stackTrace = this->GetStackTrace();
-                          return gcnew EvaluatorException(this->GetId(), cause, stackTrace);
-                      }
-                      */
-
                       array<IFailedContextClr2Java^>^ FailedEvaluatorClr2Java::GetFailedContextsClr2Java() {
                           JNIEnv *env = RetrieveEnv(_jvm);
                           jclass jclassFailedEvaluator = env->GetObjectClass(_jobjectFailedEvaluator);

--- a/lang/cs/Org.Apache.REEF.Common/Exceptions/NonSerializableEvaluatorException.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Exceptions/NonSerializableEvaluatorException.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,25 +15,26 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using Org.Apache.REEF.Utilities.Attributes;
+using System;
+using System.Runtime.Serialization;
 
-namespace Org.Apache.REEF.Driver.Bridge.Clr2java
+namespace Org.Apache.REEF.Common.Exceptions
 {
-    [Private, Interop("FailedEvaluatorClr2Java.cpp", "Clr2JavaImpl.h")]
-    public interface IFailedEvaluatorClr2Java
+    /// <summary>
+    /// Encapsulates <see cref="Exception#ToString"/> for an Exception from a 
+    /// REEF Evaluator that was not Serializable to the Job Driver.
+    /// </summary>
+    [Serializable]
+    public sealed class NonSerializableEvaluatorException : Exception
     {
-        IEvaluatorRequestorClr2Java GetEvaluatorRequestor();
+        public NonSerializableEvaluatorException(string message, SerializationException serializationException)
+            : base(message, serializationException)
+        {
+        }
 
-        string GetId();
-
-        IFailedContextClr2Java[] GetFailedContextsClr2Java();
-
-        IFailedTaskClr2Java GetFailedTaskClr2Java();
-
-        byte[] GetErrorBytes();
-
-        string GetJavaCause();
-
-        string GetJavaStackTrace();
+        public NonSerializableEvaluatorException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -107,6 +107,7 @@ under the License.
     <Compile Include="Events\IContextStart.cs" />
     <Compile Include="Events\IContextStop.cs" />
     <Compile Include="Exceptions\JobException.cs" />
+    <Compile Include="Exceptions\NonSerializableEvaluatorException.cs" />
     <Compile Include="Exceptions\NonSerializableTaskException.cs" />
     <Compile Include="Files\PathUtilities.cs" />
     <Compile Include="IContextAndTaskSubmittable.cs" />

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
@@ -24,7 +24,6 @@ using Org.Apache.REEF.Common.Exceptions;
 using Org.Apache.REEF.Common.Protobuf.ReefProtocol;
 using Org.Apache.REEF.Common.Runtime.Evaluator.Context;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
 using Org.Apache.REEF.Wake.Time;

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IFailedEvaluatorClr2Java.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IFailedEvaluatorClr2Java.cs
@@ -22,18 +22,39 @@ namespace Org.Apache.REEF.Driver.Bridge.Clr2java
     [Private, Interop("FailedEvaluatorClr2Java.cpp", "Clr2JavaImpl.h")]
     public interface IFailedEvaluatorClr2Java
     {
+        /// <summary>
+        /// Gets the Evaluator requestor.
+        /// </summary>
         IEvaluatorRequestorClr2Java GetEvaluatorRequestor();
 
+        /// <summary>
+        /// Gets the ID of the failed Evaluator.
+        /// </summary>
         string GetId();
 
+        /// <summary>
+        /// Gets the failed Contexts on the Evaluator.
+        /// </summary>
         IFailedContextClr2Java[] GetFailedContextsClr2Java();
 
+        /// <summary>
+        /// Gets the failed Task on the Evaluator.
+        /// </summary>
         IFailedTaskClr2Java GetFailedTaskClr2Java();
 
+        /// <summary>
+        /// Gets the Serialized Exception.
+        /// </summary>
         byte[] GetErrorBytes();
 
+        /// <summary>
+        /// Gets the Java Exception message.
+        /// </summary>
         string GetJavaCause();
 
+        /// <summary>
+        /// Gets the Java stack trace.
+        /// </summary>
         string GetJavaStackTrace();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedEvaluator.cs
@@ -15,9 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
 using Org.Apache.REEF.Driver.Bridge.Clr2java;
 using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Evaluator;
@@ -31,6 +34,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
     {
         private readonly string _id;
         private readonly IList<IFailedContext> _failedContexts;
+        private readonly EvaluatorException _evaluatorException;
 
         public FailedEvaluator(IFailedEvaluatorClr2Java clr2Java)
         {
@@ -39,6 +43,22 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             _failedContexts = new List<IFailedContext>(
                 FailedEvaluatorClr2Java.GetFailedContextsClr2Java().Select(clr2JavaFailedContext => 
                     new FailedContext(clr2JavaFailedContext)));
+
+            var errorBytes = FailedEvaluatorClr2Java.GetErrorBytes();
+            if (errorBytes != null)
+            {
+                var formatter = new BinaryFormatter();
+                using (var memStream = new MemoryStream(errorBytes))
+                {
+                    var inner = (Exception)formatter.Deserialize(memStream);
+                    _evaluatorException = new EvaluatorException(_id, inner.Message, inner);
+                }
+            }
+            else
+            {
+                _evaluatorException = new EvaluatorException(
+                    _id, FailedEvaluatorClr2Java.GetJavaCause(), FailedEvaluatorClr2Java.GetJavaStackTrace());
+            }
         }
 
         [DataMember]
@@ -51,7 +71,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
 
         public EvaluatorException EvaluatorException
         {
-            get { return FailedEvaluatorClr2Java.GetException(); }
+            get { return _evaluatorException; }
         }
 
         public IList<IFailedContext> FailedContexts

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedEvaluator.cs
@@ -47,6 +47,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             var errorBytes = FailedEvaluatorClr2Java.GetErrorBytes();
             if (errorBytes != null)
             {
+                // When the Exception originates from the C# side.
                 var formatter = new BinaryFormatter();
                 using (var memStream = new MemoryStream(errorBytes))
                 {
@@ -56,6 +57,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             }
             else
             {
+                // When the Exception originates from Java.
                 _evaluatorException = new EvaluatorException(
                     _id, FailedEvaluatorClr2Java.GetJavaCause(), FailedEvaluatorClr2Java.GetJavaStackTrace());
             }

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorException.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorException.cs
@@ -26,12 +26,20 @@ namespace Org.Apache.REEF.Driver.Evaluator
         private readonly string _evaluatorId;
         private readonly Optional<string> _javaStackTrace;
 
-        [Private]
-        public EvaluatorException(string evaluatorId, string message, string javaStackTrace)
+        internal EvaluatorException(string evaluatorId, string message, string javaStackTrace)
             : base(message)
         {
             _evaluatorId = evaluatorId;
-            _javaStackTrace = Optional<string>.OfNullable(javaStackTrace);
+            _javaStackTrace = string.IsNullOrWhiteSpace(javaStackTrace)
+                ? Optional<string>.Empty()
+                : Optional<string>.Of(javaStackTrace);
+        }
+
+        internal EvaluatorException(string evaluatorId, string message, Exception inner)
+            : base(message, inner)
+        {
+            _evaluatorId = evaluatorId;
+            _javaStackTrace = Optional<string>.Empty();
         }
 
         public string EvaluatorId

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/Exceptions/TestNonSerializableException.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/Exceptions/TestNonSerializableException.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,25 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using Org.Apache.REEF.Utilities.Attributes;
+using System;
 
-namespace Org.Apache.REEF.Driver.Bridge.Clr2java
+namespace Org.Apache.REEF.Tests.Functional.Bridge.Exceptions
 {
-    [Private, Interop("FailedEvaluatorClr2Java.cpp", "Clr2JavaImpl.h")]
-    public interface IFailedEvaluatorClr2Java
+    internal sealed class TestNonSerializableException : Exception
     {
-        IEvaluatorRequestorClr2Java GetEvaluatorRequestor();
-
-        string GetId();
-
-        IFailedContextClr2Java[] GetFailedContextsClr2Java();
-
-        IFailedTaskClr2Java GetFailedTaskClr2Java();
-
-        byte[] GetErrorBytes();
-
-        string GetJavaCause();
-
-        string GetJavaStackTrace();
+        public TestNonSerializableException(string message)
+            : base(message)
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/Exceptions/TestSerializableException.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/Exceptions/TestSerializableException.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,25 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using Org.Apache.REEF.Utilities.Attributes;
+using System;
+using System.Runtime.Serialization;
 
-namespace Org.Apache.REEF.Driver.Bridge.Clr2java
+namespace Org.Apache.REEF.Tests.Functional.Bridge.Exceptions
 {
-    [Private, Interop("FailedEvaluatorClr2Java.cpp", "Clr2JavaImpl.h")]
-    public interface IFailedEvaluatorClr2Java
+    [Serializable]
+    internal sealed class TestSerializableException : Exception
     {
-        IEvaluatorRequestorClr2Java GetEvaluatorRequestor();
+        public TestSerializableException(string message)
+            : base(message)
+        {
+        }
 
-        string GetId();
-
-        IFailedContextClr2Java[] GetFailedContextsClr2Java();
-
-        IFailedTaskClr2Java GetFailedTaskClr2Java();
-
-        byte[] GetErrorBytes();
-
-        string GetJavaCause();
-
-        string GetJavaStackTrace();
+        public TestSerializableException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/Parameters/ShouldThrowSerializableException.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/Parameters/ShouldThrowSerializableException.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,25 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using Org.Apache.REEF.Utilities.Attributes;
+using Org.Apache.REEF.Tang.Annotations;
 
-namespace Org.Apache.REEF.Driver.Bridge.Clr2java
+namespace Org.Apache.REEF.Tests.Functional.Bridge.Parameters
 {
-    [Private, Interop("FailedEvaluatorClr2Java.cpp", "Clr2JavaImpl.h")]
-    public interface IFailedEvaluatorClr2Java
+    [NamedParameter(documentation: "Used to indicate whether FailTask should throw a Serializable or non-Serializable Exception.")]
+    internal sealed class ShouldThrowSerializableException : Name<bool>
     {
-        IEvaluatorRequestorClr2Java GetEvaluatorRequestor();
-
-        string GetId();
-
-        IFailedContextClr2Java[] GetFailedContextsClr2Java();
-
-        IFailedTaskClr2Java GetFailedTaskClr2Java();
-
-        byte[] GetErrorBytes();
-
-        string GetJavaCause();
-
-        string GetJavaStackTrace();
+        private ShouldThrowSerializableException()
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedTaskEventHandler.cs
@@ -28,6 +28,8 @@ using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Tests.Functional.Bridge.Exceptions;
+using Org.Apache.REEF.Tests.Functional.Bridge.Parameters;
 using Org.Apache.REEF.Utilities.Logging;
 using Xunit;
 
@@ -202,36 +204,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
                 }
 
                 throw new TestNonSerializableException(ExpectedExceptionMessage);
-            }
-        }
-
-        [NamedParameter(documentation: "Used to indicate whether FailTask should throw a Serializable or non-Serializable Exception.")]
-        private sealed class ShouldThrowSerializableException : Name<bool>
-        {
-            private ShouldThrowSerializableException()
-            {
-            }
-        }
-
-        [Serializable]
-        private sealed class TestSerializableException : Exception
-        {
-            public TestSerializableException(string message)
-                : base(message)
-            {
-            }
-
-            public TestSerializableException(SerializationInfo info, StreamingContext context)
-                : base(info, context)
-            {
-            }
-        }
-
-        private sealed class TestNonSerializableException : Exception
-        {
-            public TestNonSerializableException(string message)
-                : base(message)
-            {
             }
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -74,11 +74,14 @@ under the License.
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Functional\Bridge\HelloSimpleEventHandlers.cs" />
+    <Compile Include="Functional\Bridge\Parameters\ShouldThrowSerializableException.cs" />
     <Compile Include="Functional\Bridge\TestBridgeClient.cs" />
     <Compile Include="Functional\Bridge\TestCloseTask.cs" />
     <Compile Include="Functional\Bridge\TestContextStack.cs" />
     <Compile Include="Functional\Bridge\TestFailedEvaluatorEventHandler.cs" />
     <Compile Include="Functional\Bridge\TestFailedTaskEventHandler.cs" />
+    <Compile Include="Functional\Bridge\Exceptions\TestNonSerializableException.cs" />
+    <Compile Include="Functional\Bridge\Exceptions\TestSerializableException.cs" />
     <Compile Include="Functional\Bridge\TestSimpleContext.cs" />
     <Compile Include="Functional\Bridge\TestSimpleEventHandlers.cs" />
     <Compile Include="Functional\Bridge\TestSuspendTask.cs" />
@@ -173,6 +176,7 @@ under the License.
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Import Project="$(PackagesDir)\StyleCop.MSBuild.$(StyleCopVersion)\build\StyleCop.MSBuild.Targets" Condition="Exists('$(PackagesDir)\StyleCop.MSBuild.$(StyleCopVersion)\build\StyleCop.MSBuild.Targets')" />

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedEvaluatorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedEvaluatorBridge.java
@@ -23,6 +23,7 @@ import org.apache.reef.annotations.audience.Interop;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.exception.NonSerializableException;
 import org.apache.reef.io.naming.Identifiable;
 import org.apache.reef.util.logging.LoggingScopeFactory;
 
@@ -55,14 +56,35 @@ public final class FailedEvaluatorBridge extends NativeBridge implements Identif
     this.activeContextBridgeFactory = activeContextBridgeFactory;
   }
 
+  /**
+   * @return the Evaluator number.
+   */
   public int getNewlyRequestedEvaluatorNumber() {
     return evaluatorRequestorBridge.getEvaluatorNumber();
   }
 
+  /**
+   * @return the Evaluator requestor.
+   */
   public EvaluatorRequestorBridge getEvaluatorRequestorBridge() {
     return evaluatorRequestorBridge;
   }
 
+  /**
+   * @return the non-serializable error in bytes, may translate into a serialized C# Exception.
+   */
+  public byte[] getErrorBytes() {
+    if (jfailedEvaluator.getEvaluatorException() != null &&
+        jfailedEvaluator.getEvaluatorException().getCause() instanceof NonSerializableException) {
+      return ((NonSerializableException)jfailedEvaluator.getEvaluatorException().getCause()).getError();
+    }
+
+    return null;
+  }
+
+  /**
+   * @return the localized message of the Evaluator Exception.
+   */
   public String getCause() {
     if (jfailedEvaluator.getEvaluatorException() != null) {
       return jfailedEvaluator.getEvaluatorException().getLocalizedMessage();
@@ -71,6 +93,9 @@ public final class FailedEvaluatorBridge extends NativeBridge implements Identif
     return null;
   }
 
+  /**
+   * @return the stack trace of the Evaluator Exception.
+   */
   public String getStackTrace() {
     if (jfailedEvaluator.getEvaluatorException() != null) {
       return ExceptionUtils.getStackTrace(jfailedEvaluator.getEvaluatorException());
@@ -79,6 +104,9 @@ public final class FailedEvaluatorBridge extends NativeBridge implements Identif
     return null;
   }
 
+  /**
+   * @return the list of failed Contexts associated with the Evaluator.
+   */
   public FailedContextBridge[] getFailedContexts() {
     if (jfailedEvaluator.getFailedContextList() == null) {
       return new FailedContextBridge[0];
@@ -95,6 +123,9 @@ public final class FailedEvaluatorBridge extends NativeBridge implements Identif
     return failedContextBridges;
   }
 
+  /**
+   * @return the failed task running on the Evaluator, if any.
+   */
   public FailedTaskBridge getFailedTask() {
     if (!jfailedEvaluator.getFailedTask().isPresent()) {
       return null;

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedEvaluatorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedEvaluatorBridge.java
@@ -79,6 +79,7 @@ public final class FailedEvaluatorBridge extends NativeBridge implements Identif
       return ((NonSerializableException)jfailedEvaluator.getEvaluatorException().getCause()).getError();
     }
 
+    // If not an instance of NonSerializableException, that means that the Exception is from Java.
     return null;
   }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/NonSerializableException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/NonSerializableException.java
@@ -1,9 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.reef.exception;
 
 import org.apache.reef.annotations.audience.DriverSide;
 
 /**
- * Created by anchung on 5/4/2016.
+ * An {@link Exception} that indicates that an Exception from the Evaluator
+ * was not able to be serialized.
  */
 @DriverSide
 public final class NonSerializableException extends Exception {
@@ -14,6 +33,9 @@ public final class NonSerializableException extends Exception {
     this.error = error;
   }
 
+  /**
+   * @return the Exception representation in a byte array.
+   */
   public byte[] getError() {
     return error;
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/NonSerializableException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/NonSerializableException.java
@@ -1,0 +1,20 @@
+package org.apache.reef.exception;
+
+import org.apache.reef.annotations.audience.DriverSide;
+
+/**
+ * Created by anchung on 5/4/2016.
+ */
+@DriverSide
+public final class NonSerializableException extends Exception {
+  private final byte[] error;
+
+  public NonSerializableException(final String message, final byte[] error) {
+    super(message);
+    this.error = error;
+  }
+
+  public byte[] getError() {
+    return error;
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -24,6 +24,7 @@ import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.driver.parameters.EvaluatorConfigurationProviders;
 import org.apache.reef.driver.restart.DriverRestartManager;
 import org.apache.reef.driver.restart.EvaluatorRestartState;
+import org.apache.reef.exception.NonSerializableException;
 import org.apache.reef.runtime.common.driver.evaluator.pojos.ContextStatusPOJO;
 import org.apache.reef.runtime.common.driver.evaluator.pojos.EvaluatorStatusPOJO;
 import org.apache.reef.runtime.common.driver.evaluator.pojos.State;
@@ -468,7 +469,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
         evaluatorException = new EvaluatorException(getId(), exception.get());
       } else {
         evaluatorException = new EvaluatorException(getId(),
-            new Exception("Exception sent, but can't be deserialized"));
+            new NonSerializableException("Exception sent, but can't be deserialized", evaluatorStatus.getError()));
       }
     } else {
       evaluatorException = new EvaluatorException(getId(), new Exception("No exception sent"));


### PR DESCRIPTION
This addressed the issue by
  * Adding Serializing of Evaluator Exceptions.
  * Modifying the FailedEvaluator test for both serializable and non-serializable Exceptions.

JIRA:
  [REEF-1286](https://issues.apache.org/jira/browse/REEF-1286)