### PR TITLE
[REEF-1424] Validate Task StartHandler failure => FailedTask Event

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -163,6 +163,7 @@ under the License.
     <Compile Include="Runtime\Evaluator\Task\TaskClientCodeException.cs" />
     <Compile Include="Runtime\Evaluator\Task\TaskLifeCycle.cs" />
     <Compile Include="Runtime\Evaluator\Task\TaskRuntime.cs" />
+    <Compile Include="Runtime\Evaluator\Task\TaskStartHandlerException.cs" />
     <Compile Include="Runtime\Evaluator\Task\TaskStartImpl.cs" />
     <Compile Include="Runtime\Evaluator\Task\TaskState.cs" />
     <Compile Include="Runtime\Evaluator\Task\TaskStatus.cs" />

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskLifeCycle.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskLifeCycle.cs
@@ -51,12 +51,19 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
 
         public void Start() 
         {
-            if (Interlocked.Exchange(ref _startHasBeenInvoked, 1) == 0)
+            try
             {
-                foreach (var startHandler in _taskStartHandlers)
+                if (Interlocked.Exchange(ref _startHasBeenInvoked, 1) == 0)
                 {
-                    startHandler.OnNext(_taskStart);
+                    foreach (var startHandler in _taskStartHandlers)
+                    {
+                        startHandler.OnNext(_taskStart);
+                    }
                 }
+            }
+            catch (Exception e)
+            {
+                throw new TaskStartHandlerException("Encountered Exception in TaskStartHandler.", e);
             }
         }
 
@@ -74,7 +81,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
             }
             catch (Exception e)
             {
-                throw new TaskStopHandlerException("Encountered Exception on TaskStopHandler.", e);
+                throw new TaskStopHandlerException("Encountered Exception in TaskStopHandler.", e);
             }
         }
     }

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
@@ -99,7 +99,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                     _currentStatus.SetRunning();
                     Logger.Log(Level.Verbose, "Calling into user's task.");
                     var result = _userTask.Call(null);
-                    Logger.Log(Level.Verbose, "Task Call Finished");
+                    Logger.Log(Level.Info, "Task Call Finished");
                     _currentStatus.SetResult(result);
 
                     const Level resultLogLevel = Level.Verbose;

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
@@ -99,7 +99,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                     _currentStatus.SetRunning();
                     Logger.Log(Level.Verbose, "Calling into user's task.");
                     var result = _userTask.Call(null);
-                    Logger.Log(Level.Info, "Task Call Finished");
+                    Logger.Log(Level.Verbose, "Task Call Finished");
                     _currentStatus.SetResult(result);
 
                     const Level resultLogLevel = Level.Verbose;
@@ -109,6 +109,10 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                         Logger.Log(resultLogLevel,
                             "Task running result:\r\n" + System.Text.Encoding.Default.GetString(result));
                     }
+                }
+                catch (TaskStartHandlerException e)
+                {
+                    _currentStatus.SetException(e.InnerException);
                 }
                 catch (TaskStopHandlerException e)
                 {

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStartHandlerException.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStartHandlerException.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+
+namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
+{
+    internal sealed class TaskStartHandlerException : Exception
+    {
+        internal TaskStartHandlerException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStatus.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskStatus.cs
@@ -143,17 +143,8 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                 LOGGER.Log(Level.Verbose, "TaskStatus::SetInit");
                 if (_state == TaskState.Init)
                 {
-                    try
-                    {
-                        _taskLifeCycle.Start();
-                        LOGGER.Log(Level.Info, "Sending task INIT heartbeat");
-                        Heartbeat();
-                    }
-                    catch (Exception e)
-                    {
-                        Utilities.Diagnostics.Exceptions.Caught(e, Level.Error, "Cannot set task status to INIT.", LOGGER);
-                        SetException(e);
-                    }
+                    LOGGER.Log(Level.Verbose, "Sending task INIT heartbeat");
+                    Heartbeat();
                 }
             }
         }
@@ -165,17 +156,10 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                 LOGGER.Log(Level.Verbose, "TaskStatus::SetRunning");
                 if (_state == TaskState.Init)
                 {
-                    try
-                    {
-                        State = TaskState.Running;
-                        LOGGER.Log(Level.Info, "Sending task Running heartbeat");
-                        Heartbeat();
-                    }
-                    catch (Exception e)
-                    {
-                        Utilities.Diagnostics.Exceptions.Caught(e, Level.Error, "Cannot set task status to running.", LOGGER);
-                        SetException(e);
-                    }
+                    _taskLifeCycle.Start();
+                    State = TaskState.Running;
+                    LOGGER.Log(Level.Verbose, "Sending task Running heartbeat");
+                    Heartbeat();
                 }
             }
         }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Failure/User/TaskStartExceptionTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Failure/User/TaskStartExceptionTest.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Org.Apache.REEF.Common.Context;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Common.Tasks.Events;
 using Org.Apache.REEF.Driver;
