### PR TITLE
[REEF-1357] Allow different caching levels for caching in IInputParti…

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.Tests/Org.Apache.REEF.IO.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/Org.Apache.REEF.IO.Tests.csproj
@@ -56,6 +56,7 @@ under the License.
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestAzureBlockBlobFileSystem.cs" />
     <Compile Include="TestAzureBlockBlobFileSystemE2E.cs" />
+    <Compile Include="TestDataCache.cs" />
     <Compile Include="TestFilePartitionInputDataSet.cs" />
     <Compile Include="TestHadoopFileSystem.cs" />
     <Compile Include="TestLocalFileSystem.cs" />

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestDataCache.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestDataCache.cs
@@ -1,0 +1,388 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Org.Apache.REEF.IO.Files;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Util;
+using Xunit;
+
+namespace Org.Apache.REEF.IO.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="DataCache{T}"/>.
+    /// </summary>
+    public sealed class TestDataCache 
+    {
+        private const string AnyTestStr = "AnyTestString";
+
+        private static readonly byte[] AnyTestStrBytes = Encoding.UTF8.GetBytes(AnyTestStr);
+        private static readonly MemoryStream AnyTestStrStream = new MemoryStream(AnyTestStrBytes);
+        private static readonly string[] MaterializeCompareArray = new[] { AnyTestStr };
+
+        private TestContext _context;
+
+        public TestDataCache()
+        {
+            _context = new TestContext();
+        }
+
+        /// <summary>
+        /// Tests that caching to a lower level returns the lower level.
+        /// </summary>
+        [Fact]
+        public void TestCacheToLowerLevelReturnsLowerLevel()
+        {
+            var cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+            Assert.Equal(CacheLevel.Disk, cache.Cache(CacheLevel.Disk, false));
+            Assert.Equal(CacheLevel.Disk, cache.CacheLevel);
+            Assert.True(cache.DiskDirectory.IsPresent());
+            Assert.Equal(CacheLevel.InMemoryAsStream, cache.Cache(CacheLevel.InMemoryAsStream, false));
+            Assert.Equal(CacheLevel.InMemoryAsStream, cache.CacheLevel);
+            Assert.True(cache.MemoryStreams.IsPresent());
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.Cache(CacheLevel.InMemoryMaterialized, false));
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.CacheLevel);
+            Assert.True(cache.Materialized.IsPresent());
+        }
+
+        /// <summary>
+        /// Tests that caching to a higher level does not perform any action.
+        /// </summary>
+        [Fact]
+        public void TestCacheToHigherLevelReturnsLowerLevel()
+        {
+            var cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.Cache(CacheLevel.InMemoryMaterialized, false));
+            Assert.True(cache.Materialized.IsPresent());
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.Cache(CacheLevel.Disk, false));
+            Assert.False(cache.DiskDirectory.IsPresent());
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.Cache(CacheLevel.InMemoryAsStream, false));
+            Assert.False(cache.MemoryStreams.IsPresent());
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.Cache(CacheLevel.InMemoryMaterialized, false));
+        }
+
+        /// <summary>
+        /// Tests that using the clean cache option returns the right level.
+        /// </summary>
+        [Fact]
+        public void TestCleanCacheWhileLoweringLevelReturnsRightLevel()
+        {
+            var cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+            Assert.Equal(CacheLevel.NotLocal, cache.CacheLevel);
+            Assert.Equal(CacheLevel.Disk, cache.Cache(CacheLevel.Disk, true));
+            Assert.Equal(CacheLevel.Disk, cache.CacheLevel);
+            Assert.Equal(CacheLevel.InMemoryAsStream, cache.Cache(CacheLevel.InMemoryAsStream, true));
+            Assert.Equal(CacheLevel.InMemoryAsStream, cache.CacheLevel);
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.Cache(CacheLevel.InMemoryMaterialized, true));
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.CacheLevel);
+            Assert.Equal(CacheLevel.NotLocal, cache.CleanCacheAtLevel(CacheLevel.InMemoryMaterialized));
+            Assert.Equal(CacheLevel.NotLocal, cache.CacheLevel);
+        }
+
+        /// <summary>
+        /// Tests that cleaning the cache cleans all upper level caches.
+        /// </summary>
+        [Fact]
+        public void TestCleanCacheClearsAllUpperCacheLevels()
+        {
+            var cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+            Assert.Equal(CacheLevel.Disk, cache.Cache(CacheLevel.Disk, false));
+            Assert.Equal(CacheLevel.InMemoryAsStream, cache.Cache(CacheLevel.InMemoryAsStream, false));
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.Cache(CacheLevel.InMemoryMaterialized, true));
+            Assert.Equal(CacheLevel.NotLocal, cache.CleanCacheAtLevel(CacheLevel.InMemoryMaterialized));
+        }
+
+        /// <summary>
+        /// Tests clear cache cleans all state and returns right level.
+        /// </summary>
+        [Fact]
+        public void TestClearCache()
+        {
+            var cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+            Assert.Equal(CacheLevel.Disk, cache.Cache(CacheLevel.Disk, false));
+            Assert.Equal(CacheLevel.InMemoryAsStream, cache.Cache(CacheLevel.InMemoryAsStream, false));
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.Cache(CacheLevel.InMemoryMaterialized, false));
+            cache.Clear();
+            Assert.False(cache.DiskDirectory.IsPresent());
+            Assert.False(cache.MemoryStreams.IsPresent());
+            Assert.False(cache.Materialized.IsPresent());
+            Assert.Equal(CacheLevel.NotLocal, cache.CacheLevel);
+        }
+
+        /// <summary>
+        /// Tests cleaning the cache with non-consecutive cache levels.
+        /// </summary>
+        [Fact]
+        public void TestCleanCacheJumpLevels()
+        {
+            var cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+            Assert.Equal(CacheLevel.Disk, cache.Cache(CacheLevel.Disk, false));
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.Cache(CacheLevel.InMemoryMaterialized, false));
+            Assert.Equal(CacheLevel.Disk, cache.CleanCacheAtLevel(CacheLevel.InMemoryMaterialized));
+        }
+
+        /// <summary>
+        /// Tests cleaning the cache returns the right level.
+        /// </summary>
+        [Fact]
+        public void TestCleanCacheReturnsRightLevel()
+        {
+            var cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+            cache.Cache(CacheLevel.InMemoryMaterialized, false);
+            
+            Assert.Equal(CacheLevel.NotLocal, cache.CleanCacheAtLevel(CacheLevel.InMemoryMaterialized));
+
+            cache.Cache(CacheLevel.Disk, false);
+            cache.Cache(CacheLevel.InMemoryAsStream, false);
+            cache.Cache(CacheLevel.InMemoryMaterialized, false);
+            Assert.Equal(CacheLevel.InMemoryAsStream, cache.CleanCacheAtLevel(CacheLevel.InMemoryMaterialized));
+            Assert.Equal(CacheLevel.Disk, cache.CleanCacheAtLevel(CacheLevel.InMemoryAsStream));
+            Assert.Equal(CacheLevel.NotLocal, cache.CleanCacheAtLevel(CacheLevel.Disk));
+        }
+
+        /// <summary>
+        /// Tests materialization from different cache levels.
+        /// </summary>
+        [Fact]
+        public void TestMaterializeFromDifferentLevels()
+        {
+            var cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+
+            // Test remote to materialized
+            Assert.True(MaterializeCompareArray.SequenceEqual(cache.Materialize()));
+            _context.DataMover.ReceivedWithAnyArgs(1).RemoteToMaterialized();
+            Assert.Equal(CacheLevel.NotLocal, cache.CacheLevel);
+
+            Assert.True(MaterializeCompareArray.SequenceEqual(cache.MaterializeAndCache(false)));
+            _context.DataMover.ReceivedWithAnyArgs(2).RemoteToMaterialized();
+
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.CacheLevel);
+            cache.Clear();
+
+            // Test disk to materialized
+            cache.Cache(CacheLevel.Disk, false);
+            Assert.True(MaterializeCompareArray.SequenceEqual(cache.Materialize()));
+            _context.DataMover.ReceivedWithAnyArgs(1).DiskToMaterialized(_context.DirectoryInfo);
+
+            Assert.Equal(CacheLevel.Disk, cache.CacheLevel);
+            Assert.True(MaterializeCompareArray.SequenceEqual(cache.MaterializeAndCache(false)));
+            _context.DataMover.ReceivedWithAnyArgs(2).DiskToMaterialized(_context.DirectoryInfo);
+
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.CacheLevel);
+            cache.Clear();
+
+            // Test memStream to materialized
+            cache.Cache(CacheLevel.InMemoryAsStream, false);
+            Assert.True(MaterializeCompareArray.SequenceEqual(cache.Materialize()));
+            _context.DataMover.ReceivedWithAnyArgs(1).MemoryToMaterialized(new[] { AnyTestStrStream });
+
+            Assert.Equal(CacheLevel.InMemoryAsStream, cache.CacheLevel);
+            Assert.True(MaterializeCompareArray.SequenceEqual(cache.MaterializeAndCache(false)));
+            _context.DataMover.ReceivedWithAnyArgs(2).MemoryToMaterialized(new[] { AnyTestStrStream });
+
+            Assert.Equal(CacheLevel.InMemoryMaterialized, cache.CacheLevel);
+            cache.Clear();
+        }
+
+        /// <summary>
+        /// Tests that after successfully caching state, data is not moved again.
+        /// </summary>
+        [Fact]
+        public void TestCachedDoesNotInvokeDataMover()
+        {
+            var cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+            cache.Cache(CacheLevel.InMemoryMaterialized, false);
+            _context.DataMover.ClearReceivedCalls();
+            var materialized = cache.Materialize();
+            Assert.True(MaterializeCompareArray.SequenceEqual(materialized));
+            _context.DataMover.ReceivedWithAnyArgs(0).RemoteToMaterialized();
+            cache.Cache(CacheLevel.InMemoryMaterialized, false);
+            _context.DataMover.ReceivedWithAnyArgs(0).RemoteToMaterialized();
+        }
+
+        /// <summary>
+        /// Tests that throwing an Exception in Data Mover does not corrupt
+        /// the state of the cache.
+        /// </summary>
+        [Fact]
+        public void TestErrorThrowingDataMoverDoesNotCorruptState()
+        {
+            var cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+
+            // Test remote to disk.
+            _context.DataMover.RemoteToDisk().ThrowsForAnyArgs(new Exception());
+
+            try
+            {
+                cache.Cache(CacheLevel.Disk, false);
+            }
+            catch (Exception)
+            {
+                // Empty to suppress exception.
+            }
+
+            _context.DataMover.ReceivedWithAnyArgs(1).RemoteToDisk();
+            Assert.Equal(CacheLevel.NotLocal, cache.CacheLevel);
+            Assert.False(cache.DiskDirectory.IsPresent());
+
+            // Test remote to memory stream.
+            _context = new TestContext();
+            cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+
+            _context.DataMover.RemoteToMaterialized().ThrowsForAnyArgs(new Exception());
+
+            try
+            {
+                cache.Cache(CacheLevel.InMemoryMaterialized, false);
+            }
+            catch (Exception)
+            {
+                // Empty to suppress exception.
+            }
+
+            _context.DataMover.ReceivedWithAnyArgs(1).RemoteToMaterialized();
+            Assert.Equal(CacheLevel.NotLocal, cache.CacheLevel);
+            Assert.False(cache.Materialized.IsPresent());
+
+            // Test remote to materialized.
+            _context = new TestContext();
+            cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+
+            _context.DataMover.RemoteToMemory().ThrowsForAnyArgs(new Exception());
+
+            try
+            {
+                cache.Cache(CacheLevel.InMemoryAsStream, false);
+            }
+            catch (Exception)
+            {
+                // Empty to suppress exception.
+            }
+
+            _context.DataMover.ReceivedWithAnyArgs(1).RemoteToMemory();
+            Assert.Equal(CacheLevel.NotLocal, cache.CacheLevel);
+            Assert.False(cache.MemoryStreams.IsPresent());
+
+            // Test disk to memory streams.
+            _context = new TestContext();
+            cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+
+            cache.Cache(CacheLevel.Disk, false);
+            _context.DataMover.DiskToMemory(_context.DirectoryInfo).ThrowsForAnyArgs(new Exception());
+
+            try
+            {
+                cache.Cache(CacheLevel.InMemoryAsStream, true);
+            }
+            catch (Exception)
+            {
+                // Empty to suppress exception.
+            }
+
+            _context.DataMover.ReceivedWithAnyArgs(1).DiskToMemory(_context.DirectoryInfo);
+            Assert.Equal(CacheLevel.Disk, cache.CacheLevel);
+            Assert.True(cache.DiskDirectory.IsPresent());
+            Assert.False(cache.MemoryStreams.IsPresent());
+
+            // Test disk to materialized
+            _context = new TestContext();
+            cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+
+            cache.Cache(CacheLevel.Disk, false);
+            _context.DataMover.DiskToMaterialized(_context.DirectoryInfo).ThrowsForAnyArgs(new Exception());
+
+            try
+            {
+                cache.Cache(CacheLevel.InMemoryMaterialized, true);
+            }
+            catch (Exception)
+            {
+                // Empty to suppress exception.
+            }
+
+            _context.DataMover.ReceivedWithAnyArgs(1).DiskToMaterialized(_context.DirectoryInfo);
+            Assert.Equal(CacheLevel.Disk, cache.CacheLevel);
+            Assert.True(cache.DiskDirectory.IsPresent());
+            Assert.False(cache.Materialized.IsPresent());
+
+            // Test memory streams to materialized.
+            _context = new TestContext();
+            cache = _context.GetDataCache();
+            SubstituteForBasicDataMover();
+
+            cache.Cache(CacheLevel.InMemoryAsStream, false);
+            _context.DataMover.MemoryToMaterialized(new[] { AnyTestStrStream }).ThrowsForAnyArgs(new Exception());
+
+            try
+            {
+                cache.Cache(CacheLevel.InMemoryMaterialized, true);
+            }
+            catch (Exception)
+            {
+                // Empty to suppress exception.
+            }
+
+            _context.DataMover.ReceivedWithAnyArgs(1).MemoryToMaterialized(new[] { AnyTestStrStream });
+            Assert.Equal(CacheLevel.InMemoryAsStream, cache.CacheLevel);
+            Assert.True(cache.MemoryStreams.IsPresent());
+            Assert.False(cache.Materialized.IsPresent());
+        }
+
+        private void SubstituteForBasicDataMover()
+        {
+            _context.DataMover.RemoteToDisk().ReturnsForAnyArgs(_context.DirectoryInfo);
+            _context.DataMover.RemoteToMemory().ReturnsForAnyArgs(new[] { AnyTestStrStream });
+            _context.DataMover.RemoteToMaterialized().ReturnsForAnyArgs(new[] { AnyTestStr });
+            _context.DataMover.DiskToMaterialized(_context.DirectoryInfo).ReturnsForAnyArgs(new[] { AnyTestStr });
+            _context.DataMover.DiskToMemory(_context.DirectoryInfo).ReturnsForAnyArgs(new[] { AnyTestStrStream });
+            _context.DataMover.MemoryToMaterialized(new[] { AnyTestStrStream }).ReturnsForAnyArgs(new[] { AnyTestStr });
+        }
+
+        private class TestContext
+        {
+            public readonly IInputDataMover<string> DataMover = Substitute.For<IInputDataMover<string>>();
+
+            public readonly IDirectoryInfo DirectoryInfo = Substitute.For<IDirectoryInfo>();
+
+            public DataCache<string> GetDataCache()
+            {
+                var injector = TangFactory.GetTang().NewInjector();
+                injector.BindVolatileInstance(GenericType<IInputDataMover<string>>.Class, DataMover);
+                return injector.GetInstance<DataCache<string>>();
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using Org.Apache.REEF.IO.PartitionedData;
 using Org.Apache.REEF.IO.PartitionedData.FileSystem;
 using Org.Apache.REEF.IO.PartitionedData.FileSystem.Parameters;
@@ -95,7 +96,7 @@ namespace Org.Apache.REEF.IO.Tests
                     Assert.NotNull(partition);
                     Assert.NotNull(partition.Id);
                     int count = 0;
-                    var e = partition.GetPartitionHandle();
+                    var e = partition.GetPartitionHandle().First();
                     foreach (var v in e)
                     {
                         Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Data read {0}: ", v));
@@ -173,7 +174,7 @@ namespace Org.Apache.REEF.IO.Tests
                         .GetInstance<IInputPartition<IEnumerable<byte>>>();
                 using (partition as IDisposable)
                 {
-                    var e = partition.GetPartitionHandle();
+                    var e = partition.GetPartitionHandle().First();
                     foreach (var v in e)
                     {
                         Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Data read {0}: ", v));
@@ -211,7 +212,7 @@ namespace Org.Apache.REEF.IO.Tests
                         .GetInstance<IInputPartition<IEnumerable<Row>>>();
                 using (partition as IDisposable)
                 {
-                    IEnumerable<Row> e = partition.GetPartitionHandle();
+                    IEnumerable<Row> e = partition.GetPartitionHandle().First();
 
                     foreach (var row in e)
                     {
@@ -256,7 +257,7 @@ namespace Org.Apache.REEF.IO.Tests
                         .GetInstance<IInputPartition<IEnumerable<Row>>>();
                 using (partition as IDisposable)
                 {
-                    IEnumerable<Row> e = partition.GetPartitionHandle();
+                    IEnumerable<Row> e = partition.GetPartitionHandle().First();
 
                     foreach (var row in e)
                     {

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestRandomInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestRandomInputDataSet.cs
@@ -17,6 +17,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Org.Apache.REEF.IO.PartitionedData;
 using Org.Apache.REEF.IO.PartitionedData.Random;
 using Org.Apache.REEF.Tang.Implementations.Tang;
@@ -89,9 +90,10 @@ namespace Org.Apache.REEF.IO.Tests
                 Assert.NotNull(partition);
                 Assert.NotNull(partition.Id);
 
-                using (var partitionStream = partition.GetPartitionHandle())
+                var partitionStreams = partition.GetPartitionHandle();
+                Assert.NotNull(partitionStreams);
+                using (var partitionStream = partitionStreams.Single())
                 {
-                    Assert.NotNull(partitionStream);
                     Assert.True(partitionStream.CanRead);
                     Assert.False(partitionStream.CanWrite);
                     Assert.Equal(ExpectedNumberOfBytesPerPartition, partitionStream.Length);

--- a/lang/cs/Org.Apache.REEF.IO/CacheLevel.cs
+++ b/lang/cs/Org.Apache.REEF.IO/CacheLevel.cs
@@ -25,21 +25,21 @@ namespace Org.Apache.REEF.IO
         /// <summary>
         /// The data is deserialized.
         /// </summary>
-        InMemoryMaterialized = 0,
+        InMemoryMaterialized = 100,
 
         /// <summary>
         /// The data is in memory, but as MemoryStream.
         /// </summary>
-        InMemoryAsStream = 1,
+        InMemoryAsStream = 200,
 
         /// <summary>
         /// The data is in disk.
         /// </summary>
-        Disk = 2,
+        Disk = 5000,
         
         /// <summary>
         /// The data is not local.
         /// </summary>
-        NotLocal = 3,
+        NotLocal = 10000,
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/CacheLevel.cs
+++ b/lang/cs/Org.Apache.REEF.IO/CacheLevel.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,34 +15,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System.Collections.Generic;
-using Org.Apache.REEF.Utilities.Attributes;
-
-namespace Org.Apache.REEF.IO.PartitionedData
+namespace Org.Apache.REEF.IO
 {
     /// <summary>
-    /// Evaluator-Side representation of a data set partition.
+    /// The level at which data is cached.
     /// </summary>
-    /// <typeparam name="T">Generic Type representing data pointer.
-    /// For example, for data in local file it can be file pointer </typeparam>
-    [Unstable("API contract may change.")]
-    public interface IInputPartition<T> 
+    public enum CacheLevel
     {
         /// <summary>
-        /// The id of the partition.
+        /// The data is deserialized.
         /// </summary>
-        string Id { get; }
+        InMemoryMaterialized = 0,
 
         /// <summary>
-        /// Caches the data based on the method parameter. Returns the actual cached level.
+        /// The data is in memory, but as MemoryStream.
         /// </summary>
-        [Unstable("0.15", "Contract may change.")]
-        CacheLevel Cache(CacheLevel level);
+        InMemoryAsStream = 1,
 
         /// <summary>
-        /// Gives a pointer to the underlying partition.
+        /// The data is in disk.
         /// </summary>
-        /// <returns>The pointer to the underlying partition</returns>
-        IEnumerable<T> GetPartitionHandle();
+        Disk = 2,
+        
+        /// <summary>
+        /// The data is not local.
+        /// </summary>
+        NotLocal = 3,
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/DataCache.cs
+++ b/lang/cs/Org.Apache.REEF.IO/DataCache.cs
@@ -1,0 +1,434 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Org.Apache.REEF.IO.Files;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Exceptions;
+using Org.Apache.REEF.Utilities;
+using Org.Apache.REEF.Utilities.Attributes;
+
+namespace Org.Apache.REEF.IO
+{
+    /// <summary>
+    /// A class that manages the caching of data at different layers of storage medium.
+    /// </summary>
+    [Unstable("0.15", "API contract may change.")]
+    public sealed class DataCache<T>
+    {
+        private readonly IInputDataMover<T> _inputDataMover;
+
+        private Optional<IDirectoryInfo> _diskDirectory = Optional<IDirectoryInfo>.Empty();
+        private Optional<IReadOnlyCollection<MemoryStream>> _memStreams = Optional<IReadOnlyCollection<MemoryStream>>.Empty();
+        private Optional<IReadOnlyCollection<T>> _materialized = Optional<IReadOnlyCollection<T>>.Empty();
+
+        private CacheLevel _lowestCacheLevel = CacheLevel.NotLocal;
+
+        [Inject]
+        private DataCache(IInputDataMover<T> inputDataMover)
+        {
+            _inputDataMover = inputDataMover;
+        }
+
+        /// <summary>
+        /// The current level at which the data is cached.
+        /// </summary>
+        public CacheLevel CacheLevel
+        {
+            get { return _lowestCacheLevel; }
+        }
+
+        /// <summary>
+        /// The directory where cached data resides, if the data is cached on disk.
+        /// </summary>
+        public Optional<IDirectoryInfo> DiskDirectory
+        {
+            get { return _diskDirectory; }
+        }
+
+        /// <summary>
+        /// The collection of memory streams where cached data resides, if the data is
+        /// cached in memory.
+        /// </summary>
+        public Optional<IReadOnlyCollection<MemoryStream>> MemoryStreams
+        {
+            get { return _memStreams; }
+        }
+
+        /// <summary>
+        /// The cached collection of "materialized" objects, if the data is cached
+        /// in memory and deserialized.
+        /// </summary>
+        public Optional<IReadOnlyCollection<T>> Materialized
+        {
+            get { return _materialized; }
+        }
+
+        /// <summary>
+        /// Clears all levels of cache.
+        /// </summary>
+        public void Clear()
+        {
+            while (CleanCacheAtLevel(CacheLevel) != CacheLevel.NotLocal)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Cache the data to a <see cref="CacheLevel"/>.
+        /// If the data is already cached at a lower level, no action will be taken.
+        /// </summary>
+        /// <param name="cacheToLevel">Level to cache to.</param>
+        /// <param name="shouldCleanHigherLevelCache">Whether or not to clean the higher level caches.</param>
+        /// <returns>The cached level.</returns>
+        public CacheLevel Cache(CacheLevel cacheToLevel, bool shouldCleanHigherLevelCache)
+        {
+            if (_lowestCacheLevel <= cacheToLevel)
+            {
+                return _lowestCacheLevel;
+            }
+
+            switch (cacheToLevel)
+            {
+                case CacheLevel.NotLocal:
+                    return _lowestCacheLevel;
+                case CacheLevel.Disk:
+                    return CacheToDisk();
+                case CacheLevel.InMemoryAsStream:
+                    return CacheToMemory(shouldCleanHigherLevelCache);
+                case CacheLevel.InMemoryMaterialized:
+                    return CacheToMaterialized(shouldCleanHigherLevelCache);
+                default:
+                    throw new SystemException("Unexpected cache level " + cacheToLevel);
+            }
+        }
+
+        /// <summary>
+        /// Cleans up the cache at the specified cache level.
+        /// </summary>
+        /// <returns>the lowest cache level.</returns>
+        public CacheLevel CleanCacheAtLevel(CacheLevel cacheLevel)
+        {
+            switch (cacheLevel)
+            {
+                case CacheLevel.Disk:
+                    CleanUpDisk(false);
+                    break;
+                case CacheLevel.InMemoryAsStream:
+                    CleanUpMemoryStreams(false);
+                    break;
+                case CacheLevel.InMemoryMaterialized:
+                    CleanUpMaterialized(false);
+                    break;
+            }
+
+            _lowestCacheLevel = FindLowestCacheLevel();
+            return _lowestCacheLevel;
+        }
+
+        /// <summary>
+        /// Finds the lowest cache level.
+        /// </summary>
+        private CacheLevel FindLowestCacheLevel()
+        {
+            if (CheckMaterialized(false))
+            {
+                return CacheLevel.InMemoryMaterialized;
+            }
+
+            if (CheckMemoryStreams(false))
+            {
+                return CacheLevel.InMemoryAsStream;
+            }
+
+            if (CheckDisk(false))
+            {
+                return CacheLevel.Disk;
+            }
+
+            return CacheLevel.NotLocal;
+        }
+
+        /// <summary>
+        /// Cache to disk with the injected <see cref="IInputDataMover{T}"/>.
+        /// </summary>
+        /// <returns>The cached level.</returns>
+        private CacheLevel CacheToDisk()
+        {
+            switch (_lowestCacheLevel)
+            {
+                case CacheLevel.NotLocal:
+                    _diskDirectory = Optional<IDirectoryInfo>.Of(_inputDataMover.RemoteToDisk());
+                    break;
+                default:
+                    throw new SystemException(
+                        "Unexpected cache level transition from " + _lowestCacheLevel + " to " + CacheLevel.Disk);
+            }
+
+            _lowestCacheLevel = CacheLevel.Disk;
+            return _lowestCacheLevel;
+        }
+
+        /// <summary>
+        /// Cache to memory with the injected <see cref="IInputDataMover{T}"/>.
+        /// </summary>
+        /// <returns>The cached level.</returns>
+        public CacheLevel CacheToMemory(bool shouldCleanHigherLevelCache)
+        {
+            Optional<IReadOnlyCollection<MemoryStream>> memStreams;
+            switch (_lowestCacheLevel)
+            {
+                case CacheLevel.Disk:
+                    CheckDisk(true);
+                    memStreams = Optional<IReadOnlyCollection<MemoryStream>>.Of(
+                        new List<MemoryStream>(_inputDataMover.DiskToMemory(_diskDirectory.Value)));
+                    break;
+                case CacheLevel.NotLocal:
+                    memStreams = Optional<IReadOnlyCollection<MemoryStream>>.Of(
+                        new List<MemoryStream>(_inputDataMover.RemoteToMemory()));
+                    break;
+                default:
+                    throw new SystemException(
+                        "Unexpected cache level transition from " + _lowestCacheLevel + " to " + CacheLevel.InMemoryAsStream);
+            }
+
+            if (shouldCleanHigherLevelCache)
+            {
+                CleanHigherLevelCache(CacheLevel.InMemoryAsStream);
+            }
+
+            _memStreams = memStreams;
+            _lowestCacheLevel = CacheLevel.InMemoryAsStream;
+            return _lowestCacheLevel;
+        }
+
+        /// <summary>
+        /// "Materializes" and deserializes the data. Also caches to memory.
+        /// To not cache to memory, please use the <see cref="Materialize"/> method.
+        /// </summary>
+        /// <returns>The deserialized data.</returns>
+        public IEnumerable<T> MaterializeAndCache(bool shouldCleanHigherLevelCache)
+        {
+            return Materialize(true, shouldCleanHigherLevelCache);
+        }
+
+        /// <summary>
+        /// "Materializes" and deserializes the data. Does not cache.
+        /// To cache, please use the <see cref="MaterializeAndCache"/> method.
+        /// </summary>
+        /// <returns>The deserialized data.</returns>
+        public IEnumerable<T> Materialize()
+        {
+            return Materialize(false, false);
+        }
+
+        private IEnumerable<T> Materialize(bool shouldCache, bool shouldCleanHigherLevelCache)
+        {
+            if (shouldCache)
+            {
+                CacheToMaterialized(shouldCleanHigherLevelCache);
+            }
+
+            switch (_lowestCacheLevel)
+            {
+                case CacheLevel.InMemoryAsStream:
+                    CheckMemoryStreams(true);
+                    return _inputDataMover.MemoryToMaterialized(_memStreams.Value);
+                case CacheLevel.Disk:
+                    CheckDisk(true);
+                    return _inputDataMover.DiskToMaterialized(_diskDirectory.Value);
+                case CacheLevel.NotLocal:
+                    return _inputDataMover.RemoteToMaterialized();
+                case CacheLevel.InMemoryMaterialized:
+                    CheckMaterialized(true);
+                    return _materialized.Value;
+                default:
+                    throw new IllegalStateException("Illegal cache layer.");
+            }
+        }
+
+        /// <summary>
+        /// Deserialize and cache the data in memory from the level the data is currently at.
+        /// </summary>
+        private CacheLevel CacheToMaterialized(bool shouldCleanHigherLevelCache)
+        {
+            Optional<IReadOnlyCollection<T>> materialized;
+
+            switch (_lowestCacheLevel)
+            {
+                case CacheLevel.InMemoryAsStream:
+                    CheckMemoryStreams(true);
+                    materialized = Optional<IReadOnlyCollection<T>>.Of(
+                        new List<T>(_inputDataMover.MemoryToMaterialized(_memStreams.Value)));
+                    break;
+                case CacheLevel.Disk:
+                    CheckDisk(true);
+                    materialized = Optional<IReadOnlyCollection<T>>.Of(
+                        new List<T>(_inputDataMover.DiskToMaterialized(_diskDirectory.Value)));
+                    
+                    break;
+                case CacheLevel.NotLocal:
+                    materialized = Optional<IReadOnlyCollection<T>>.Of(
+                        new List<T>(_inputDataMover.RemoteToMaterialized()));
+                    break;
+                default:
+                    throw new SystemException(
+                        "Unexpected cache level transition from " + _lowestCacheLevel + " to " + CacheLevel.InMemoryMaterialized);
+            }
+
+            if (shouldCleanHigherLevelCache)
+            {
+                CleanHigherLevelCache(CacheLevel.InMemoryMaterialized);
+            }
+
+            _materialized = materialized;
+            _lowestCacheLevel = CacheLevel.InMemoryMaterialized;
+            return _lowestCacheLevel;
+        }
+
+        /// <summary>
+        /// Cleans up higher level cache recursively towards non-local.
+        /// </summary>
+        private void CleanHigherLevelCache(CacheLevel newLevel)
+        {
+            while (_lowestCacheLevel > newLevel)
+            {
+                switch (_lowestCacheLevel)
+                {
+                    case CacheLevel.InMemoryAsStream:
+                        CleanUpMemoryStreams(true);
+                        break;
+                    case CacheLevel.Disk:
+                        CleanUpDisk(true);
+                        break;
+                    case CacheLevel.InMemoryMaterialized:
+                        CleanUpMaterialized(true);
+                        break;
+                    case CacheLevel.NotLocal:
+                        // We cannot go to a higher level than this, return.
+                        return;
+                    default:
+                        throw new SystemException("Unexpected cache level " + _lowestCacheLevel + ".");
+                }
+
+                var prevLowest = _lowestCacheLevel;
+                _lowestCacheLevel = FindLowestCacheLevel();
+                if (prevLowest > _lowestCacheLevel)
+                {
+                    throw new SystemException("The new lowest CacheLevel must be higher than the previous lowest CacheLevel.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Check that the data is "materialized."
+        /// </summary>
+        private bool CheckMaterialized(bool shouldThrow)
+        {
+            if (_materialized.IsPresent())
+            {
+                return true;
+            }
+
+            if (shouldThrow)
+            {
+                throw new IllegalStateException("Collection is expected to be materialized in memory.");
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Releases reference to the materialized collection such that
+        /// garbage collection can collect. If the user holds a reference to the
+        /// collection, this will not work.
+        /// </summary>
+        private void CleanUpMaterialized(bool shouldThrow)
+        {
+            if (CheckMaterialized(shouldThrow))
+            {
+                _materialized = Optional<IReadOnlyCollection<T>>.Empty();
+            }
+        }
+
+        /// <summary>
+        /// Check that the data is in memory as a <see cref="MemoryStream"/>.
+        /// </summary>
+        private bool CheckMemoryStreams(bool shouldThrow)
+        {
+            if (_memStreams.IsPresent())
+            {
+                return true;
+            }
+
+            if (shouldThrow)
+            {
+                throw new IllegalStateException("Data is expected to be in memory.");
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Clean up the data stored as <see cref="MemoryStream"/>s.
+        /// </summary>
+        private void CleanUpMemoryStreams(bool shouldThrow)
+        {
+            if (CheckMemoryStreams(shouldThrow))
+            {
+                foreach (var memStream in _memStreams.Value)
+                {
+                    memStream.Dispose();
+                }
+
+                _memStreams = Optional<IReadOnlyCollection<MemoryStream>>.Empty();
+            }
+        }
+
+        /// <summary>
+        /// Check that the data is stored on disk.
+        /// </summary>
+        private bool CheckDisk(bool shouldThrow)
+        {
+            if (_diskDirectory.IsPresent())
+            {
+                return true;
+            }
+
+            if (shouldThrow)
+            {
+                throw new IllegalStateException("Disk directory is expected to be present.");
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Clean up the data stored on disk.
+        /// </summary>
+        private void CleanUpDisk(bool shouldThrow)
+        {
+            if (CheckDisk(shouldThrow))
+            {
+                _diskDirectory.Value.Delete(true);
+                _diskDirectory = Optional<IDirectoryInfo>.Empty();
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IO/FileStreamInputDataMover.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileStreamInputDataMover.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Org.Apache.REEF.IO.Files;
+using Org.Apache.REEF.Utilities.Attributes;
+
+namespace Org.Apache.REEF.IO
+{
+    /// <summary>
+    /// An abstract class inherits <see cref="SerializerBasedInputDataMover{T}"/> and models 
+    /// each file as a <see cref="Stream"/> (and consequently each file an object 
+    /// of type T.
+    /// </summary>
+    [Unstable("0.15", "API contract may change.")]
+    public abstract class FileStreamInputDataMover<T> : SerializerBasedInputDataMover<T>
+    {
+        protected FileStreamInputDataMover(ISerializer<T> serializer) 
+            : base(serializer)
+        {
+        }
+
+        /// <summary>
+        /// Moves data from disk to memory as stream, with each file as a <see cref="Stream"/>.
+        /// </summary>
+        public override IEnumerable<MemoryStream> DiskToMemory(IDirectoryInfo info)
+        {
+            foreach (var file in info.EnumerateFiles("*", SearchOption.AllDirectories))
+            {
+                var memStream = new MemoryStream();
+                using (var fileStream = new FileStream(file.FullName, FileMode.Open))
+                {
+                    fileStream.CopyTo(memStream);
+                }
+
+                yield return memStream;
+            }
+        }
+
+        /// <summary>
+        /// Moves data from disk to memory in its deserialized form, with each
+        /// file as an objecto of type <see cref="T"/>.
+        /// </summary>
+        public override IEnumerable<T> DiskToMaterialized(IDirectoryInfo info)
+        {
+            var fileStreams = 
+                info
+                .EnumerateFiles("*", SearchOption.AllDirectories)
+                .Select(file => new FileStream(file.FullName, FileMode.Open));
+
+            return StreamToMaterialized(fileStreams);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IO/IInputDataMover.cs
+++ b/lang/cs/Org.Apache.REEF.IO/IInputDataMover.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Collections.Generic;
+using System.IO;
+using Org.Apache.REEF.IO.Files;
+using Org.Apache.REEF.Utilities.Attributes;
+
+namespace Org.Apache.REEF.IO
+{
+    /// <summary>
+    /// An interface that describes a contract for data movement between 
+    /// different types of storage medium.
+    /// </summary>
+    [Unstable("0.15", "API contract may change.")]
+    public interface IInputDataMover<T>
+    {
+        /// <summary>
+        /// Fetches the data from remote and stores to disk.
+        /// </summary>
+        IDirectoryInfo RemoteToDisk();
+
+        /// <summary>
+        /// Fetches the data from remote and puts in memory without deserialization.
+        /// </summary>
+        IEnumerable<MemoryStream> RemoteToMemory();
+
+        /// <summary>
+        /// Fetches the data from remote and deserializes it.
+        /// </summary>
+        IEnumerable<T> RemoteToMaterialized();
+
+        /// <summary>
+        /// Fetches the data from a directory on disk and puts in memory 
+        /// without deserialization.
+        /// </summary>
+        /// <param name="info">The directory.</param>
+        IEnumerable<MemoryStream> DiskToMemory(IDirectoryInfo info);
+
+        /// <summary>
+        /// Fetches the data from a directory on disk and deserializes it.
+        /// </summary>
+        /// <param name="info"></param>
+        IEnumerable<T> DiskToMaterialized(IDirectoryInfo info);
+
+        /// <summary>
+        /// Deserializes a memory stream.
+        /// </summary>
+        /// <param name="streams">Memory streams to deserialize.</param>
+        /// <returns></returns>
+        IEnumerable<T> MemoryToMaterialized(IEnumerable<MemoryStream> streams);
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IO/ISerializer.cs
+++ b/lang/cs/Org.Apache.REEF.IO/ISerializer.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,34 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System.Collections.Generic;
-using Org.Apache.REEF.Utilities.Attributes;
+using System.IO;
 
-namespace Org.Apache.REEF.IO.PartitionedData
+namespace Org.Apache.REEF.IO
 {
     /// <summary>
-    /// Evaluator-Side representation of a data set partition.
+    /// The interface for a Serializer that serializes an object into a Stream and deserializes
+    /// from a Stream into an object.
     /// </summary>
-    /// <typeparam name="T">Generic Type representing data pointer.
-    /// For example, for data in local file it can be file pointer </typeparam>
-    [Unstable("API contract may change.")]
-    public interface IInputPartition<T> 
+    public interface ISerializer<T>
     {
         /// <summary>
-        /// The id of the partition.
+        /// Serialize into the Stream.
         /// </summary>
-        string Id { get; }
+        void Serialize(T value, Stream stream);
 
         /// <summary>
-        /// Caches the data based on the method parameter. Returns the actual cached level.
+        /// Deserialize from the Stream.
         /// </summary>
-        [Unstable("0.15", "Contract may change.")]
-        CacheLevel Cache(CacheLevel level);
-
-        /// <summary>
-        /// Gives a pointer to the underlying partition.
-        /// </summary>
-        /// <returns>The pointer to the underlying partition</returns>
-        IEnumerable<T> GetPartitionHandle();
+        T Deserialize(Stream stream);
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/Org.Apache.REEF.IO.csproj
+++ b/lang/cs/Org.Apache.REEF.IO/Org.Apache.REEF.IO.csproj
@@ -70,6 +70,8 @@ under the License.
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CacheLevel.cs" />
+    <Compile Include="FileStreamInputDataMover.cs" />
     <Compile Include="FileSystem\AzureBlob\AzureBlockBlobFileSystemConfiguration.cs" />
     <Compile Include="FileSystem\AzureBlob\AzureBlobType.cs" />
     <Compile Include="FileSystem\AzureBlob\AzureBlockBlobFileSystemConfigurationProvider.cs" />
@@ -104,6 +106,10 @@ under the License.
     <Compile Include="Files\IDirectoryInfo.cs" />
     <Compile Include="Files\IFileInfo.cs" />
     <Compile Include="Files\IFileSystemInfo.cs" />
+    <Compile Include="DataCache.cs" />
+    <Compile Include="IInputDataMover.cs" />
+    <Compile Include="ISerializer.cs" />
+    <Compile Include="PartitionedData\DefaultInputPartition.cs" />
     <Compile Include="PartitionedData\FileSystem\FileSystemInputPartition.cs" />
     <Compile Include="PartitionedData\FileSystem\FileInputPartitionDescriptor.cs" />
     <Compile Include="PartitionedData\FileSystem\Parameters\CopyToLocal.cs" />
@@ -124,6 +130,7 @@ under the License.
     <Compile Include="PartitionedData\Random\RandomInputPartition.cs" />
     <Compile Include="PartitionedData\Random\RandomInputPartitionDescriptor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SerializerBasedInputDataMover.cs" />
     <Compile Include="TempFileCreation\ITempFileCreator.cs" />
     <Compile Include="TempFileCreation\TempFileFolder.cs" />
     <Compile Include="TempFileCreation\TempFileConfigurationModule.cs" />

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/DefaultInputPartition.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/DefaultInputPartition.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Collections.Generic;
+using Org.Apache.REEF.IO.PartitionedData.Random.Parameters;
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.IO.PartitionedData
+{
+    /// <summary>
+    /// A default implementation of <see cref="IInputPartition{T}"/> that utilizes 
+    /// an inject <see cref="DataCache{T}"/>.
+    /// </summary>
+    public sealed class DefaultInputPartition<T> : IInputPartition<T>
+    {
+        private readonly DataCache<T> _dataCache;
+        private readonly string _partitionId;
+
+        [Inject]
+        private DefaultInputPartition(
+            [Parameter(typeof(PartitionId))] string partitionId,
+            DataCache<T> dataCache)
+        {
+            _partitionId = partitionId;
+            _dataCache = dataCache;
+        }
+
+        public string Id
+        {
+            get { return _partitionId; }
+        }
+
+        /// <summary>
+        /// Caches to the designated <see cref="CacheLevel"/>.
+        /// </summary>
+        public CacheLevel Cache(CacheLevel level)
+        {
+            return _dataCache.Cache(level, true);
+        }
+
+        /// <summary>
+        /// Materializes from based on the cache level of <see cref="DataCache{T}"/>,
+        /// but does not cache the materialized data.
+        /// </summary>
+        public IEnumerable<T> GetPartitionHandle()
+        {
+            return _dataCache.Materialize();
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IO/SerializerBasedInputDataMover.cs
+++ b/lang/cs/Org.Apache.REEF.IO/SerializerBasedInputDataMover.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Org.Apache.REEF.IO.Files;
+using Org.Apache.REEF.Utilities.Attributes;
+
+namespace Org.Apache.REEF.IO
+{
+    /// <summary>
+    /// A <see cref="IInputDataMover{T}"/> that uses <see cref="ISerializer{T}"/> to deserialize
+    /// data from <see cref="MemoryStream"/>.
+    /// </summary>
+    [Unstable("0.15", "API contract may change.")]
+    public abstract class SerializerBasedInputDataMover<T> : IInputDataMover<T>
+    {
+        private readonly ISerializer<T> _serializer;
+
+        protected SerializerBasedInputDataMover(ISerializer<T> serializer)
+        {
+            _serializer = serializer;
+        }
+
+        protected ISerializer<T> Serializer
+        {
+            get { return _serializer; }
+        }
+
+        public abstract IDirectoryInfo RemoteToDisk();
+
+        public abstract IEnumerable<MemoryStream> RemoteToMemory();
+
+        public abstract IEnumerable<T> RemoteToMaterialized();
+
+        public abstract IEnumerable<MemoryStream> DiskToMemory(IDirectoryInfo info);
+
+        public abstract IEnumerable<T> DiskToMaterialized(IDirectoryInfo info);
+
+        /// <summary>
+        /// Uses an <see cref="ISerializer{T}"/> to deserialize data from <see cref="IEnumerable{MemoryStream}"/>,
+        /// where each stream is an object of type T.
+        /// </summary>
+        public IEnumerable<T> MemoryToMaterialized(IEnumerable<MemoryStream> streams)
+        {
+            return StreamToMaterialized(streams);
+        }
+
+        /// <summary>
+        /// Uses an <see cref="ISerializer{T}"/> to deserialize data from <see cref="IEnumerable{MemoryStream}"/>,
+        /// where each stream is an object of type T.
+        /// </summary>
+        protected IEnumerable<T> StreamToMaterialized(IEnumerable<Stream> streams)
+        {
+            var deserialized = streams.Select(stream => _serializer.Deserialize(stream)).ToList();
+            return deserialized.AsReadOnly();
+        }
+    }
+}


### PR DESCRIPTION
…tion

This addressed the issue by
  * Adding the interface IInputDataMover, which abstracts the movement of data between different memory layers.
  * Adding the DataCache class, which abstracts the caching of data at different storage layers.
  * Changing the IInputPartition interface to work with the new ISerializer.

JIRA:
  [REEF-1357](https://issues.apache.org/jira/browse/REEF-1357)