### PR TITLE
[REEF-1390] Compute Optional Class' methods on demand

### DIFF
--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/Optional.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/Optional.java
@@ -35,8 +35,8 @@ public final class Optional<T> implements Serializable {
   private static final long serialVersionUID = 42L;
 
   private final T value;
-  private static final String EMPTY_VALUE_STR = "OptionalvNothing";
-  private static final int EMPTY_VALUE_HASH = 0;
+  private static final Optional<?> EMPTY = new Optional<>();
+  private static final String EMPTY_VALUE_STR = "Optional.empty";
 
   private Optional(final T value) {
     this.value = value;
@@ -61,7 +61,7 @@ public final class Optional<T> implements Serializable {
    * @return an Optional with no value.
    */
   public static <T> Optional<T> empty() {
-    return new Optional<>();
+    return (Optional<T>) EMPTY;
   }
 
   /**
@@ -118,19 +118,11 @@ public final class Optional<T> implements Serializable {
 
   @Override
   public int hashCode() {
-    if (this.isPresent()) {
-      return this.value.hashCode();
-    } else {
-      return EMPTY_VALUE_HASH;
-    }
+    return this.value == null ? 0 : this.value.hashCode();
   }
 
   @Override
   public String toString() {
-    if (this.isPresent()) {
-      return "Optional:{" + this.value + "}";
-    } else {
-      return EMPTY_VALUE_STR;
-    }
+    return this.value == null ? EMPTY_VALUE_STR : "Optional:{" + this.value + "}";
   }
 }

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/Optional.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/Optional.java
@@ -35,19 +35,15 @@ public final class Optional<T> implements Serializable {
   private static final long serialVersionUID = 42L;
 
   private final T value;
-  private final String valueStr;
-  private final int valueHash;
+  private static final String EMPTY_VALUE_STR = "OptionalvNothing";
+  private static final int EMPTY_VALUE_HASH = 0;
 
   private Optional(final T value) {
     this.value = value;
-    this.valueStr = "Optional:{" + value + '}';
-    this.valueHash = value.hashCode();
   }
 
   private Optional() {
     this.value = null;
-    this.valueStr = "OptionalvNothing";
-    this.valueHash = 0;
   }
 
   /**
@@ -122,11 +118,19 @@ public final class Optional<T> implements Serializable {
 
   @Override
   public int hashCode() {
-    return this.valueHash;
+    if (this.isPresent()) {
+      return this.value.hashCode();
+    } else {
+      return EMPTY_VALUE_HASH;
+    }
   }
 
   @Override
   public String toString() {
-    return this.valueStr;
+    if (this.isPresent()) {
+      return "Optional:{" + this.value + "}";
+    } else {
+      return EMPTY_VALUE_STR;
+    }
   }
 }


### PR DESCRIPTION
This PR:
- fixes `util/Optional` so that computation for `hashCode()` and
  `toString()` are done upon function calls.
- fixes `util/Optional` so that requesting for empty `Optional`s return a reference of a static variable instead of making new objects every time.

JIRA: [REEF-1390](https://issues.apache.org/jira/browse/REEF-1390)
PR: This resolves #1003