### PR TITLE
[REEF-1393] Consider active threads when checking applicationDispatch…

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
@@ -32,6 +32,8 @@ import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.driver.parameters.*;
 import org.apache.reef.driver.task.*;
 import org.apache.reef.runtime.common.driver.DriverRuntimeConfiguration;
+import org.apache.reef.runtime.common.driver.parameters.EvaluatorIdlenessThreadPoolSize;
+import org.apache.reef.runtime.common.driver.parameters.EvaluatorIdlenessWaitInMilliseconds;
 import org.apache.reef.tang.formats.*;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.time.Clock;
@@ -177,6 +179,8 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
    */
   public static final OptionalImpl<EventHandler<ContextMessage>> ON_CONTEXT_MESSAGE = new OptionalImpl<>();
 
+  // ***** MISC
+
   /**
    * Progress provider. See {@link ProgressProvider}.
    */
@@ -191,6 +195,18 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
    * The number of submissions that the resource manager will attempt to submit the application. Defaults to 1.
    */
   public static final OptionalParameter<Integer> MAX_APPLICATION_SUBMISSIONS = new OptionalParameter<>();
+
+  /**
+   * The number of Threads in a Driver to verify the completion of Evaluators.
+   * Used by {@link org.apache.reef.runtime.common.driver.evaluator.EvaluatorIdlenessThreadPool}.
+   */
+  public static final OptionalParameter<Integer> EVALUATOR_IDLENESS_THREAD_POOL_SIZE = new OptionalParameter<>();
+
+  /**
+   * The number of Threads in a Driver to verify the completion of Evaluators.
+   * Used by {@link org.apache.reef.runtime.common.driver.evaluator.EvaluatorIdlenessThreadPool}.
+   */
+  public static final OptionalParameter<Long> EVALUATOR_IDLENESS_WAIT_IN_MS = new OptionalParameter<>();
 
   /**
    * ConfigurationModule to fill out to get a legal Driver Configuration.
@@ -235,6 +251,8 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
 
           // Various parameters
       .bindNamedParameter(EvaluatorDispatcherThreads.class, EVALUATOR_DISPATCHER_THREADS)
+      .bindNamedParameter(EvaluatorIdlenessThreadPoolSize.class, EVALUATOR_IDLENESS_THREAD_POOL_SIZE)
+      .bindNamedParameter(EvaluatorIdlenessWaitInMilliseconds.class, EVALUATOR_IDLENESS_WAIT_IN_MS)
       .bindImplementation(ProgressProvider.class, PROGRESS_PROVIDER)
       .build();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverSingletons.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverSingletons.java
@@ -32,6 +32,7 @@ import org.apache.reef.driver.task.*;
 import org.apache.reef.proto.ClientRuntimeProtocol;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseHandler;
+import org.apache.reef.runtime.common.driver.evaluator.EvaluatorIdlenessThreadPool;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.wake.EventHandler;
 
@@ -98,6 +99,8 @@ final class DriverSingletons {
       // we get container failures dure to modifications
       // to already submitted global jar file
       final ResourceLaunchHandler resourceLaunchHandler,
-      final ResourceReleaseHandler resourceReleaseHandler) {
+      final ResourceReleaseHandler resourceReleaseHandler,
+
+      final EvaluatorIdlenessThreadPool evaluatorIdlenessThreadPool) {
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorIdlenessThreadPool.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorIdlenessThreadPool.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.driver.evaluator;
+
+import org.apache.commons.lang3.Validate;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.runtime.common.driver.parameters.EvaluatorIdlenessThreadPoolSize;
+import org.apache.reef.runtime.common.driver.parameters.EvaluatorIdlenessWaitInMilliseconds;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.impl.DefaultThreadFactory;
+
+import javax.inject.Inject;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Runs threads in a thread pool to check the completion of Evaluators on the closing
+ * of an {@link EvaluatorManager} in order to trigger Evaluator idleness checks.
+ */
+@Private
+public final class EvaluatorIdlenessThreadPool {
+  private static final Logger LOG = Logger.getLogger(EvaluatorIdlenessThreadPool.class.getName());
+
+  private final ExecutorService executor;
+  private final long waitInMillis;
+
+  @Inject
+  private EvaluatorIdlenessThreadPool(@Parameter(EvaluatorIdlenessThreadPoolSize.class) final int numThreads,
+                                      @Parameter(EvaluatorIdlenessWaitInMilliseconds.class) final long waitInMillis) {
+
+    Validate.isTrue(waitInMillis >= 0, "EvaluatorIdlenessWaitInMilliseconds must be configured to be >= 0");
+    Validate.isTrue(numThreads > 0, "EvaluatorIdlenessThreadPoolSize must be configured to be > 0");
+
+    this.waitInMillis = waitInMillis;
+    this.executor = Executors.newFixedThreadPool(
+        numThreads, new DefaultThreadFactory(EvaluatorIdlenessThreadPool.class.getName()));
+  }
+
+  /**
+   * Runs a check in the ThreadPool for the {@link EvaluatorManager} to wait for it to finish its
+   * Event Handling and check its idleness source.
+   * @param manager the {@link EvaluatorManager}
+   */
+  void runCheckAsync(final EvaluatorManager manager) {
+    executor.submit(new Runnable() {
+      @Override
+      public void run() {
+        while (!manager.isClosed()) {
+          try {
+            Thread.sleep(waitInMillis);
+          } catch (final InterruptedException e) {
+            LOG.log(Level.SEVERE, "Thread interrupted while waiting for Evaluator to finish.");
+            throw new RuntimeException(e);
+          }
+        }
+
+        manager.checkIdlenessSource();
+        LOG.log(Level.FINE, "Evaluator " + manager.getId() + " has finished.");
+      }
+    });
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/EvaluatorIdlenessThreadPoolSize.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/EvaluatorIdlenessThreadPoolSize.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.driver.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * The number of Threads in a Driver to verify the completion of Evaluators.
+ * Used by {@link org.apache.reef.runtime.common.driver.evaluator.EvaluatorIdlenessThreadPool}.
+ */
+@NamedParameter(doc = "The number of Threads in a Driver to verify the completion of Evaluators.",
+    default_value = "5")
+public final class EvaluatorIdlenessThreadPoolSize implements Name<Integer> {
+  private EvaluatorIdlenessThreadPoolSize(){
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/EvaluatorIdlenessWaitInMilliseconds.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/EvaluatorIdlenessWaitInMilliseconds.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.driver.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * The number of Threads in a Driver to verify the completion of Evaluators.
+ * Used by {@link org.apache.reef.runtime.common.driver.evaluator.EvaluatorIdlenessThreadPool}.
+ */
+@NamedParameter(doc = "The number of milliseconds to wait in a loop to verify the completion of Evaluators.",
+    default_value = "500")
+public final class EvaluatorIdlenessWaitInMilliseconds implements Name<Long> {
+  private EvaluatorIdlenessWaitInMilliseconds(){
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/DispatchingEStage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/DispatchingEStage.java
@@ -114,7 +114,7 @@ public final class DispatchingEStage implements AutoCloseable {
    * Return true if there are no messages queued or in processing, false otherwise.
    */
   public boolean isEmpty() {
-    return this.stage.getQueueLength() == 0;
+    return this.stage.getQueueLength() + this.stage.getActiveCount() == 0;
   }
 
   /**


### PR DESCRIPTION
…er.isEmpty

This addressed the issue by
  * Adding active threads to consideration in applicationDispatcher.isEmpty.
  * Adding a ThreadPool to check for the exit of Evaluator handlers and to trigger a check for the idleness of the Evaluator.

JIRA:
  [REEF-1393](https://issues.apache.org/jira/browse/REEF-1393)