### PR TITLE
[REEF-1183] Enable KMeans .NET tests

### DIFF
--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/DataPartitionCache.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/DataPartitionCache.cs
@@ -94,7 +94,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
             return ReadDataFile(file);
         }
 
-        [NamedParameter("Data partition index", "partition", "")]
+        [NamedParameter("Data partition index", "partition")]
         public class PartitionIndex : Name<int>
         {
         }

--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansDriverHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansDriverHandlers.cs
@@ -73,9 +73,9 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
             CommandLineArguments arguments)
         {
             _executionDirectory = Path.Combine(Directory.GetCurrentDirectory(), Constants.KMeansExecutionBaseDirectory, Guid.NewGuid().ToString("N").Substring(0, 4));
-            string dataFile = arguments.Arguments.Single(a => a.StartsWith("DataFile", StringComparison.Ordinal)).Split(':')[1];
+            string dataFile = arguments.Arguments.First();
             DataVector.ShuffleDataAndGetInitialCentriods(
-                Path.Combine(Directory.GetCurrentDirectory(), "reef", "global", dataFile),
+                dataFile,
                 numPartitions,
                 _clustersNumber,
                 _executionDirectory);
@@ -86,7 +86,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
             _evaluatorRequestor = evaluatorRequestor;
 
             _centroidCodecConf = CodecToStreamingCodecConfiguration<Centroids>.Conf
-                .Set(CodecConfiguration<Centroids>.Codec, GenericType<CentroidsCodec>.Class)
+                .Set(CodecToStreamingCodecConfiguration<Centroids>.Codec, GenericType<CentroidsCodec>.Class)
                 .Build();
 
             IConfiguration dataConverterConfig1 = PipelineDataConverterConfiguration<Centroids>.Conf
@@ -94,7 +94,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
                 .Build();
 
             _controlMessageCodecConf = CodecToStreamingCodecConfiguration<ControlMessage>.Conf
-                .Set(CodecConfiguration<ControlMessage>.Codec, GenericType<ControlMessageCodec>.Class)
+                .Set(CodecToStreamingCodecConfiguration<ControlMessage>.Codec, GenericType<ControlMessageCodec>.Class)
                 .Build();
 
             IConfiguration dataConverterConfig2 = PipelineDataConverterConfiguration<ControlMessage>.Conf
@@ -102,7 +102,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
                 .Build();
 
             _processedResultsCodecConf = CodecToStreamingCodecConfiguration<ProcessedResults>.Conf
-                .Set(CodecConfiguration<ProcessedResults>.Codec, GenericType<ProcessedResultsCodec>.Class)
+                .Set(CodecToStreamingCodecConfiguration<ProcessedResults>.Codec, GenericType<ProcessedResultsCodec>.Class)
                 .Build();
 
             IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<ProcessedResults>.Conf
@@ -187,7 +187,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
 
         public void OnNext(IDriverStarted value)
         {
-            var request = _evaluatorRequestor.NewBuilder().SetCores(1).SetMegabytes(2048).Build();
+            var request = _evaluatorRequestor.NewBuilder().SetNumber(_totalEvaluators).SetCores(1).SetMegabytes(2048).Build();
 
             _evaluatorRequestor.Submit(request);
         }

--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansMasterTask.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansMasterTask.cs
@@ -140,7 +140,8 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
                 for (int i = 0; i < clustersNum; i++)
                 {
                     List<PartialMean> means = totalList.Where(m => m.Mean.Label == i).ToList();
-                    aggregatedMeans.Add(new PartialMean(PartialMean.AggreatedMean(means), means.Count));
+                    PartialMean aggregatedPartialMean = PartialMean.AggregatedPartialMean(means);
+                    aggregatedMeans.Add(new PartialMean(aggregatedPartialMean.Mean, aggregatedPartialMean.Size));
                 }
 
                 ProcessedResults returnMeans = new ProcessedResults(aggregatedMeans, aggregatedLoss);

--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/PartialMean.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/PartialMean.cs
@@ -53,7 +53,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
             return new PartialMean(DataVector.FromString(parts[0]), int.Parse(parts[1], CultureInfo.InvariantCulture));
         }
 
-        public static DataVector AggreatedMean(List<PartialMean> means)
+        public static PartialMean AggregatedPartialMean(List<PartialMean> means)
         {
             if (means == null || means.Count == 0)
             {
@@ -64,7 +64,12 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
             {
                 mean = mean.CombinePartialMean(means[i]);
             }
-            return mean.Mean;
+            return mean;
+        }
+
+        public static DataVector AggregatedMean(List<PartialMean> means)
+        {
+            return AggregatedPartialMean(means).Mean;
         }
 
         public static List<DataVector> AggregateTrueMeansToFileSystem(int partitionsNum, int clustersNum, string executionDirectory)
@@ -93,7 +98,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
             for (int i = 0; i < clustersNum; i++)
             {
                 List<PartialMean> means = partialMeans.Where(m => m.Mean.Label == i).ToList();
-                newCentroids.Add(PartialMean.AggreatedMean(means));
+                newCentroids.Add(PartialMean.AggregatedMean(means));
             }
             return newCentroids;
         }


### PR DESCRIPTION
This addressed the issue by
  * removing dependency on an obsolete file
  * adding code for on-the-fly input file generaton
  * fixing KMeans tests to generate an input file before running and take it as input
  * fix bug by removing default value for DataPartitionCache.PartitionIndex
  * fix bug of requesting only one evaluator
  * fix bug of miscalculating partial means in algorithm
  * fix bug of using CodecConfiguration instead of CodecToStreamingCodecConfiguration

JIRA:
  [REEF-1183](https://issues.apache.org/jira/browse/REEF-1183)

Pull Request:
  This closes #

Remarks:
  I marked the YarnOneBox test as `Skip = "Requires Yarn Single Node"`, but I checked that the test indeed succeeds on a single-node YARN cluster.