### PR TITLE
[REEF-1427] Validate Task.Call failure => FailedTask Event

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Common/Task/ExceptionTask.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Common/Task/ExceptionTask.cs
@@ -36,7 +36,6 @@ namespace Org.Apache.REEF.Tests.Functional.Common.Task
 
         public void Dispose()
         {
-            throw new System.NotImplementedException();
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Common/Task/ExceptionTask.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Common/Task/ExceptionTask.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using Org.Apache.REEF.Common.Tasks;
+
+namespace Org.Apache.REEF.Tests.Functional.Common.Task
+{
+    public abstract class ExceptionTask : ITask
+    {
+        private readonly Exception _exToThrow;
+
+        protected ExceptionTask(Exception exToThrow)
+        {
+            _exToThrow = exToThrow;
+        }
+
+        public byte[] Call(byte[] memento)
+        {
+            throw _exToThrow;
+        }
+
+        public void Dispose()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Failure/User/TaskCallExceptionTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Failure/User/TaskCallExceptionTest.cs
@@ -185,11 +185,11 @@ namespace Org.Apache.REEF.Tests.Functional.Failure.User
             [Inject]
             private TaskCallExceptionTask(
                 [Parameter(typeof(ShouldThrowSerializableException))] bool shouldThrowSerializableException) 
-                : base(ExceptionToThrow(shouldThrowSerializableException))
+                : base(GetExceptionToThrow(shouldThrowSerializableException))
             {
             }
 
-            private static Exception ExceptionToThrow(bool shouldThrowSerializableException)
+            private static Exception GetExceptionToThrow(bool shouldThrowSerializableException)
             {
                 if (shouldThrowSerializableException)
                 {

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -79,7 +79,8 @@ under the License.
     <Compile Include="Functional\Bridge\TestCloseTask.cs" />
     <Compile Include="Functional\Bridge\TestContextStack.cs" />
     <Compile Include="Functional\Bridge\TestFailedEvaluatorEventHandler.cs" />
-    <Compile Include="Functional\Bridge\TestFailedTaskEventHandler.cs" />
+    <Compile Include="Functional\Common\Task\ExceptionTask.cs" />
+    <Compile Include="Functional\Failure\User\TaskCallExceptionTest.cs" />
     <Compile Include="Functional\Bridge\Exceptions\TestNonSerializableException.cs" />
     <Compile Include="Functional\Bridge\Exceptions\TestSerializableException.cs" />
     <Compile Include="Functional\Bridge\TestSimpleContext.cs" />


### PR DESCRIPTION
This addressed the issue by
  * Moving test from Bridge/TestFailedTaskEventHandler to User/TaskCallExceptionTest.
  * Adding ExceptionTask for convenience in testing.
  * Using common classes for testing.

JIRA:
  [REEF-1427](https://issues.apache.org/jira/browse/REEF-1427)