### PR TITLE
[REEF-1447] Validate Task close failure => FailedEvaluator Event (task has…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/TaskRuntimeTests.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/TaskRuntimeTests.cs
@@ -206,7 +206,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
 
         /// <summary>
         /// Tests whether task start and stop handlers are properly instantiated and invoked
-        /// on the failure of a task.
+        /// on the failure of a task. On failure, TaskStop handler should not be invoked.
         /// </summary>
         [Fact]
         public void TestTaskEventsOnFailure()
@@ -232,8 +232,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
                 throw new Exception("Event handler is not expected to be null.");
             }
 
-            Assert.True(testTaskEventStopHandler.StopInvoked.IsPresent());
-            Assert.Equal(testTaskEventStopHandler.StopInvoked.Value, taskId);
+            Assert.False(testTaskEventStopHandler.StopInvoked.IsPresent());
 
             taskThread.Join();
         }
@@ -337,7 +336,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
                 throw new Exception("Event handler is not expected to be null.");
             }
 
-            Assert.True(testTaskEventStopHandler.StopInvoked.IsPresent());
+            Assert.False(testTaskEventStopHandler.StopInvoked.IsPresent());
             Assert.Equal(taskRuntime.GetTaskState(), TaskState.Failed);
 
             taskRuntime.Suspend(null);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Common/EventHandle.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Common/EventHandle.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Threading;
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.Tests.Functional.Common
+{
+    /// <summary>
+    /// An test EventHandle that simply wraps around a <see cref="ManualResetEventSlim"/>.
+    /// </summary>
+    public sealed class EventHandle
+    {
+        private readonly ManualResetEventSlim _eventHandle = new ManualResetEventSlim();
+
+        [Inject]
+        private EventHandle()
+        {
+        }
+
+        /// <summary>
+        /// Sets the Event.
+        /// </summary>
+        public void Signal()
+        {
+            _eventHandle.Set();
+        }
+
+        /// <summary>
+        /// Waits for the event signal.
+        /// </summary>
+        public void Wait()
+        {
+            _eventHandle.Wait();
+        }
+
+        /// <summary>
+        /// Resets the event signal.
+        /// </summary>
+        public void Reset()
+        {
+            _eventHandle.Reset();
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Common/Task/Handlers/ExceptionThrowingHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Common/Task/Handlers/ExceptionThrowingHandler.cs
@@ -26,23 +26,28 @@ namespace Org.Apache.REEF.Tests.Functional.Common.Task.Handlers
     internal abstract class ExceptionThrowingHandler<T> : IObserver<T>
     {
         private readonly Exception _exceptionToThrow;
-        private readonly Action<T> _action;
+        private readonly Action<T> _finallyAction;
 
         protected ExceptionThrowingHandler(
-            Exception exceptionToThrow, Action<T> action = null)
+            Exception exceptionToThrow, Action<T> finallyAction = null)
         {
             _exceptionToThrow = exceptionToThrow;
-            _action = action;
+            _finallyAction = finallyAction;
         }
 
         public void OnNext(T value)
         {
-            if (_action != null)
+            try
             {
-                _action(value);
+                throw _exceptionToThrow;
             }
-
-            throw _exceptionToThrow;
+            finally
+            {
+                if (_finallyAction != null)
+                {
+                    _finallyAction(value);
+                }
+            }
         }
 
         public void OnError(Exception error)

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Failure/User/TaskCloseExceptionTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Failure/User/TaskCloseExceptionTest.cs
@@ -1,0 +1,173 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Org.Apache.REEF.Common.Tasks;
+using Org.Apache.REEF.Common.Tasks.Events;
+using Org.Apache.REEF.Driver;
+using Org.Apache.REEF.Driver.Evaluator;
+using Org.Apache.REEF.Driver.Task;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Tests.Functional.Bridge.Exceptions;
+using Org.Apache.REEF.Tests.Functional.Common;
+using Org.Apache.REEF.Tests.Functional.Common.Task;
+using Org.Apache.REEF.Tests.Functional.Common.Task.Handlers;
+using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
+
+namespace Org.Apache.REEF.Tests.Functional.Failure.User
+{
+    /// <summary>
+    /// This test class contains a test that validates that an Exception in the 
+    /// TaskCloseHandler causes a FailedTask event in the Driver.
+    /// </summary>
+    [Collection("FunctionalTests")]
+    public sealed class TaskCloseExceptionTest : ReefFunctionalTest
+    {
+        private static readonly Logger Logger = Logger.GetLogger(typeof(TaskCloseExceptionTest));
+
+        private const string TaskCloseExceptionMessage = "TaskCloseExceptionMessage";
+        private const string FailedEvaluatorReceived = "FailedEvaluatorReceived";
+
+        /// <summary>
+        /// This test validates that an Exception in the TaskCloseHandler causes a FailedTask
+        /// event in the Driver, and that a new Task can be submitted on the original Context.
+        /// </summary>
+        [Fact]
+        public void TestCloseTaskWithExceptionOnLocalRuntime()
+        {
+            string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
+            TestRun(DriverConfiguration.ConfigurationModule
+                .Set(DriverConfiguration.OnDriverStarted, GenericType<TaskCloseExceptionTestDriver>.Class)
+                .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<TaskCloseExceptionTestDriver>.Class)
+                .Set(DriverConfiguration.OnEvaluatorFailed, GenericType<TaskCloseExceptionTestDriver>.Class)
+                .Set(DriverConfiguration.OnTaskRunning, GenericType<TaskCloseExceptionTestDriver>.Class)
+                .Build(), typeof(TaskCloseExceptionTestDriver), 1, "testCloseTaskWithExceptionOnLocalRuntime", "local", testFolder);
+
+            var driverMessages = new List<string>
+            {
+                FailedEvaluatorReceived
+            };
+
+            ValidateSuccessForLocalRuntime(numberOfContextsToClose: 0, numberOfEvaluatorsToFail: 1, testFolder: testFolder);
+            ValidateMessagesSuccessfullyLoggedForDriver(driverMessages, testFolder, 1);
+            ValidateMessageSuccessfullyLogged(driverMessages, "driver", DriverStdout, testFolder, 1);
+            CleanUp(testFolder);
+        }
+
+        private sealed class TaskCloseExceptionTestDriver :
+            IObserver<IDriverStarted>,
+            IObserver<IAllocatedEvaluator>,
+            IObserver<IRunningTask>,
+            IObserver<IFailedEvaluator>
+        {
+            private static readonly string TaskId = "TaskId";
+
+            private readonly IEvaluatorRequestor _requestor;
+
+            [Inject]
+            private TaskCloseExceptionTestDriver(IEvaluatorRequestor requestor)
+            {
+                _requestor = requestor;
+            }
+
+            public void OnNext(IDriverStarted value)
+            {
+                _requestor.Submit(_requestor.NewBuilder().Build());
+            }
+
+            public void OnNext(IAllocatedEvaluator value)
+            {
+                // submit the first Task.
+                value.SubmitTask(TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, TaskId)
+                        .Set(TaskConfiguration.Task, GenericType<TaskCloseExceptionTask>.Class)
+                        .Set(TaskConfiguration.OnClose, GenericType<TaskCloseHandlerWithException>.Class)
+                        .Build());
+            }
+
+            public void OnNext(IRunningTask value)
+            {
+                if (value.Id == TaskId)
+                {
+                    value.Dispose();
+                }
+            }
+
+            public void OnNext(IFailedEvaluator value)
+            {
+                Assert.True(value.FailedTask.IsPresent());
+                var failedTask = value.FailedTask.Value;
+
+                Assert.Equal(TaskId, failedTask.Id);
+
+                // Check that Exceptions are deserialized correctly.
+                var ex = value.EvaluatorException.InnerException;
+                if (ex == null)
+                {
+                    throw new Exception("Exception was not expected to be null.");
+                }
+
+                var taskCloseEx = ex as TestSerializableException;
+
+                if (taskCloseEx == null)
+                {
+                    throw new Exception("Expected Exception to be of type TaskCloseExceptionTestException, but instead got type " + ex.GetType().Name);
+                }
+
+                if (taskCloseEx.Message != TaskCloseExceptionMessage)
+                {
+                    throw new Exception(
+                        "Expected message to be " + TaskCloseExceptionMessage + " but instead got " + taskCloseEx.Message + ".");
+                }
+
+                Logger.Log(Level.Info, FailedEvaluatorReceived);
+            }
+
+            public void OnError(Exception error)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void OnCompleted()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private sealed class TaskCloseExceptionTask : WaitingTask
+        {
+            [Inject]
+            private TaskCloseExceptionTask(EventMonitor monitor) : base(monitor)
+            {
+            }
+        }
+
+        private sealed class TaskCloseHandlerWithException : ExceptionThrowingHandler<ICloseEvent>
+        {
+            [Inject]
+            private TaskCloseHandlerWithException(EventMonitor monitor) : base(
+                new TestSerializableException(TaskCloseExceptionMessage),
+                close => { monitor.Signal(); })
+            {
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -84,7 +84,6 @@ under the License.
     <Compile Include="Functional\Failure\User\ServiceConstructorExceptionTest.cs" />
     <Compile Include="Functional\Failure\User\ReceiveContextMessageExceptionTest.cs" />
     <Compile Include="Functional\Failure\User\ContextStartExceptionTest.cs" />
-    <Compile Include="Functional\Common\Task\WaitingTask.cs" />
     <Compile Include="Functional\Failure\User\ReceiveTaskMessageExceptionTest.cs" />
     <Compile Include="Functional\Failure\User\TaskCallExceptionTest.cs" />
     <Compile Include="Functional\Bridge\Exceptions\TestNonSerializableException.cs" />
@@ -97,6 +96,7 @@ under the License.
     <Compile Include="Functional\Common\Task\Handlers\ExceptionThrowingHandler.cs" />
     <Compile Include="Functional\Failure\User\TaskStartExceptionTest.cs" />
     <Compile Include="Functional\Failure\User\UnhandledThreadExceptionInTaskTest.cs" />
+    <Compile Include="Functional\Common\Task\WaitingTask.cs" />
     <Compile Include="Functional\Driver\DriverTestStartHandler.cs" />
     <Compile Include="Functional\Failure\BasePoisonedEvaluatorWithActiveContextDriver.cs" />
     <Compile Include="Functional\Failure\BasePoisonedEvaluatorWithRunningTaskDriver.cs" />
@@ -107,6 +107,7 @@ under the License.
     <Compile Include="Functional\Failure\TestEvaluatorWithActiveContextImmediatePoison.cs" />
     <Compile Include="Functional\Failure\TestEvaluatorWithRunningTaskImmediatePoison.cs" />
     <Compile Include="Functional\Failure\SleepTask.cs" />
+    <Compile Include="Functional\Failure\User\TaskCloseExceptionTest.cs" />
     <Compile Include="Functional\Failure\User\TaskConstructorExceptionTest.cs" />
     <Compile Include="Functional\Failure\User\TaskStopExceptionTest.cs" />
     <Compile Include="Functional\FaultTolerant\TestContextStart.cs" />


### PR DESCRIPTION
… not yet finished)

This addressed the issue by
  * Failing the Evaluator on an `Exception` in `TaskCloseHandler`.
  * Adding a test to test for close event failure while Task is still running. Validating that the `TaskCloseHandler` `Exception` triggers a `FailedEvaluator`.
  * Modify `TaskRuntime` and related tests to verify that the `TaskStopHandler` is not called upon `Task` failure.

JIRA:
  [REEF-1447](https://issues.apache.org/jira/browse/REEF-1447)