### PR TITLE
[REEF-1207] REEF.NET Evaluator should print a known log line on exit

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Constants.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Constants.cs
@@ -19,20 +19,46 @@ using System;
 
 namespace Org.Apache.REEF.Common
 {
-    public class Constants
+    public static class Constants
     {
-        // if 8080 port is not used, then query would fail, 
-        // this is only for local runtime testing purpose though, so it should be ok
+        /// <summary>
+        /// The local HTTP Endpoint used for local runtime HTTP Server tests.
+        /// </summary>
         public const string LocalHttpEndpointBaseUri = @"http://localhost:8080/";  
 
+        /// <summary>
+        /// The base endpoint to redirect HTTP requests to the Driver's HTTP Server on HDInsight.
+        /// </summary>
         public const string HDInsightClusterHttpEndpointBaseUri = @"http://headnodehost:9014/proxy/";
 
+        /// <summary>
+        /// The v1 REEF HTTP API URI specification of a REEF Job.
+        /// </summary>
         public const string HttpReefUriSpecification = @"Reef/v1/";
 
+        /// <summary>
+        /// The relative path to Driver on a REEF HTTP Server request.
+        /// </summary>
         public const string HttpDriverUriTarget = @"Driver/";
 
+        /// <summary>
+        /// The Name Server name.
+        /// </summary>
         public const string NameServerServiceName = "NameServer";
 
+        /// <summary>
+        /// The Environment variable used to discover the YARN Application ID of the REEF Job.
+        /// </summary>
         public const string ReefYarnApplicationIdEnvironmentVariable = "REEF_YARN_APPLICATION_ID";
+
+        /// <summary>
+        /// The log that is printed on a successful Evaluator exit.
+        /// </summary>
+        public const string EvaluatorExitSuccessLog = "The Evaluator has successfully exited.";
+
+        /// <summary>
+        /// The log that is printed on an Evaluator failure.
+        /// </summary>
+        public const string EvaluatorExitFailureLog = "The Evaluator has exited on a failure.";
     }
 }

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -148,6 +148,7 @@ under the License.
     <Compile Include="Runtime\Evaluator\Context\ContextStartImpl.cs" />
     <Compile Include="Runtime\Evaluator\Context\ContextStopImpl.cs" />
     <Compile Include="Runtime\Evaluator\Context\RootContextLauncher.cs" />
