### PR TITLE
[REEF-1369] Remove obsolete RuntimeClock.RegisterObserver

### DIFF
--- a/lang/cs/Org.Apache.REEF.Wake/Time/Runtime/RuntimeClock.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Time/Runtime/RuntimeClock.cs
@@ -162,21 +162,6 @@ namespace Org.Apache.REEF.Wake.Time.Runtime
         }
 
         /// <summary>
-        /// Register the IObserver for the particular Time event.
-        /// </summary>
-        /// <param name="observer">The handler to register</param>
-        [Obsolete("Will be removed in REEF 0.16")]
-        public void RegisterObserver<U>(IObserver<U> observer) where U : Time
-        {
-            if (_disposed)
-            {
-                return;
-            }
-
-            _handlers.Subscribe(observer);
-        }
-
-        /// <summary>
         /// Start the RuntimeClock.
         /// Clock will continue to run and handle events until it has been disposed.
         /// </summary>


### PR DESCRIPTION
JIRA:
  [REEF-1369](https://issues.apache.org/jira/browse/REEF-1369)

Pull request:
  This closes #