### PR TITLE
[REEF-1439] Validate Exception in spun off System.Threading.Thread =>…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -85,10 +85,10 @@ under the License.
     <Compile Include="Functional\Bridge\TestSimpleContext.cs" />
     <Compile Include="Functional\Bridge\TestSimpleEventHandlers.cs" />
     <Compile Include="Functional\Bridge\TestSuspendTask.cs" />
-    <Compile Include="Functional\Bridge\TestUnhandledTaskException.cs" />
     <Compile Include="Functional\Common\Task\Handlers\LoggingHandler.cs" />
     <Compile Include="Functional\Common\Task\LoggingTask.cs" />
     <Compile Include="Functional\Common\Task\Handlers\ExceptionThrowingHandler.cs" />
+    <Compile Include="Functional\Failure\User\UnhandledThreadExceptionInTaskTest.cs" />
     <Compile Include="Functional\Driver\DriverTestStartHandler.cs" />
     <Compile Include="Functional\Failure\BasePoisonedEvaluatorWithActiveContextDriver.cs" />
     <Compile Include="Functional\Failure\BasePoisonedEvaluatorWithRunningTaskDriver.cs" />


### PR DESCRIPTION
… FailedEvaluator Event

This addressed the issue by
  * Moving existing Test to the right folder for user Exception validation.

JIRA:
  [REEF-1439](https://issues.apache.org/jira/browse/REEF-1439)