### PR TITLE
[REEF-1392] Adding IObserver<ICloseEvent> for IMRU tasks

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskStates.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskStates.cs
@@ -125,11 +125,22 @@ namespace Org.Apache.REEF.IMRU.Tests
             Action moveNext = () => taskState.MoveNext(TaskStateEvent.RunningTask);
             Assert.Throws<TaskStateTransitionException>(moveNext);
 
-            moveNext = () => taskState.MoveNext(TaskStateEvent.CompletedTask);
-            Assert.Throws<TaskStateTransitionException>(moveNext);
-
             moveNext = () => taskState.MoveNext(TaskStateEvent.SubmittedTask);
             Assert.Throws<TaskStateTransitionException>(moveNext);
+        }
+
+        /// <summary>
+        /// This is to test from WaitingTaskToClose to receiving CompletedTask event
+        /// </summary>
+        [Fact]
+        public void TestRunningToWaitingTaskToCloseToComplete()
+        {
+            var taskState = new TaskStateMachine();
+            taskState.MoveNext(TaskStateEvent.SubmittedTask);
+            taskState.MoveNext(TaskStateEvent.RunningTask);
+            taskState.MoveNext(TaskStateEvent.WaitingTaskToClose);
+            taskState.MoveNext(TaskStateEvent.CompletedTask);
+            Assert.Equal(TaskState.TaskClosedByDriver, taskState.CurrentState);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -329,6 +329,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                 .NewConfigurationBuilder(TaskConfiguration.ConfigurationModule
                     .Set(TaskConfiguration.Identifier, taskId)
                     .Set(TaskConfiguration.Task, GenericType<MapTaskHost<TMapInput, TMapOutput>>.Class)
+                    .Set(TaskConfiguration.OnClose, GenericType<MapTaskHost<TMapInput, TMapOutput>>.Class)
                     .Build(),
                     _configurationManager.MapFunctionConfiguration,
                     mapSpecificConfig,
@@ -350,6 +351,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                         .Set(TaskConfiguration.Identifier,
                             IMRUConstants.UpdateTaskName)
                         .Set(TaskConfiguration.Task,
+                            GenericType<UpdateTaskHost<TMapInput, TMapOutput, TResult>>.Class)
+                        .Set(TaskConfiguration.OnClose,
                             GenericType<UpdateTaskHost<TMapInput, TMapOutput, TResult>>.Class)
                         .Build(),
                         _configurationManager.UpdateFunctionConfiguration,

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/StateMachine/TaskStateMachine.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/StateMachine/TaskStateMachine.cs
@@ -50,6 +50,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver.StateMachine
             { new StateTransition<TaskState, TaskStateEvent>(TaskState.TaskWaitingForClose, TaskStateEvent.FailedTaskSystemError), TaskState.TaskClosedByDriver },
             { new StateTransition<TaskState, TaskStateEvent>(TaskState.TaskWaitingForClose, TaskStateEvent.FailedTaskEvaluatorError), TaskState.TaskClosedByDriver },
             { new StateTransition<TaskState, TaskStateEvent>(TaskState.TaskWaitingForClose, TaskStateEvent.FailedTaskCommunicationError), TaskState.TaskClosedByDriver },
+            { new StateTransition<TaskState, TaskStateEvent>(TaskState.TaskWaitingForClose, TaskStateEvent.CompletedTask), TaskState.TaskClosedByDriver },
             { new StateTransition<TaskState, TaskStateEvent>(TaskState.TaskFailedBySystemError, TaskStateEvent.FailedTaskEvaluatorError), TaskState.TaskFailedByEvaluatorFailure },
             { new StateTransition<TaskState, TaskStateEvent>(TaskState.TaskFailedByGroupCommunication, TaskStateEvent.FailedTaskEvaluatorError), TaskState.TaskFailedByEvaluatorFailure }
         });

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/MapTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/MapTaskHost.cs
@@ -16,7 +16,10 @@
 // under the License.
 
 using System;
+using System.Text;
+using System.Threading;
 using Org.Apache.REEF.Common.Tasks;
+using Org.Apache.REEF.Common.Tasks.Events;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.IMRU.OnREEF.MapInputWithControlMessage;
@@ -24,6 +27,7 @@ using Org.Apache.REEF.IMRU.OnREEF.Parameters;
 using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Network.Group.Task;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities.Attributes;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
