### PR TITLE
[REEF-1374] Task failure heartbeat could be sent after Evaluator fail…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Globalization;
-using System.Linq;
 using System.Threading;
 using Org.Apache.REEF.Common.Protobuf.ReefProtocol;
 using Org.Apache.REEF.Common.Tasks;
@@ -220,8 +219,6 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
         {
             Logger.Log(Level.Info, "TaskRuntime::OnNext(ICloseEvent value)");
             _closeHandlerFuture.Get().OnNext(value);
-
-            // TODO: send a heartbeat
         }
 
         public void OnNext(ISuspendEvent value)


### PR DESCRIPTION
…ure heartbeat

This addressed the issue by
  * Disabling Evaluator heartbeats after the Evaluator declares itself as DONE or KILLED or FAILED.

JIRA:
  [REEF-1374](https://issues.apache.org/jira/browse/REEF-1374)