@@ -33,22 +34,22 @@ using Xunit;
 namespace Org.Apache.REEF.Tests.Functional.Failure.User
 {
     /// <summary>
-    /// This test class contains a test that validates that an Exception in the 
-    /// TaskStopHandler causes a FailedTask event in the Driver.
+    /// This test class contains a test that validates that an Exception in 
+    /// a TaskStartHandler triggers an <see cref="IFailedTask"/> event.
     /// </summary>
     [Collection("FunctionalTests")]
-    public sealed class TaskStopExceptionTest : ReefFunctionalTest
+    public sealed class TaskStartExceptionTest : ReefFunctionalTest
     {
-        private static readonly Logger Logger = Logger.GetLogger(typeof(TaskStopExceptionTest));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(TaskStartExceptionTest));
 
-        private const string TaskStopExceptionMessage = "TaskStopExceptionMessage";
+        private const string TaskStartExceptionMessage = "TaskStartExceptionMessage";
         private const string InitialTaskMessage = "InitialTaskMessage";
         private const string ResubmitTaskMessage = "ResubmitTaskMessage";
         private const string FailedTaskReceived = "FailedTaskReceived";
         private const string CompletedTaskReceived = "CompletedTaskReceived";
 
         /// <summary>
-        /// This test validates that an Exception in the TaskStopHandler causes a FailedTask
+        /// This test validates that an Exception in the TaskStartHandler causes a FailedTask
         /// event in the Driver, and that a new Task can be submitted on the original Context.
         /// </summary>
         [Fact]
@@ -56,11 +57,11 @@ namespace Org.Apache.REEF.Tests.Functional.Failure.User
         {
             string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
             TestRun(DriverConfiguration.ConfigurationModule
-                .Set(DriverConfiguration.OnDriverStarted, GenericType<TaskStopExceptionTestDriver>.Class)
-                .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<TaskStopExceptionTestDriver>.Class)
-                .Set(DriverConfiguration.OnTaskCompleted, GenericType<TaskStopExceptionTestDriver>.Class)
-                .Set(DriverConfiguration.OnTaskFailed, GenericType<TaskStopExceptionTestDriver>.Class)
-                .Build(), typeof(TaskStopExceptionTestDriver), 1, "testStopTaskWithExceptionOnLocalRuntime", "local", testFolder);
+                .Set(DriverConfiguration.OnDriverStarted, GenericType<TaskStartExceptionTestDriver>.Class)
+                .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<TaskStartExceptionTestDriver>.Class)
+                .Set(DriverConfiguration.OnTaskCompleted, GenericType<TaskStartExceptionTestDriver>.Class)
+                .Set(DriverConfiguration.OnTaskFailed, GenericType<TaskStartExceptionTestDriver>.Class)
+                .Build(), typeof(TaskStartExceptionTestDriver), 1, "testStartTaskWithExceptionOnLocalRuntime", "local", testFolder);
 
             var driverMessages = new List<string>
             {
@@ -70,21 +71,26 @@ namespace Org.Apache.REEF.Tests.Functional.Failure.User
 
             ValidateMessagesSuccessfullyLoggedForDriver(driverMessages, testFolder, 1);
 
-            var evaluatorMessages = new List<string> { InitialTaskMessage, ResubmitTaskMessage };
-            ValidateMessageSuccessfullyLogged(evaluatorMessages, "Node-*", EvaluatorStdout, testFolder, 1);
+            // Validate that the first Task never starts.
+            ValidateMessageSuccessfullyLogged(
+                new List<string> { InitialTaskMessage }, "Node-*", EvaluatorStdout, testFolder, 0);
+
+            ValidateMessageSuccessfullyLogged(
+                new List<string> { ResubmitTaskMessage }, "Node-*", EvaluatorStdout, testFolder, 1);
+
             CleanUp(testFolder);
         }
 