@@ -33,7 +37,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
     /// </summary>
     /// <typeparam name="TMapInput">Map input</typeparam>
     /// <typeparam name="TMapOutput">Map output</typeparam>
-    internal sealed class MapTaskHost<TMapInput, TMapOutput> : ITask
+    [ThreadSafe]
+    internal sealed class MapTaskHost<TMapInput, TMapOutput> : ITask, IObserver<ICloseEvent>
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(MapTaskHost<TMapInput, TMapOutput>));
 
@@ -43,14 +48,38 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         private readonly bool _invokeGC;
 
         /// <summary>
+        /// When receiving a close event, this variable is set to 1. At the beginning of each task iteration,
+        /// if this variable is set to 1, the task will break from the loop and return from the Call() method.
+        /// </summary>
+        private long _shouldCloseTask = 0;
+
+        /// <summary>
+        /// Before the task is returned, this variable is set to 1.
+        /// Close handler will check this variable to decide if it needs to throw an exception.
+        /// </summary>
+        private long _isTaskStopped = 0;
+
+        /// <summary>
+        /// Waiting time for the task to close by itself
+        /// </summary>
+        private readonly int _enforceCloseTimeoutMilliseconds;
+
+        /// <summary>
+        /// An event that will wait in close handler until it is either signaled from Call method or timeout.
+        /// </summary>
+        private readonly ManualResetEventSlim _waitToCloseEvent = new ManualResetEventSlim(false);
+
+        /// <summary>
         /// </summary>
         /// <param name="mapTask">The MapTask hosted in this REEF Task.</param>
         /// <param name="groupCommunicationsClient">Used to setup the communications.</param>
+        /// <param name="enforceCloseTimeoutMilliseconds">Timeout to enforce the task to close if receiving task close event</param>
         /// <param name="invokeGC">Whether to call Garbage Collector after each iteration or not</param>
         [Inject]
         private MapTaskHost(
             IMapFunction<TMapInput, TMapOutput> mapTask,
             IGroupCommClient groupCommunicationsClient,
+            [Parameter(typeof(EnforceCloseTimeoutMilliseconds))] int enforceCloseTimeoutMilliseconds,
             [Parameter(typeof(InvokeGC))] bool invokeGC)
         {
             _mapTask = mapTask;
@@ -59,6 +88,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
                 cg.GetBroadcastReceiver<MapInputWithControlMessage<TMapInput>>(IMRUConstants.BroadcastOperatorName);
             _dataReducer = cg.GetReduceSender<TMapOutput>(IMRUConstants.ReduceOperatorName);
             _invokeGC = invokeGC;
+            _enforceCloseTimeoutMilliseconds = enforceCloseTimeoutMilliseconds;
         }
 
         /// <summary>
