### PR TITLE
[REEF-1360] Enforce comment style for license headers in Java

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceManagerStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceManagerStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceManagerStopHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceManagerStopHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
@@ -72,6 +72,13 @@
     <!-- not a check -->
     <module name="SuppressWarningsFilter"/>
 
+    <!-- Checks for Headers                                -->
+    <!-- See http://checkstyle.sf.net/config_header.html   -->
+    <module name="RegexpHeader">
+        <property name="header" value="^/\*$"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
     <module name="TreeWalker">
         <!-- not a check -->
         <module name="SuppressWarningsHolder"/>
@@ -95,25 +102,6 @@
         <module name="ParameterName"/>
         <module name="StaticVariableName"/>
         <module name="TypeName"/>
-
-
-        <!-- Checks for Headers                                -->
-        <!-- See http://checkstyle.sf.net/config_header.html   -->
-        <!-- <module name="Header">                            -->
-        <!-- The follow property value demonstrates the ability     -->
-        <!-- to have access to ANT properties. In this case it uses -->
-        <!-- the ${basedir} property to allow Checkstyle to be run  -->
-        <!-- from any directory within a project. See property      -->
-        <!-- expansion,                                             -->
-        <!-- http://checkstyle.sf.net/config.html#properties        -->
-        <!-- <property                                              -->
-        <!--     name="headerFile"                                  -->
-        <!--     value="${basedir}/java.header"/>                   -->
-        <!-- </module> -->
-
-        <!-- Following interprets the header file as regular expressions. -->
-        <!-- <module name="RegexpHeader"/>                                -->
-
 
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->

--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -72,6 +72,13 @@
     <!-- not a check -->
     <module name="SuppressWarningsFilter"/>
 
+    <!-- Checks for Headers                                -->
+    <!-- See http://checkstyle.sf.net/config_header.html   -->
+    <module name="RegexpHeader">
+        <property name="header" value="^/\*$"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
     <module name="TreeWalker">
         <!-- not a check -->
         <module name="SuppressWarningsHolder"/>
@@ -96,24 +103,6 @@
         <module name="ParameterName"/>
         <module name="StaticVariableName"/>
         <module name="TypeName"/>
-
-
-        <!-- Checks for Headers                                -->
-        <!-- See http://checkstyle.sf.net/config_header.html   -->
-        <!-- <module name="Header">                            -->
-        <!-- The follow property value demonstrates the ability     -->
-        <!-- to have access to ANT properties. In this case it uses -->
-        <!-- the ${basedir} property to allow Checkstyle to be run  -->
-        <!-- from any directory within a project. See property      -->
-        <!-- expansion,                                             -->
-        <!-- http://checkstyle.sf.net/config.html#properties        -->
-        <!-- <property                                              -->
-        <!--     name="headerFile"                                  -->
-        <!--     value="${basedir}/java.header"/>                   -->
-        <!-- </module> -->
-
-        <!-- Following interprets the header file as regular expressions. -->
-        <!-- <module name="RegexpHeader"/>                                -->
 
 
         <!-- Checks for imports                              -->

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnectionServiceImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnectionServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStartHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStopHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStopHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-multi/src/main/java/org/apache/reef/runtime/multi/driver/MultiRuntimeResourceManagerStartHandler.java
+++ b/lang/java/reef-runtime-multi/src/main/java/org/apache/reef/runtime/multi/driver/MultiRuntimeResourceManagerStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-multi/src/main/java/org/apache/reef/runtime/multi/driver/MultiRuntimeResourceManagerStopHandler.java
+++ b/lang/java/reef-runtime-multi/src/main/java/org/apache/reef/runtime/multi/driver/MultiRuntimeResourceManagerStopHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
This change enforces /* style in Java license headers and fixes existing violations.

JIRA:
  [REEF-1360](https://issues.apache.org/jira/browse/REEF-1360)

Pull request:
  This closes #