### PR TITLE
[REEF-1243] Fix StreamingRemoteManagerTest tests which get stuck in A…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,17 +34,8 @@ build_script:
 # test script temporarily excludes StreamingRemoteManagerTest (see REEF-1311) and downloads xunit.runner.console
 # to be reverted as part of REEF-1243
 test_script:
-  - cmd: cd .\lang\cs
-  - cmd: nuget restore .\.nuget\packages.config -o .\packages
-  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Client.Tests\Org.Apache.REEF.Client.Tests.dll
-  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Common.Tests\Org.Apache.REEF.Common.Tests.dll
-  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Evaluator.Tests\Org.Apache.REEF.Evaluator.Tests.dll
-  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.IMRU.Tests\Org.Apache.REEF.IMRU.Tests.dll
-  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.IO.Tests\Org.Apache.REEF.IO.Tests.dll
-  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Network.Tests\Org.Apache.REEF.Network.Tests.dll
-  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Tang.Tests\Org.Apache.REEF.Tang.Tests.dll
-  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Wake.Tests\Org.Apache.REEF.Wake.Tests.dll -class Org.Apache.REEF.Wake.Tests.ClockTest -class Org.Apache.REEF.Wake.Tests.MultiCodecTest -class Org.Apache.REEF.Wake.Tests.PubSubSubjectTest -class Org.Apache.REEF.Wake.Tests.RemoteManagerTest -class Org.Apache.REEF.Wake.Tests.StreamingTransportTest -class Org.Apache.REEF.Wake.Tests.TimeTest -class Org.Apache.REEF.Wake.Tests.TransportTest
-  - cmd: .\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe .\bin\x64\Debug\Org.Apache.REEF.Tests\Org.Apache.REEF.Tests.dll
+  - cmd: nuget restore .\lang\cs\.nuget\packages.config -o .\lang\cs\packages
+  - cmd: msbuild .\lang\cs\TestRunner.proj /p:Configuration="Debug" /p:Platform="x64"
 
 notifications:
   - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,10 +31,7 @@ install:
 build_script:
   - cmd: msbuild .\lang\cs\Org.Apache.REEF.sln /p:Configuration="Debug" /p:Platform="x64" /m
 
-# test script temporarily excludes StreamingRemoteManagerTest (see REEF-1311) and downloads xunit.runner.console
-# to be reverted as part of REEF-1243
 test_script:
-  - cmd: nuget restore .\lang\cs\.nuget\packages.config -o .\lang\cs\packages
   - cmd: msbuild .\lang\cs\TestRunner.proj /p:Configuration="Debug" /p:Platform="x64"
 
 notifications:

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportClient.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportClient.cs
@@ -68,7 +68,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
             : this(remoteEndpoint, streamingCodec, clientFactory)
         {
             _observer = observer;
-            Task.Run(() => ResponseLoop());
+            Task.Factory.StartNew(() => ResponseLoop(), TaskCreationOptions.LongRunning);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportServer.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportServer.cs
@@ -82,7 +82,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         public void Run()
         {
             FindAPortAndStartListener();
-            _serverTask = Task.Run(() => StartServer());
+            _serverTask = Task.Factory.StartNew(() => StartServer(), TaskCreationOptions.LongRunning);
         }
 
         private void FindAPortAndStartListener()
@@ -131,21 +131,16 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
 
                 if (_serverTask != null)
                 {
-                    _serverTask.Wait();
-
                     // Give the TransportServer Task 500ms to shut down, ignore any timeout errors
                     try
                     {
                         CancellationTokenSource serverDisposeTimeout = new CancellationTokenSource(500);
                         _serverTask.Wait(serverDisposeTimeout.Token);
+                        _serverTask.Dispose();
                     }
                     catch (Exception e)
                     {
-                        Console.Error.WriteLine(e);
-                    }
-                    finally
-                    {
-                        _serverTask.Dispose();
+                        Exceptions.Caught(e, Level.Warning, LOGGER);
                     }
                 }
             }


### PR DESCRIPTION
…ppVeyor

This addressed the issue by
  * Using dedicated threads for long running and blocking Tasks.
  * Removing duplicated Wait calls in StreamingTransportServer.

JIRA:
  [REEF-1243](https://issues.apache.org/jira/browse/REEF-1243)