### PR TITLE
[REEF-1379] Add a fluid interface to EvaluatorRequestor

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -20,6 +20,7 @@ package org.apache.reef.driver.evaluator;
 
 import org.apache.reef.annotations.Provided;
 import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.annotations.audience.Public;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -138,7 +139,7 @@ public final class EvaluatorRequest {
   /**
    * {@link EvaluatorRequest}s are build using this Builder.
    */
-  public static final class Builder implements org.apache.reef.util.Builder<EvaluatorRequest> {
+  public static class Builder<T extends Builder> implements org.apache.reef.util.Builder<EvaluatorRequest> {
 
     private int n = 1;
     private int megaBytes = -1;
@@ -147,7 +148,8 @@ public final class EvaluatorRequest {
     private final List<String> rackNames = new ArrayList<>();
     private String runtimeName = "";
 
-    private Builder() {
+    @Private
+    public Builder() {
     }
 
     /**
@@ -176,9 +178,9 @@ public final class EvaluatorRequest {
      * @return this builder
      */
     @SuppressWarnings("checkstyle:hiddenfield")
-    public Builder setMemory(final int megaBytes) {
+    public T setMemory(final int megaBytes) {
       this.megaBytes = megaBytes;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -187,9 +189,10 @@ public final class EvaluatorRequest {
      * @param runtimeName to request for the Evaluator.
      * @return this builder
      */
-    public Builder setRuntimeName(final String runtimeName) {
+    @SuppressWarnings("checkstyle:hiddenfield")
+    public T setRuntimeName(final String runtimeName) {
       this.runtimeName = runtimeName;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -199,9 +202,9 @@ public final class EvaluatorRequest {
      * @return this Builder.
      */
     @SuppressWarnings("checkstyle:hiddenfield")
-    public Builder setNumberOfCores(final int cores) {
+    public T setNumberOfCores(final int cores) {
       this.cores = cores;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -211,9 +214,9 @@ public final class EvaluatorRequest {
      * @return this Builder.
      */
     @SuppressWarnings("checkstyle:hiddenfield")
-    public Builder setNumber(final int n) {
+    public T setNumber(final int n) {
       this.n = n;
-      return this;
+      return (T) this;
     }
 
     /**
@@ -224,9 +227,9 @@ public final class EvaluatorRequest {
      * @param nodeName a preferred node name
      * @return this Builder.
      */
-    public Builder addNodeName(final String nodeName) {
+    public T addNodeName(final String nodeName) {
       this.nodeNames.add(nodeName);
-      return this;
+      return (T) this;
     }
 
     /**
@@ -238,9 +241,9 @@ public final class EvaluatorRequest {
      * @param rackName a preferred rack name
      * @return this Builder.
      */
-    public Builder addRackName(final String rackName) {
+    public T addRackName(final String rackName) {
       this.rackNames.add(rackName);
-      return this;
+      return (T) this;
     }
 
     /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequestor.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequestor.java
@@ -21,6 +21,7 @@ package org.apache.reef.driver.evaluator;
 import org.apache.reef.annotations.Provided;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Public;
+import org.apache.reef.runtime.common.driver.EvaluatorRequestorImpl;
 
 /**
  * Interface through which Evaluators can be requested.
@@ -35,4 +36,10 @@ public interface EvaluatorRequestor {
    * The response will surface in the AllocatedEvaluator message handler.
    */
   void submit(final EvaluatorRequest req);
+
+  /**
+   * Get a new Builder for the evaluator with fluid interface.
+   * @return Builder for the evaluator
+   */
+  EvaluatorRequestorImpl.Builder newRequest();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
@@ -112,4 +112,24 @@ public final class EvaluatorRequestorImpl implements EvaluatorRequestor {
       this.resourceRequestHandler.onNext(request);
     }
   }
+
+  /**
+   * Get a new builder.
+   *
+   * @return a new EvaluatorRequest Builder extended with the new submit method.
+   */
+  @Override
+  public Builder newRequest() {
+    return new Builder();
+  }
+
+  /**
+   * {@link EvaluatorRequest.Builder} extended with a new submit method.
+   * {@link EvaluatorRequest}s are built using this builder.
+   */
+  public final class Builder extends EvaluatorRequest.Builder<Builder> {
+    public synchronized void submit() {
+      EvaluatorRequestorImpl.this.submit(this.build());
+    }
+  }
 }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/output/OutputServiceDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/output/OutputServiceDriver.java
@@ -21,7 +21,6 @@ package org.apache.reef.examples.data.output;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ContextConfiguration;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
-import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.task.TaskConfiguration;
 import org.apache.reef.io.data.output.OutputService;
@@ -79,11 +78,11 @@ public final class OutputServiceDriver {
   public final class StartHandler implements EventHandler<StartTime> {
     @Override
     public void onNext(final StartTime startTime) {
-      OutputServiceDriver.this.requestor.submit(EvaluatorRequest.newBuilder()
+      OutputServiceDriver.this.requestor.newRequest()
           .setNumber(3)
           .setMemory(64)
           .setNumberOfCores(1)
-          .build());
+          .submit();
       LOG.log(Level.INFO, "Requested Evaluator.");
     }
   }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastDriver.java
@@ -23,7 +23,6 @@ import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ClosedContext;
 import org.apache.reef.driver.context.ContextConfiguration;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
-import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.driver.task.TaskConfiguration;
@@ -129,10 +128,10 @@ public class BroadcastDriver {
     public void onNext(final StartTime startTime) {
       final int numEvals = BroadcastDriver.this.numberOfReceivers + 1;
       LOG.log(Level.FINE, "Requesting {0} evaluators", numEvals);
-      BroadcastDriver.this.requestor.submit(EvaluatorRequest.newBuilder()
+      BroadcastDriver.this.requestor.newRequest()
           .setNumber(numEvals)
           .setMemory(2048)
-          .build());
+          .submit();
     }
   }
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriver.java
@@ -19,7 +19,6 @@
 package org.apache.reef.examples.hello;
 
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
-import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.task.TaskConfiguration;
 import org.apache.reef.tang.Configuration;
@@ -58,11 +57,11 @@ public final class HelloDriver {
   public final class StartHandler implements EventHandler<StartTime> {
     @Override
     public void onNext(final StartTime startTime) {
-      HelloDriver.this.requestor.submit(EvaluatorRequest.newBuilder()
+      HelloDriver.this.requestor.newRequest()
           .setNumber(1)
           .setMemory(64)
           .setNumberOfCores(1)
-          .build());
+          .submit();
       LOG.log(Level.INFO, "Requested Evaluator.");
     }
   }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloJVMOptionsDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloJVMOptionsDriver.java
@@ -19,7 +19,6 @@
 package org.apache.reef.examples.hello;
 
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
-import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.evaluator.JVMProcess;
 import org.apache.reef.driver.evaluator.JVMProcessFactory;
@@ -64,11 +63,11 @@ public final class HelloJVMOptionsDriver {
   public final class StartHandler implements EventHandler<StartTime> {
     @Override
     public void onNext(final StartTime startTime) {
-      HelloJVMOptionsDriver.this.requestor.submit(EvaluatorRequest.newBuilder()
+      HelloJVMOptionsDriver.this.requestor.newRequest()
           .setNumber(1)
           .setMemory(64)
           .setNumberOfCores(1)
-          .build());
+          .submit();
       LOG.log(Level.INFO, "Requested Evaluator.");
     }
   }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HttpShellJobDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HttpShellJobDriver.java
@@ -23,7 +23,6 @@ import org.apache.reef.driver.context.ClosedContext;
 import org.apache.reef.driver.context.ContextConfiguration;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
-import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.driver.task.CompletedTask;
@@ -167,12 +166,11 @@ public final class HttpShellJobDriver {
   private synchronized void requestEvaluators() {
     assert this.state == State.INIT;
     LOG.log(Level.INFO, "Schedule on {0} Evaluators.", this.numEvaluators);
-    this.evaluatorRequestor.submit(
-        EvaluatorRequest.newBuilder()
-            .setMemory(128)
-            .setNumberOfCores(1)
-            .setNumber(this.numEvaluators).build()
-    );
+    this.evaluatorRequestor.newRequest()
+        .setMemory(128)
+        .setNumberOfCores(1)
+        .setNumber(this.numEvaluators)
+        .submit();
     this.state = State.WAIT_EVALUATORS;
     this.expectCount = this.numEvaluators;
   }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellomultiruntime/HelloMultiRuntimeDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellomultiruntime/HelloMultiRuntimeDriver.java
@@ -19,10 +19,10 @@
 package org.apache.reef.examples.hellomultiruntime;
 
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
-import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.task.TaskConfiguration;
 import org.apache.reef.examples.hello.HelloTask;
+import org.apache.reef.runtime.local.driver.RuntimeIdentifier;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.wake.EventHandler;
@@ -59,21 +59,21 @@ public final class HelloMultiRuntimeDriver {
   public final class StartHandler implements EventHandler<StartTime> {
     @Override
     public void onNext(final StartTime startTime) {
-      HelloMultiRuntimeDriver.this.requestor.submit(EvaluatorRequest.newBuilder()
+      HelloMultiRuntimeDriver.this.requestor.newRequest()
           .setNumber(1)
           .setMemory(64)
           .setNumberOfCores(1)
-          .setRuntimeName(org.apache.reef.runtime.local.driver.RuntimeIdentifier.RUNTIME_NAME)
-          .build());
+          .setRuntimeName(RuntimeIdentifier.RUNTIME_NAME)
+          .submit();
 
       LOG.log(Level.INFO, "Requested Local Evaluator .");
 
-      HelloMultiRuntimeDriver.this.requestor.submit(EvaluatorRequest.newBuilder()
-              .setNumber(1)
-              .setMemory(64)
-              .setNumberOfCores(1)
-              .setRuntimeName(org.apache.reef.runtime.yarn.driver.RuntimeIdentifier.RUNTIME_NAME)
-              .build());
+      HelloMultiRuntimeDriver.this.requestor.newRequest()
+          .setNumber(1)
+          .setMemory(64)
+          .setNumberOfCores(1)
+          .setRuntimeName(RuntimeIdentifier.RUNTIME_NAME)
+          .submit();
 
       LOG.log(Level.INFO, "Requested Yarn Evaluator.");
     }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/JobDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/JobDriver.java
@@ -22,7 +22,6 @@ import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ContextConfiguration;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.CompletedEvaluator;
-import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.task.CompletedTask;
 import org.apache.reef.driver.task.RunningTask;
@@ -131,12 +130,11 @@ public final class JobDriver {
     @Override
     public void onNext(final StartTime startTime) {
       LOG.log(Level.INFO, "TIME: Start Driver with {0} Evaluators", numEvaluators);
-      evaluatorRequestor.submit(
-          EvaluatorRequest.newBuilder()
-              .setMemory(128)
-              .setNumberOfCores(1)
-              .setNumber(numEvaluators).build()
-      );
+      evaluatorRequestor.newRequest()
+          .setMemory(128)
+          .setNumberOfCores(1)
+          .setNumber(numEvaluators)
+          .submit();
     }
   }
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/SchedulerDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/SchedulerDriver.java
@@ -21,7 +21,6 @@ package org.apache.reef.examples.scheduler.driver;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ContextConfiguration;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
-import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.task.CompletedTask;
 import org.apache.reef.examples.scheduler.client.SchedulerREEF;
@@ -251,10 +250,10 @@ public final class SchedulerDriver {
     }
 
     nRequestedEval += numToRequest;
-    requestor.submit(EvaluatorRequest.newBuilder()
+    requestor.newRequest()
         .setMemory(32)
         .setNumber(numToRequest)
-        .build());
+        .submit();
   }
 
   /**

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendDriver.java
@@ -23,7 +23,6 @@ import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ContextConfiguration;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
-import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.task.*;
 import org.apache.reef.io.checkpoint.fs.FSCheckPointServiceConfiguration;
@@ -322,8 +321,11 @@ public class SuspendDriver {
     @Override
     public void onNext(final StartTime time) {
       LOG.log(Level.INFO, "StartTime: {0}", time);
-      evaluatorRequestor.submit(EvaluatorRequest.newBuilder()
-          .setMemory(128).setNumberOfCores(1).setNumber(NUM_EVALUATORS).build());
+      evaluatorRequestor.newRequest()
+          .setMemory(128)
+          .setNumberOfCores(1)
+          .setNumber(NUM_EVALUATORS)
+          .submit();
     }
   }
 


### PR DESCRIPTION
This PR:
- extends `EvaluatorRequest.Builder` under `EvaluatorRequestorImpl` with a
  `submit()` method
- enables the newly implemented builder to be created with the `newRequest()` method
- changes examples under `reef-examples` to use the new method

JIRA: [REEF-1379](https://issues.apache.org/jira/browse/REEF-1379)
resolved