-        private sealed class TaskStopExceptionTestDriver : 
-            IObserver<IDriverStarted>, 
-            IObserver<IAllocatedEvaluator>, 
-            IObserver<ICompletedTask>, 
+        private sealed class TaskStartExceptionTestDriver :
+            IObserver<IDriverStarted>,
+            IObserver<IAllocatedEvaluator>,
+            IObserver<ICompletedTask>,
             IObserver<IFailedTask>
         {
             private readonly IEvaluatorRequestor _requestor;
 
             [Inject]
-            private TaskStopExceptionTestDriver(IEvaluatorRequestor requestor)
+            private TaskStartExceptionTestDriver(IEvaluatorRequestor requestor)
             {
                 _requestor = requestor;
             }
@@ -99,8 +105,8 @@ namespace Org.Apache.REEF.Tests.Functional.Failure.User
                 // submit the first Task.
                 value.SubmitTask(TaskConfiguration.ConfigurationModule
                         .Set(TaskConfiguration.Identifier, "TaskID")
-                        .Set(TaskConfiguration.Task, GenericType<TaskStopExceptionTask>.Class)
-                        .Set(TaskConfiguration.OnTaskStop, GenericType<TaskStopHandlerWithException>.Class)
+                        .Set(TaskConfiguration.Task, GenericType<TaskStartExceptionTask>.Class)
+                        .Set(TaskConfiguration.OnTaskStart, GenericType<TaskStartHandlerWithException>.Class)
                         .Build());
             }
 
@@ -120,17 +126,17 @@ namespace Org.Apache.REEF.Tests.Functional.Failure.User
                     throw new Exception("Exception was not expected to be null.");
                 }
 
-                var taskStopEx = ex as TaskStopExceptionTestException;
+                var taskStartEx = ex as TaskStartExceptionTestException;
 
-                if (taskStopEx == null)
+                if (taskStartEx == null)
                 {
-                    throw new Exception("Expected Exception to be of type TaskStopExceptionTestException, but instead got type " + ex.GetType().Name);
+                    throw new Exception("Expected Exception to be of type TaskStartExceptionTestException, but instead got type " + ex.GetType().Name);
                 }
 
-                if (taskStopEx.Message != TaskStopExceptionMessage)
+                if (taskStartEx.Message != TaskStartExceptionMessage)
                 {
                     throw new Exception(
-                        "Expected message to be " + TaskStopExceptionMessage + " but instead got " + taskStopEx.Message + ".");
+                        "Expected message to be " + TaskStartExceptionMessage + " but instead got " + taskStartEx.Message + ".");
                 }
 
                 Logger.Log(Level.Info, FailedTaskReceived);
@@ -139,7 +145,7 @@ namespace Org.Apache.REEF.Tests.Functional.Failure.User
                 value.GetActiveContext().Value.SubmitTask(
                     TaskConfiguration.ConfigurationModule
                         .Set(TaskConfiguration.Identifier, "TaskID")
-                        .Set(TaskConfiguration.Task, GenericType<TaskStopExceptionResubmitTask>.Class)
+                        .Set(TaskConfiguration.Task, GenericType<TaskStartExceptionResubmitTask>.Class)
                         .Build());
             }
 
@@ -154,29 +160,29 @@ namespace Org.Apache.REEF.Tests.Functional.Failure.User
             }
         }
 
-        private sealed class TaskStopExceptionTask : LoggingTask
+        private sealed class TaskStartExceptionTask : LoggingTask
         {
             [Inject]
-            private TaskStopExceptionTask() 
+            private TaskStartExceptionTask()
                 : base(InitialTaskMessage)
             {
             }
         }
 
-        private sealed class TaskStopExceptionResubmitTask : LoggingTask
+        private sealed class TaskStartExceptionResubmitTask : LoggingTask
         {
             [Inject]
-            private TaskStopExceptionResubmitTask() 
+            private TaskStartExceptionResubmitTask()
                 : base(ResubmitTaskMessage)
             {
             }
         }
 
