### PR TITLE
[REEF-1250] Fix memory leak in Evaluators

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorHeartbeatHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorHeartbeatHandler.java
@@ -72,7 +72,7 @@ public final class EvaluatorHeartbeatHandler
       }
 
       if (this.evaluators.wasClosed(evaluatorId)) {
-        LOG.log(Level.FINE, "Evaluator [" + evaluatorId + "] has reported back to the driver after it was closed.");
+        LOG.log(Level.WARNING, "Evaluator [" + evaluatorId + "] has reported back to the driver after it was closed.");
         return;
       }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorHeartbeatHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorHeartbeatHandler.java
@@ -71,6 +71,11 @@ public final class EvaluatorHeartbeatHandler
         return;
       }
 
+      if (this.evaluators.wasClosed(evaluatorId)) {
+        LOG.log(Level.FINE, "Evaluator [" + evaluatorId + "] has reported back to the driver after it was closed.");
+        return;
+      }
+
       if (driverRestartManager.isRestarting() &&
           driverRestartManager.getEvaluatorRestartState(evaluatorId) == EvaluatorRestartState.EXPECTED) {
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorResourceManagerErrorHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorResourceManagerErrorHandler.java
@@ -63,7 +63,7 @@ public final class EvaluatorResourceManagerErrorHandler
       evaluatorManager.get().onEvaluatorException(evaluatorException);
     } else {
       if (this.evaluators.wasClosed(evaluatorId)) {
-        LOG.log(Level.FINE, "Evaluator [" + evaluatorId + "] has raised exception after it was closed.");
+        LOG.log(Level.WARNING, "Evaluator [" + evaluatorId + "] has raised exception after it was closed.");
       } else {
         LOG.log(Level.WARNING, "Unknown evaluator runtime error: " + error);
       }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorResourceManagerErrorHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorResourceManagerErrorHandler.java
@@ -62,7 +62,11 @@ public final class EvaluatorResourceManagerErrorHandler
     if (evaluatorManager.isPresent()) {
       evaluatorManager.get().onEvaluatorException(evaluatorException);
     } else {
-      LOG.log(Level.WARNING, "Unknown evaluator runtime error: " + error);
+      if (this.evaluators.wasClosed(evaluatorId)) {
+        LOG.log(Level.FINE, "Evaluator [" + evaluatorId + "] has raised exception after it was closed.");
+      } else {
+        LOG.log(Level.WARNING, "Unknown evaluator runtime error: " + error);
+      }
     }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
@@ -50,8 +50,8 @@ public final class ResourceStatusHandler implements EventHandler<ResourceStatusE
   }
 
   /**
-   * This resource status message comes from the ResourceManager layer; telling me what it thinks.
-   * about the state of the resource executing an Evaluator; This method simply passes the message
+   * This resource status message comes from the ResourceManager layer, telling me what it thinks
+   * about the state of the resource executing an Evaluator. This method simply passes the message
    * off to the referenced EvaluatorManager
    *
    * @param resourceStatusEvent resource status message from the ResourceManager
@@ -61,7 +61,15 @@ public final class ResourceStatusHandler implements EventHandler<ResourceStatusE
     final Optional<EvaluatorManager> evaluatorManager = this.evaluators.get(resourceStatusEvent.getIdentifier());
     if (evaluatorManager.isPresent()) {
       evaluatorManager.get().onResourceStatusMessage(resourceStatusEvent);
+
+      if (evaluatorManager.get().isClosed()) {
+        this.evaluators.removeClosedEvaluator(evaluatorManager.get());
+      }
     } else {
+      if (this.evaluators.wasClosed(evaluatorManager.get().getId())) {
+        return;
+      }
+
       if (driverRestartManager.get().getEvaluatorRestartState(resourceStatusEvent.getIdentifier())
             .isFailedOrExpired()) {
         final EvaluatorManager previousEvaluatorManager = this.evaluatorManagerFactory

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
@@ -28,6 +28,8 @@ import org.apache.reef.util.Optional;
 import org.apache.reef.wake.EventHandler;
 
 import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A ResourceStatusProto message comes from the ResourceManager layer to indicate what it thinks
@@ -35,6 +37,7 @@ import javax.inject.Inject;
  */
 @Private
 public final class ResourceStatusHandler implements EventHandler<ResourceStatusEvent> {
+  private static final Logger LOG = Logger.getLogger(Evaluators.class.getName());
 
   private final Evaluators evaluators;
   private final EvaluatorManagerFactory evaluatorManagerFactory;
@@ -66,8 +69,9 @@ public final class ResourceStatusHandler implements EventHandler<ResourceStatusE
         this.evaluators.removeClosedEvaluator(evaluatorManager.get());
       }
     } else {
-      if (this.evaluators.wasClosed(evaluatorManager.get().getId())) {
-        return;
+      if (this.evaluators.wasClosed(resourceStatusEvent.getIdentifier())) {
+        LOG.log(Level.WARNING, "Unexpected resource status from closed evaluator " +
+            resourceStatusEvent.getIdentifier() + " with state " + resourceStatusEvent.getState());
       }
 
       if (driverRestartManager.get().getEvaluatorRestartState(resourceStatusEvent.getIdentifier())


### PR DESCRIPTION
This change:
 * introduces a set of closed evaluator ids,
 * moves evaluator to this set whenever resource manager
   sends resource status indicating that evaluator is closed.

JIRA:
  [REEF-1250](https://issues.apache.org/jira/browse/REEF-1250)

Pull request:
  This closes #