### PR TITLE
[REEF-1421] Transport Client inner thread is not canceled when the object is disposed

### DIFF
--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportClient.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportClient.cs
@@ -100,6 +100,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         {
             if (!_disposed)
             {
+                _cancellationSource.Cancel();
                 _link.Dispose();
                 _disposed = true;
             }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TransportClient.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TransportClient.cs
@@ -112,6 +112,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         {
             if (!_disposed && disposing)
             {
+                _cancellationSource.Cancel();
                 _link.Dispose();
                 _disposed = true;
             }


### PR DESCRIPTION

This is to cancel the Cancellation token for TransportClient and StreamingTransportClient in Dispose().

JIRA: [REEF-1421](https://issues.apache.org/jira/browse/REEF-1421)
This closes