-        private sealed class TaskStopHandlerWithException : ExceptionThrowingHandler<ITaskStop>
+        private sealed class TaskStartHandlerWithException : ExceptionThrowingHandler<ITaskStart>
         {
             [Inject]
-            private TaskStopHandlerWithException() : 
-                base(new TaskStopExceptionTestException(TaskStopExceptionMessage))
+            private TaskStartHandlerWithException() :
+                base(new TaskStartExceptionTestException(TaskStartExceptionMessage))
             {
             }
         }
@@ -185,13 +191,14 @@ namespace Org.Apache.REEF.Tests.Functional.Failure.User
         /// A Serializable Exception to verify that the Exception is deserialized correctly.
         /// </summary>
         [Serializable]
-        private sealed class TaskStopExceptionTestException : Exception
+        private sealed class TaskStartExceptionTestException : Exception
         {
-            public TaskStopExceptionTestException(string message) : base(message)
+            public TaskStartExceptionTestException(string message)
+                : base(message)
             {
             }
 
-            private TaskStopExceptionTestException(SerializationInfo info, StreamingContext context)
+            private TaskStartExceptionTestException(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {
             }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Failure/User/TaskStartExceptionTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Failure/User/TaskStartExceptionTest.cs
@@ -128,16 +128,9 @@ namespace Org.Apache.REEF.Tests.Functional.Failure.User
 
                 var taskStartEx = ex as TaskStartExceptionTestException;
 
-                if (taskStartEx == null)
-                {
-                    throw new Exception("Expected Exception to be of type TaskStartExceptionTestException, but instead got type " + ex.GetType().Name);
-                }
-
-                if (taskStartEx.Message != TaskStartExceptionMessage)
-                {
-                    throw new Exception(
-                        "Expected message to be " + TaskStartExceptionMessage + " but instead got " + taskStartEx.Message + ".");
-                }
+                Assert.True(taskStartEx != null, "Expected Exception to be of type TaskStartExceptionTestException, but instead got type " + ex.GetType().Name);
+                Assert.True(taskStartEx.Message.Equals(TaskStartExceptionMessage),
+                    "Expected message to be " + TaskStartExceptionMessage + " but instead got " + taskStartEx.Message + ".");
 
                 Logger.Log(Level.Info, FailedTaskReceived);
 
@@ -169,6 +162,10 @@ namespace Org.Apache.REEF.Tests.Functional.Failure.User
             }
         }
 
+        /// <summary>
+        /// A simple Task for Task resubmission validation on a Context with a previous Task
+        /// that failed on a Task StartHandler.
+        /// </summary>
         private sealed class TaskStartExceptionResubmitTask : LoggingTask
         {
             [Inject]
@@ -178,6 +175,9 @@ namespace Org.Apache.REEF.Tests.Functional.Failure.User
             }
         }
 
+        /// <summary>
+        /// Throws a test Exception on Task Start to trigger a task failure.
+        /// </summary>
         private sealed class TaskStartHandlerWithException : ExceptionThrowingHandler<ITaskStart>
         {
             [Inject]

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -88,6 +88,7 @@ under the License.
     <Compile Include="Functional\Common\Task\Handlers\LoggingHandler.cs" />
     <Compile Include="Functional\Common\Task\LoggingTask.cs" />
     <Compile Include="Functional\Common\Task\Handlers\ExceptionThrowingHandler.cs" />
+    <Compile Include="Functional\Failure\User\TaskStartExceptionTest.cs" />
     <Compile Include="Functional\Failure\User\UnhandledThreadExceptionInTaskTest.cs" />
     <Compile Include="Functional\Driver\DriverTestStartHandler.cs" />
     <Compile Include="Functional\Failure\BasePoisonedEvaluatorWithActiveContextDriver.cs" />


### PR DESCRIPTION
This addressed the issue by
  * Concentrating Task Exception logic handling into TaskRuntime.cs instead of in TaskLifeCycle or TaskStatus.
  * Adding TaskStartExceptionTest.
  * Adding TaskStartHandlerException to indicate that an Exception happened in the TaskStartHandler.

JIRA:
  [REEF-1424](https://issues.apache.org/jira/browse/REEF-1424)