### PR TITLE
[REEF-1409] Upgrade HDP2.4 docker image to use 2.4.2 repository

### DIFF
--- a/dev/docker/ubuntu12.04-jdk7-hdp2.4/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.4/Dockerfile
@@ -18,25 +18,25 @@
 FROM reefrt/ubuntu12.04-jdk7
 MAINTAINER Apache REEF <dev@reef.apache.org>
 
-# HDP 2.4.0
+# HDP 2.4.2
 RUN \
-  wget http://public-repo-1.hortonworks.com/HDP/ubuntu12/2.x/updates/2.4.0.0/hdp.list -O /etc/apt/sources.list.d/hdp.list && \
+  wget http://public-repo-1.hortonworks.com/HDP/ubuntu12/2.x/updates/2.4.2.0/hdp.list -O /etc/apt/sources.list.d/hdp.list && \
   gpg --keyserver pgp.mit.edu --recv-keys B9733A7A07513CAD && \
   gpg -a --export 07513CAD | apt-key add - && \
   apt-get update && \
-  apt-get install -y hadoop-2-4-0* && \
+  apt-get install -y hadoop-2-4-2* && \
   apt-get clean
-ENV HADOOP_PREFIX /usr/hdp/2.4.0.0-169/hadoop
+ENV HADOOP_PREFIX /usr/hdp/2.4.2.0-258/hadoop
 
 ENV YARN_CONF_DIR $HADOOP_PREFIX/etc/hadoop
 RUN \
-  echo 'HADOOP_PREFIX="/usr/hdp/2.4.0.0-169/hadoop"' >> /etc/environment && \
-  echo 'HADOOP_COMMON_HOME="/usr/hdp/2.4.0.0-169/hadoop"' >> /etc/environment && \
-  echo 'HADOOP_HDFS_HOME="/usr/hdp/2.4.0.0-169/hadoop"' >> /etc/environment && \
-  echo 'HADOOP_MAPRED_HOME="/usr/hdp/2.4.0.0-169/hadoop"' >> /etc/environment && \
-  echo 'HADOOP_YARN_HOME="/usr/hdp/2.4.0.0-169/hadoop-yarn"' >> /etc/environment && \
-  echo 'HADOOP_CONF_DIR="/usr/hdp/2.4.0.0-169/hadoop/etc/hadoop"' >> /etc/environment && \
-  echo 'YARN_CONF_DIR="/usr/hdp/2.4.0.0-169/hadoop/etc/hadoop"' >> /etc/environment
+  echo 'HADOOP_PREFIX="/usr/hdp/2.4.2.0-258/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_COMMON_HOME="/usr/hdp/2.4.2.0-258/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_HDFS_HOME="/usr/hdp/2.4.2.0-258/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_MAPRED_HOME="/usr/hdp/2.4.2.0-258/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_YARN_HOME="/usr/hdp/2.4.2.0-258/hadoop-yarn"' >> /etc/environment && \
+  echo 'HADOOP_CONF_DIR="/usr/hdp/2.4.2.0-258/hadoop/etc/hadoop"' >> /etc/environment && \
+  echo 'YARN_CONF_DIR="/usr/hdp/2.4.2.0-258/hadoop/etc/hadoop"' >> /etc/environment
 ENV PATH $PATH:$HADOOP_PREFIX/bin:$HADOOP_PREFIX/sbin:$HADOOP_PREFIX-yarn/bin:$HADOOP_PREFIX-yarn/sbin:$HADOOP_PREFIX-hdfs/bin:$HADOOP_PREFIX-hdfs/sbin
 
 COPY core-site.xml $HADOOP_PREFIX/etc/hadoop/

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.4/init-nn.sh
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.4/init-nn.sh
@@ -20,8 +20,6 @@
 
 /usr/sbin/sshd
 
-/root/sync-hosts.sh
-
 grep hdn /etc/hosts | awk '{print $1}' | sort | uniq > $HADOOP_PREFIX/etc/hadoop/slaves
 for host in `cat $HADOOP_PREFIX/etc/hadoop/slaves`
 do
@@ -32,9 +30,9 @@ done
 hdfs namenode -format
 
 hadoop-daemon.sh --script hdfs start namenode
-slaves.sh /usr/hdp/2.4.0.0-169/hadoop/sbin/hadoop-daemon.sh --script hdfs start datanode
+slaves.sh /usr/hdp/2.4.2.0-258/hadoop/sbin/hadoop-daemon.sh --script hdfs start datanode
 
 yarn-daemon.sh start resourcemanager
-slaves.sh /usr/hdp/2.4.0.0-169/hadoop-yarn/sbin/yarn-daemon.sh start nodemanager
+slaves.sh /usr/hdp/2.4.2.0-258/hadoop-yarn/sbin/yarn-daemon.sh start nodemanager
 
 cd ~ && /bin/bash

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.4/yarn-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.4/yarn-site.xml
@@ -53,7 +53,7 @@ under the License.
 
     <property>
       <name>yarn.application.classpath</name>
-      <value>/usr/hdp/2.4.0.0-169/hadoop/etc/hadoop, /usr/hdp/2.4.0.0-169/hadoop/*, /usr/hdp/2.4.0.0-169/hadoop/lib/*, /usr/hdp/2.4.0.0-169/hadoop-hdfs/*, /usr/hdp/2.4.0.0-169/hadoop-hdfs/lib/*, /usr/hdp/2.4.0.0-169/hadoop-mapreduce/*, /usr/hdp/2.4.0.0-169/hadoop-mapreduce/lib/*, /usr/hdp/2.4.0.0-169/hadoop-yarn/*, /usr/hdp/2.4.0.0-169/hadoop-yarn/lib/*</value>
+      <value>/usr/hdp/2.4.2.0-258/hadoop/etc/hadoop, /usr/hdp/2.4.2.0-258/hadoop/*, /usr/hdp/2.4.2.0-258/hadoop/lib/*, /usr/hdp/2.4.2.0-258/hadoop-hdfs/*, /usr/hdp/2.4.2.0-258/hadoop-hdfs/lib/*, /usr/hdp/2.4.2.0-258/hadoop-mapreduce/*, /usr/hdp/2.4.2.0-258/hadoop-mapreduce/lib/*, /usr/hdp/2.4.2.0-258/hadoop-yarn/*, /usr/hdp/2.4.2.0-258/hadoop-yarn/lib/*</value>
     </property>
 
     <property>


### PR DESCRIPTION
This PR upgrades HDP2.4 docker images from HDP 2.4.0 into HDP 2.4.2.
HDInsight was already upgraded to use HDP 2.4.2 two weeks ago.
We had better upgrade ours to HDP 2.4.2.

JIRA:
  [REEF-1409](https://issues.apache.org/jira/browse/REEF-1409)

Pull Request:
  This closes #