### PR TITLE
[REEF-1388] Fix RunningTask to be sent for short-lived .NET tasks

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextRuntime.cs
@@ -440,15 +440,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
                 }
 
                 var taskStatusProto = _task.Value.GetStatusProto();
-                if (taskStatusProto.state == State.RUNNING)
-                {
-                    // only RUNNING status is allowed to rurn here, all other state pushed out to heartbeat 
-                    return Optional<TaskStatusProto>.Of(taskStatusProto);
-                }
-
-                var e = new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Task state must be RUNNING, but instead is in {0} state", taskStatusProto.state));
-                Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
-                return Optional<TaskStatusProto>.Empty();
+                return Optional<TaskStatusProto>.Of(taskStatusProto);
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
@@ -89,13 +89,14 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                 throw new InvalidOperationException("TaskRun has already been called on TaskRuntime.");
             }
 
-            // Send heartbeat such that user receives a TaskRunning message.
-            _currentStatus.SetRunning();
+            _currentStatus.SetInit();
 
             var taskThread = new Thread(() =>
             {
                 try
                 {
+                    Logger.Log(Level.Verbose, "Set running status for task");
+                    _currentStatus.SetRunning();
                     Logger.Log(Level.Verbose, "Calling into user's task.");
                     var result = _userTask.Call(null);
                     Logger.Log(Level.Info, "Task Call Finished");

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStatus.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStatus.cs
@@ -145,6 +145,28 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
             }
         }
 
+        public void SetInit()
+        {
+            lock (_heartBeatManager)
+            {
+                LOGGER.Log(Level.Verbose, "TaskStatus::SetInit");
+                if (_state == TaskState.Init)
+                {
+                    try
+                    {
+                        _taskLifeCycle.Start();
+                        LOGGER.Log(Level.Info, "Sending task INIT heartbeat");
+                        Heartbeat();
+                    }
+                    catch (Exception e)
+                    {
+                        Utilities.Diagnostics.Exceptions.Caught(e, Level.Error, "Cannot set task status to INIT.", LOGGER);
+                        SetException(e);
+                    }
+                }
+            }
+        }
+
         public void SetRunning()
         {
             lock (_heartBeatManager)
@@ -154,12 +176,9 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                 {
                     try
                     {
-                        _taskLifeCycle.Start();
-                        
-                        // Need to send an INIT heartbeat to the driver prompting it to create an RunningTask event. 
-                        LOGGER.Log(Level.Info, "Sending task INIT heartbeat");
-                        Heartbeat();
                         State = TaskState.Running;
+                        LOGGER.Log(Level.Info, "Sending task Running heartbeat");
+                        Heartbeat();
                     }
                     catch (Exception e)
                     {

--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/ContextRuntimeTests.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/ContextRuntimeTests.cs
@@ -35,7 +35,6 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities;
-using Org.Apache.REEF.Wake.Remote.Parameters;
 using Xunit;
 using ContextConfiguration = Org.Apache.REEF.Common.Context.ContextConfiguration;
 
@@ -43,9 +42,6 @@ namespace Org.Apache.REEF.Evaluator.Tests
 {
     public sealed class ContextRuntimeTests
     {
-        private const int SleepTime = 10;
-        private const int MaxSleepTime = 1000;
-
         [Fact]
         [Trait("Priority", "0")]
         [Trait("Category", "Unit")]
@@ -188,14 +184,8 @@ namespace Org.Apache.REEF.Evaluator.Tests
                     Assert.True(contextRuntime.GetTaskStatus().IsPresent());
 
                     // wait for the task to start
-                    var totalSleep = 0;
-                    while (contextRuntime.GetTaskStatus().Value.state == State.INIT && totalSleep < MaxSleepTime)
-                    {
-                        Thread.Sleep(SleepTime);
-                        totalSleep += SleepTime;
-                    }
-
-                    // if the task failed to start even after MaxSleepTime delay, the test should fail
+                    var testTask = contextRuntime.TaskRuntime.Value.Task as TestTask;
+                    testTask.StartEvent.Wait();
                     Assert.Equal(State.RUNNING, contextRuntime.GetTaskStatus().Value.state);
 
                     var childContextConfiguration = GetSimpleContextConfiguration();
@@ -249,14 +239,8 @@ namespace Org.Apache.REEF.Evaluator.Tests
                     Assert.True(contextRuntime.GetTaskStatus().IsPresent());
 
                     // wait for the task to start
-                    var totalSleep = 0;
-                    while (contextRuntime.GetTaskStatus().Value.state == State.INIT && totalSleep < MaxSleepTime)
-                    {
-                        Thread.Sleep(SleepTime);
-                        totalSleep += SleepTime;
-                    }
-
-                    // if the task failed to start even after MaxSleepTime delay, the test should fail
+                    var testTask = contextRuntime.TaskRuntime.Value.Task as TestTask;
+                    testTask.StartEvent.Wait();
                     Assert.Equal(State.RUNNING, contextRuntime.GetTaskStatus().Value.state);
 
                     Assert.Throws<InvalidOperationException>(() => contextRuntime.StartTaskOnNewThread(taskConfig));

--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/TestUtils/TestTask.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/TestUtils/TestTask.cs
@@ -28,10 +28,13 @@ namespace Org.Apache.REEF.Evaluator.Tests.TestUtils
         [Inject]
         private TestTask()
         {
+            StartEvent = new CountdownEvent(1);
             CountDownEvent = new CountdownEvent(1);
             StopEvent = new CountdownEvent(1);
             DisposedEvent = new CountdownEvent(1);
         }
+
+        public CountdownEvent StartEvent { get; private set; }
 
         public CountdownEvent CountDownEvent { get; private set; }
 
@@ -46,6 +49,7 @@ namespace Org.Apache.REEF.Evaluator.Tests.TestUtils
 
         public byte[] Call(byte[] memento)
         {
+            StartEvent.Signal();
             CountDownEvent.Wait();
             return null;
         }

--- a/lang/cs/Org.Apache.REEF.Examples/Tasks/HelloTask/HelloTask.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/Tasks/HelloTask/HelloTask.cs
@@ -66,7 +66,7 @@ namespace Org.Apache.REEF.Examples.Tasks.HelloTask
                 Console.WriteLine("IP Address: {0}", _nameClient.Lookup("abc"));
             }
             PrintGuestList();
-            Thread.Sleep(5 * 1000);
+            Thread.Sleep(1000);
             Console.WriteLine("Bye, CLR REEF!");
 
             return null;

--- a/lang/cs/Org.Apache.REEF.Examples/Tasks/HelloTask/HelloTask.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/Tasks/HelloTask/HelloTask.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Linq;
 using System.Net;
-using System.Threading;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Common.Tasks.Events;
@@ -66,7 +65,6 @@ namespace Org.Apache.REEF.Examples.Tasks.HelloTask
                 Console.WriteLine("IP Address: {0}", _nameClient.Lookup("abc"));
             }
             PrintGuestList();
-            ////Thread.Sleep(1000);
             Console.WriteLine("Bye, CLR REEF!");
 
             return null;

--- a/lang/cs/Org.Apache.REEF.Examples/Tasks/HelloTask/HelloTask.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/Tasks/HelloTask/HelloTask.cs
@@ -66,7 +66,7 @@ namespace Org.Apache.REEF.Examples.Tasks.HelloTask
                 Console.WriteLine("IP Address: {0}", _nameClient.Lookup("abc"));
             }
             PrintGuestList();
-            Thread.Sleep(1000);
+            ////Thread.Sleep(1000);
             Console.WriteLine("Bye, CLR REEF!");
 
             return null;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestCloseTask.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestCloseTask.cs
@@ -118,7 +118,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             const string failedTaskIndication = "Java_org_apache_reef_javabridge_NativeInterop_clrSystemFailedTaskHandlerOnNext";
 
             string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
-            TestRun(DriverConfigurations(DisposeMessageFromDriver, GetTaskConfigurationForFailToCloseTask()), typeof(CloseTaskTestDriver), 1, "testStopTask", "local", testFolder);
+            TestRun(DriverConfigurations(DisposeMessageFromDriver, GetTaskConfigurationForFailToCloseTask()), typeof(CloseTaskTestDriver), 1, "testStopTaskWithException", "local", testFolder);
             var messages = new List<string>();
             messages.Add(successIndication);
             messages.Add(failedTaskIndication);
@@ -140,7 +140,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             const string closeHandlerNoBound = "ExceptionCaught TaskCloseHandlerNotBoundException";
 
             string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
-            TestRun(DriverConfigurations(DisposeMessageFromDriver, GetTaskConfigurationForNoCloseHandlerTask()), typeof(CloseTaskTestDriver), 1, "testStopTask", "local", testFolder);
+            TestRun(DriverConfigurations(DisposeMessageFromDriver, GetTaskConfigurationForNoCloseHandlerTask()), typeof(CloseTaskTestDriver), 1, "testStopTaskWithNoCloseHandler", "local", testFolder);
             var messages = new List<string>();
             messages.Add(closeHandlerNoBound);
             ValidateMessageSuccessfullyLogged(messages, "Node-*", EvaluatorStdout, testFolder, 1);
@@ -154,7 +154,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         public void TestStopTaskOnLocalRuntimeWithNullMessage()
         {
             string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
-            TestRun(DriverConfigurations(NoMessage, GetTaskConfigurationForCloseTask()), typeof(CloseTaskTestDriver), 1, "testStopTask", "local", testFolder);
+            TestRun(DriverConfigurations(NoMessage, GetTaskConfigurationForCloseTask()), typeof(CloseTaskTestDriver), 1, "testStopTaskWithNullMessage", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder: testFolder);
             ValidateMessageSuccessfullyLoggedForDriver(CompletedValidationMessage, testFolder, 1);
             var messages = new List<string>();

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
@@ -17,10 +17,13 @@
 
 using System;
 using System.Globalization;
+using System.Text;
 using System.Threading;
 using Org.Apache.REEF.Common.Tasks;
+using Org.Apache.REEF.Common.Tasks.Events;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Evaluator;
+using Org.Apache.REEF.Driver.Task;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
@@ -32,7 +35,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
     [Collection("FunctionalTests")]
     public sealed class TestFailedEvaluatorEventHandler : ReefFunctionalTest
     {
-        private static readonly Logger Logger = Logger.GetLogger(typeof(TestFailedEvaluatorEventHandler));
         private const string FailedEvaluatorMessage = "I have succeeded in seeing a failed evaluator.";
         private const string RightFailedTaskMessage = "I have succeeded in seeing the right failed task.";
         private const string FailSignal = "Fail";
@@ -60,11 +62,12 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
                 .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<FailedEvaluatorDriver>.Class)
                 .Set(DriverConfiguration.OnEvaluatorCompleted, GenericType<FailedEvaluatorDriver>.Class)
                 .Set(DriverConfiguration.OnEvaluatorFailed, GenericType<FailedEvaluatorDriver>.Class)
+                .Set(DriverConfiguration.OnTaskRunning, GenericType<FailedEvaluatorDriver>.Class)
                 .Build();
         }
 
         private sealed class FailedEvaluatorDriver : IObserver<IDriverStarted>, IObserver<IAllocatedEvaluator>, 
-            IObserver<ICompletedEvaluator>, IObserver<IFailedEvaluator>
+            IObserver<ICompletedEvaluator>, IObserver<IFailedEvaluator>, IObserver<IRunningTask>
         {
             private static readonly Logger Logger = Logger.GetLogger(typeof(FailedEvaluatorDriver));
 
@@ -86,7 +89,13 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
                 value.SubmitTask(TaskConfiguration.ConfigurationModule
                     .Set(TaskConfiguration.Identifier, TaskId)
                     .Set(TaskConfiguration.Task, GenericType<FailEvaluatorTask>.Class)
+                    .Set(TaskConfiguration.OnMessage, GenericType<FailEvaluatorTask>.Class)
                     .Build());
+            }
+
+            public void OnNext(IRunningTask value)
+            {
+                value.Send(Encoding.UTF8.GetBytes(FailSignal));
             }
 
             public void OnNext(ICompletedEvaluator value)
@@ -116,8 +125,10 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             }
         }
 
-        private sealed class FailEvaluatorTask : ITask
+        private sealed class FailEvaluatorTask : ITask, IDriverMessageHandler
         {
+            private readonly CountdownEvent _countdownEvent = new CountdownEvent(1);
+
             [Inject]
             private FailEvaluatorTask()
             {
@@ -129,12 +140,14 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
 
             public byte[] Call(byte[] memento)
             {
-                Logger.Log(Level.Info, "Entered FailEvaluatorTask");
-
-                // need to sleep to allow Java code to get heartbeat with information about task
-                Thread.Sleep(100);
+                _countdownEvent.Wait();
                 Environment.Exit(1);
                 return null;
+            }
+
+            public void Handle(IDriverMessage message)
+            {
+                _countdownEvent.Signal();
             }
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestUnhandledTaskException.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestUnhandledTaskException.cs
@@ -49,11 +49,12 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         [Fact]
         public void TestUnhandledTaskExceptionCrashesEvaluator()
         {
-            var testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
+            var testFolder = DefaultRuntimeFolder + TestId;
             TestRun(GetDriverConfiguration(), typeof(TestUnhandledTaskException), 1, "testUnhandledTaskException", "local", testFolder);
             ValidateSuccessForLocalRuntime(0, numberOfEvaluatorsToFail: 2, testFolder: testFolder);
             ValidateMessageSuccessfullyLoggedForDriver(SerializableSuccessMessage, testFolder, 1);
             ValidateMessageSuccessfullyLoggedForDriver(NonSerializableSuccessMessage, testFolder, 1);
+            CleanUp(testFolder);
         }
 
         private static IConfiguration GetDriverConfiguration()

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTask.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTask.cs
@@ -37,7 +37,6 @@ namespace Org.Apache.REEF.Tests.Functional.Messaging
         public byte[] Call(byte[] memento)
         {
             Logger.Log(Level.Info, "Hello, CLR Task!");
-            Thread.Sleep(5 * 1000);
             return null;
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/RuntimeName/RuntimeNameTest.cs
@@ -65,6 +65,7 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
             string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(DriverConfigurationsWithEvaluatorRequest(GenericType<EvaluatorRequestingDriverSpecifyingRuntimeName>.Class), typeof(EvaluatorRequestingDriverSpecifyingRuntimeName), 1, "EvaluatorRequestingDriverSpecifyingRuntimeName", "local", testFolder);
             ValidateMessageSuccessfullyLoggedForDriver("Runtime Name: Local", testFolder, 1);
+            CleanUp(testFolder);
         }
 
         /// <summary>


### PR DESCRIPTION
This change:
 * sends RUNNING message immediately before Task.call(), instead of
   relying on time-based heartbeat to report task in Running state.
 * removes Thread.Sleep() calls from tests which don't need them any more.
 * fixes tests which rely on running status improperly.

JIRA:
  [REEF-1388](https://issues.apache.org/jira/browse/REEF-1388)

Pull request:
  This closes #