### PR TITLE
[REEF-1454] onResourceLaunch should not throw exception if evaluator failed

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -487,6 +487,9 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
       if (this.stateManager.isAllocated()) {
         this.stateManager.setSubmitted();
         this.resourceLaunchHandler.onNext(resourceLaunchEvent);
+      } else if (this.stateManager.isFailedOrKilled()) {
+        LOG.log(Level.WARNING, "Evaluator manager expected" + EvaluatorState.ALLOCATED +
+            " state but instead is in state " + this.stateManager);
       } else {
         throw new RuntimeException("Evaluator manager expected " + EvaluatorState.ALLOCATED +
             " state but instead is in state " + this.stateManager);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
@@ -147,6 +147,10 @@ final class EvaluatorStatusManager {
     return EvaluatorState.ALLOCATED == this.state;
   }
 
+  synchronized boolean isFailedOrKilled() {
+    return EvaluatorState.FAILED == this.state || EvaluatorState.KILLED == this.state;
+  }
+
   @Override
   public synchronized String toString() {
     return this.state.toString();


### PR DESCRIPTION
Evaluator can fail before task is submitted; there will be a FailedEvaluator
event produced which can be handled properly, and no need to throw exception
to crash process.

JIRA:
  [REEF-1454](https://issues.apache.org/jira/browse/REEF-1454)

Pull request:
  This closes #