@@ -68,7 +98,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         /// <returns></returns>
         public byte[] Call(byte[] memento)
         {
-            while (true)
+            while (Interlocked.Read(ref _shouldCloseTask) == 0)
             {
                 if (_invokeGC)
                 {
@@ -91,14 +121,55 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
              
                 _dataReducer.Send(result);
             }
+
+            Interlocked.Exchange(ref _isTaskStopped, 1);
+
+            if (Interlocked.Read(ref _shouldCloseTask) == 1)
+            {
+                _waitToCloseEvent.Set();
+            }
             return null;
         }
 
         /// <summary>
-        /// Dispose function 
+        /// Task close handler.
+        /// If the closed event is sent from driver, set _shouldCloseTask to 1 so that to inform the Call() to stop at the end of the current iteration.
+        /// Then waiting for the signal from Call method. Either it is signaled or after _enforceCloseTimeoutMilliseconds,
+        /// checks if the task has been stopped. If not, throw IMRUTaskSystemException to enforce the task to stop.
+        /// </summary>
+        /// <param name="closeEvent"></param>
+        public void OnNext(ICloseEvent closeEvent)
+        {
+            var msg = Encoding.UTF8.GetString(closeEvent.Value.Value);
+            if (closeEvent.Value.IsPresent() && msg.Equals(TaskManager.CloseTaskByDriver))
+            {
+                Logger.Log(Level.Info, "The task received close event with message: {0}.", msg);
+                Interlocked.Exchange(ref _shouldCloseTask, 1);
+
+                _waitToCloseEvent.Wait(TimeSpan.FromMilliseconds(_enforceCloseTimeoutMilliseconds));
+
+                if (Interlocked.Read(ref _isTaskStopped) == 0)
+                {
+                    throw new IMRUTaskSystemException(TaskManager.TaskKilledByDriver);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Dispose function
         /// </summary>
         public void Dispose()
         {
+        }
+
+        public void OnError(Exception error)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void OnCompleted()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
@@ -16,7 +16,10 @@
 // under the License.
 
 using System;
+using System.Text;
+using System.Threading;
 using Org.Apache.REEF.Common.Tasks;
+using Org.Apache.REEF.Common.Tasks.Events;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.IMRU.OnREEF.MapInputWithControlMessage;
@@ -24,6 +27,7 @@ using Org.Apache.REEF.IMRU.OnREEF.Parameters;
 using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Network.Group.Task;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities.Attributes;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
@@ -34,7 +38,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
     /// <typeparam name="TMapInput">Map input</typeparam>
     /// <typeparam name="TMapOutput">Map output</typeparam>
     /// <typeparam name="TResult">Final result</typeparam>
-    internal sealed class UpdateTaskHost<TMapInput, TMapOutput, TResult> : ITask
+    [ThreadSafe]
+    internal sealed class UpdateTaskHost<TMapInput, TMapOutput, TResult> : ITask, IObserver<ICloseEvent>
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(UpdateTaskHost<TMapInput, TMapOutput, TResult>));
 
@@ -45,16 +50,40 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         private readonly IIMRUResultHandler<TResult> _resultHandler;
 
         /// <summary>
+        /// When receiving a close event, this variable is set to 1. At the beginning of each task iteration,
+        /// if this variable is set to 1, the task will break from the loop and return from the Call() method.
+        /// </summary>
+        private long _shouldCloseTask = 0;
+
+        /// <summary>
+        /// Before the task is returned, this variable is set to 1.
+        /// Close handler will check this variable to decide if it needs to throw an exception.
+        /// </summary>
+        private long _isTaskStopped = 0;
+
+        /// <summary>
+        /// Waiting time for the task to close by itself
+        /// </summary>
+        private readonly int _enforceCloseTimeoutMilliseconds;
+
+        /// <summary>
+        /// An event that will wait in close handler until it is either signaled from Call method or timeout.
+        /// </summary>
+        private readonly ManualResetEventSlim _waitToCloseEvent = new ManualResetEventSlim(false);
+
+        /// <summary>
         /// </summary>
         /// <param name="updateTask">The UpdateTask hosted in this REEF Task.</param>
         /// <param name="groupCommunicationsClient">Used to setup the communications.</param>
         /// <param name="resultHandler">Result handler</param>
+        /// <param name="enforceCloseTimeoutMilliseconds">Timeout in milliseconds to enforce the task to close if receiving task close event</param>
         /// <param name="invokeGC">Whether to call Garbage Collector after each iteration or not</param>
         [Inject]
         private UpdateTaskHost(
             IUpdateFunction<TMapInput, TMapOutput, TResult> updateTask,
             IGroupCommClient groupCommunicationsClient,
             IIMRUResultHandler<TResult> resultHandler,
+            [Parameter(typeof(EnforceCloseTimeoutMilliseconds))] int enforceCloseTimeoutMilliseconds,
             [Parameter(typeof(InvokeGC))] bool invokeGC)
         {
             _updateTask = updateTask;
@@ -64,6 +93,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
             _dataReceiver = cg.GetReduceReceiver<TMapOutput>(IMRUConstants.ReduceOperatorName);
             _invokeGC = invokeGC;
             _resultHandler = resultHandler;
+            _enforceCloseTimeoutMilliseconds = enforceCloseTimeoutMilliseconds;
         }
 
         /// <summary>
@@ -76,7 +106,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
             var updateResult = _updateTask.Initialize();
             int iterNo = 0;
 
-            while (updateResult.HasMapInput)
+            while (updateResult.HasMapInput && Interlocked.Read(ref _shouldCloseTask) == 0)
             {
                 iterNo++;
 
@@ -104,12 +134,45 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
                 }
             }
 
-            MapInputWithControlMessage<TMapInput> stopMessage =
+            if (Interlocked.Read(ref _shouldCloseTask) == 0)
+            {
+                MapInputWithControlMessage<TMapInput> stopMessage =
                     new MapInputWithControlMessage<TMapInput>(MapControlMessage.Stop);
-            _dataAndControlMessageSender.Send(stopMessage);
+                _dataAndControlMessageSender.Send(stopMessage);
+            }
 
             _resultHandler.Dispose();
+            Interlocked.Exchange(ref _isTaskStopped, 1);
+
+            if (Interlocked.Read(ref _shouldCloseTask) == 1)
+            {
+                _waitToCloseEvent.Set();
+            }
             return null;
+        }
+
+        /// <summary>
+        /// Task close handler.
+        /// If the closed event is sent from driver, set _shouldCloseTask to 1 so that to inform the Call() to stop at the end of the current iteration.
+        /// Then waiting for the signal from Call method. Either it is signaled or after _enforceCloseTimeoutMilliseconds,
+        /// checks if the task has been stopped. If not, throw IMRUTaskSystemException to enforce the task to stop.
+        /// </summary>
+        /// <param name="closeEvent"></param>
+        public void OnNext(ICloseEvent closeEvent)
+        {
+            var msg = Encoding.UTF8.GetString(closeEvent.Value.Value);
+            if (closeEvent.Value.IsPresent() && msg.Equals(TaskManager.CloseTaskByDriver))
+            {
+                Logger.Log(Level.Info, "The task received close event with message: {0}.", msg);
+                Interlocked.Exchange(ref _shouldCloseTask, 1);
+
+                _waitToCloseEvent.Wait(TimeSpan.FromMilliseconds(_enforceCloseTimeoutMilliseconds));
+
+                if (Interlocked.Read(ref _isTaskStopped) == 0)
+                {
+                    throw new IMRUTaskSystemException(TaskManager.TaskKilledByDriver);
+                }
+            }
         }
 
         /// <summary>
@@ -117,6 +180,16 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         /// </summary>
         public void Dispose()
         {
+        }
+
+        public void OnError(Exception error)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void OnCompleted()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/EnforceCloseTimeoutMilliseconds.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/EnforceCloseTimeoutMilliseconds.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.IMRU.OnREEF.Parameters
+{
+    /// <summary>
+    /// When driver sends close event to a task, it would expect the task to close gracefully. 
+    /// After specified time out, if the task is still not closed, the close handler will throw exception, 
+    /// enforce the task to close after waiting for this much time (in milliseconds). 
+    /// </summary>
+    [NamedParameter("Enforce the task to close after waiting for this much time (in milliseconds).", "EnforceCloseTimeout", "1000")]
+    internal sealed class EnforceCloseTimeoutMilliseconds : Name<int>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
+++ b/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
@@ -99,6 +99,7 @@ under the License.
     <Compile Include="OnREEF\MapInputWithControlMessage\MapInputWithControlMessage.cs" />
     <Compile Include="OnREEF\MapInputWithControlMessage\MapInputWithControlMessageCodec.cs" />
     <Compile Include="OnREEF\MapInputWithControlMessage\MapInputwithControlMessagePipelineDataConverter.cs" />
+    <Compile Include="OnREEF\Parameters\EnforceCloseTimeoutMilliseconds.cs" />
     <Compile Include="OnREEF\Parameters\InvokeGC .cs" />
     <Compile Include="OnREEF\Parameters\AllowedFailedEvaluatorsFraction.cs" />
     <Compile Include="OnREEF\Parameters\CoresForUpdateTask.cs" />

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -183,7 +183,7 @@ under the License.
       <Project>{6dc3b04e-2b99-4fda-bd23-2c7864f4c477}</Project>
       <Name>Org.Apache.REEF.IMRU.Examples</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Org.Apache.REEF.IMRU\Org.Apache.REEF.IMRU.csproj">
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.IMRU\Org.Apache.REEF.IMRU.csproj">
       <Project>{cc797c57-b465-4d11-98ac-edaaef5899a6}</Project>
       <Name>Org.Apache.REEF.IMRU</Name>
     </ProjectReference>


### PR DESCRIPTION
* IMRU tasks implement IObserver<ICloseEvent>
* Task will return after it receives the close event and completes the current iteration
* Update TaskStateMachine to allow transit from TaskWaitingForClose with CompletedTask event to TaskClosedByDriver state
* Adding test cases

JIRA: [REEF-1392](https://issues.apache.org/jira/browse/REEF-1392)
This closes