+    <Compile Include="Runtime\Evaluator\EvaluatorExitLogger.cs" />
     <Compile Include="Runtime\Evaluator\EvaluatorRuntime.cs" />
     <Compile Include="Runtime\Evaluator\EvaluatorSettings.cs" />
     <Compile Include="Runtime\Evaluator\HeartBeatManager.cs" />

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorExitLogger.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorExitLogger.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities.Attributes;
+using Org.Apache.REEF.Utilities.Logging;
+
+namespace Org.Apache.REEF.Common.Runtime.Evaluator
+{
+    /// <summary>
+    /// A logger that logs <see cref="Common.Constants.EvaluatorExitSuccessLog"/> on
+    /// an Evaluator's successful exit and <see cref="Common.Constants.EvaluatorExitFailureLog"/>
+    /// an Evaluator's failure. Will only log once.
+    /// </summary>
+    [ThreadSafe]
+    internal sealed class EvaluatorExitLogger
+    {
+        private static readonly Logger Logger = Logger.GetLogger(typeof(EvaluatorExitLogger));
+
+        private readonly object _lock = new object();
+        private bool _exitLogged = false;
+
+        [Inject]
+        private EvaluatorExitLogger()
+        {
+        }
+
+        public void LogExit(bool successfulExit)
+        {
+            lock (_lock)
+            {
+                if (_exitLogged)
+                {
+                    return;
+                }
+
+                if (successfulExit)
+                {
+                    Logger.Log(Level.Info, Common.Constants.EvaluatorExitSuccessLog);
+                }
+                else
+                {
+                    Logger.Log(Level.Error, Common.Constants.EvaluatorExitFailureLog);
+                }
+
+                _exitLogged = true;
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorExitLogger.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorExitLogger.cs
@@ -32,21 +32,33 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
         private static readonly Logger Logger = Logger.GetLogger(typeof(EvaluatorExitLogger));
 
         private readonly object _lock = new object();
-        private bool _exitLogged = false;
+        private bool? _successfulExit;
 
         [Inject]
         private EvaluatorExitLogger()
         {
         }
 
-        public void LogExit(bool successfulExit)
+        /// <summary>
+        /// Logs an Evaluator message based on successful/unsuccessful exit.
+        /// </summary>
+        internal void LogExit(bool successfulExit)
         {
             lock (_lock)
             {
-                if (_exitLogged)
+                if (_successfulExit != null)
                 {
+                    if (_successfulExit != successfulExit)
+                    {
+                        Logger.Log(
+                            Level.Warning, 
+                            "Evaluator exit has been logged multiple times with conflicting exit status.");
+                    }
+
                     return;
                 }
+
+                _successfulExit = successfulExit;
 
                 if (successfulExit)
                 {
@@ -56,8 +68,6 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                 {
                     Logger.Log(Level.Error, Common.Constants.EvaluatorExitFailureLog);
                 }
-
-                _exitLogged = true;
             }
         }
     }

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
@@ -204,6 +204,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
             }
             else
             {
+                var exceptionOccurredOnDispose = false;
                 try
                 {
                     _contextManager.Dispose();
@@ -211,9 +212,16 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                 }
                 catch (Exception e)
                 {
-                    _evaluatorExitLogger.LogExit(false);
+                    exceptionOccurredOnDispose = true;
                     Utilities.Diagnostics.Exceptions.CaughtAndThrow(
-                        new InvalidOperationException("Cannot stop evaluator properly", e), Level.Error, "Exception during shut down.", Logger);
+                        new InvalidOperationException("Cannot stop evaluator properly", e),
+                        Level.Error,
+                        "Exception during shut down.",
+                        Logger);
+                }
+                finally
+                {
+                    _evaluatorExitLogger.LogExit(exceptionOccurredOnDispose);
                 }
             }
         }

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorRuntime.cs
@@ -37,16 +37,17 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
         private readonly IHeartBeatManager _heartBeatManager;
         private readonly IClock _clock;
         private readonly IDisposable _evaluatorControlChannel; 
+        private readonly PIDStoreHandler _pidStoreHelper;
+        private readonly EvaluatorExitLogger _evaluatorExitLogger;
 
         private State _state = State.INIT;
-
-        private PIDStoreHandler _pidStoreHelper;
 
         [Inject]
         public EvaluatorRuntime(
             ContextManager contextManager,
             IHeartBeatManager heartBeatManager,
-            PIDStoreHandler pidStoreHelper)
+            PIDStoreHandler pidStoreHelper,
+            EvaluatorExitLogger evaluatorExitLogger)
         {
             using (Logger.LogFunction("EvaluatorRuntime::EvaluatorRuntime"))
             {
@@ -55,6 +56,8 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                 _contextManager = contextManager;
                 _evaluatorId = _heartBeatManager.EvaluatorSettings.EvalutorId;
                 _pidStoreHelper = pidStoreHelper;
+                _evaluatorExitLogger = evaluatorExitLogger;
+
                 var remoteManager = _heartBeatManager.EvaluatorSettings.RemoteManager;
 
                 ReefMessageProtoObserver driverObserver = new ReefMessageProtoObserver();
@@ -208,11 +211,11 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                 }
                 catch (Exception e)
                 {
-                    Utilities.Diagnostics.Exceptions.CaughtAndThrow(new InvalidOperationException("Cannot stop evaluator properly", e), Level.Error, "Exception during shut down.", Logger);
+                    _evaluatorExitLogger.LogExit(false);
+                    Utilities.Diagnostics.Exceptions.CaughtAndThrow(
+                        new InvalidOperationException("Cannot stop evaluator properly", e), Level.Error, "Exception during shut down.", Logger);
                 }
             }
-
-            Logger.Log(Level.Info, "EvaluatorRuntime shutdown complete");      
         }
 
         public void OnNext(REEFMessage value)
@@ -247,6 +250,8 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
 
                 _heartBeatManager.OnNext(evaluatorStatusProto);
                 _contextManager.Dispose();
+
+                _evaluatorExitLogger.LogExit(false);
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
@@ -42,13 +42,16 @@ namespace Org.Apache.REEF.Evaluator
     {
         private static Logger logger = Logger.GetLogger(typeof(Evaluator));
         private readonly RuntimeClock _clock;
+        private readonly EvaluatorExitLogger _evaluatorExitLogger;
 
         [Inject]
         private Evaluator(
             RuntimeClock clock,
             CustomTraceListeners customTraceListeners,
-            CustomTraceLevel customTraceLevel)
+            CustomTraceLevel customTraceLevel,
+            EvaluatorExitLogger evaluatorExitLogger)
         {
+            _evaluatorExitLogger = evaluatorExitLogger;
             _clock = clock;
             SetCustomTraceListeners(customTraceListeners, customTraceLevel);
         }
@@ -56,6 +59,7 @@ namespace Org.Apache.REEF.Evaluator
         private void Run()
         {
             _clock.Run();
+            _evaluatorExitLogger.LogExit(true);
         }
 
         /// <summary>


### PR DESCRIPTION
This addressed the issue by
  * Adding constnats for the known Evaluator exit line.
  * Logging the lines on Evaluator Exit and ensuring that exits are only logged a single time.

JIRA:
  [REEF-1207](https://issues.apache.org/jira/browse/REEF-1207)