### PR TITLE
[REEF-1440] Test tasks should not throw NotImplementedException in Dispose

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
@@ -957,7 +957,6 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
     {
         public void Dispose()
         {
-            throw new NotImplementedException();
         }
 
         public byte[] Call(byte[] memento)

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
@@ -22,11 +22,9 @@ using System.Threading;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Common.Tasks.Events;
 using Org.Apache.REEF.Driver;
-using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Evaluator;
 using Org.Apache.REEF.Driver.Task;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
@@ -138,7 +136,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
 
             public void Dispose()
             {
-                throw new NotImplementedException();
             }
 
             public byte[] Call(byte[] memento)

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestUnhandledTaskException.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestUnhandledTaskException.cs
@@ -103,7 +103,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
 
             public void Dispose()
             {
-                throw new NotImplementedException();
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/FaultTolerant/TestResubmitEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/FaultTolerant/TestResubmitEvaluator.cs
@@ -248,7 +248,6 @@ namespace Org.Apache.REEF.Tests.Functional.FaultTolerant
 
             public void Dispose()
             {
-                throw new NotImplementedException();
             }
 
             public void OnCompleted()


### PR DESCRIPTION
This change removes throwing NotImplementedException in Dispose methods
of tasks used in .NET tests.

JIRA:
  [REEF-1440](https://issues.apache.org/jira/browse/REEF-1440)

Pull request:
  This closes #