### PR TITLE
[REEF-650] Introduce example that actually uses IPerMapperConfigs in …

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/IntSumReduceFunction.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/IntSumReduceFunction.cs
@@ -20,7 +20,7 @@ using System.Linq;
 using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Tang.Annotations;
 
-namespace Org.Apache.REEF.IMRU.Examples.MapperCount
+namespace Org.Apache.REEF.IMRU.Examples
 {
     /// <summary>
     /// A reduce function that sums integers.

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/NaturalSum/NaturalSum.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/NaturalSum/NaturalSum.cs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Org.Apache.REEF.IMRU.API;
@@ -31,6 +32,13 @@ namespace Org.Apache.REEF.IMRU.Examples.NaturalSum
     /// <summary>
     /// A simple IMRU program that caclulates the sum of natural numbers.
     /// </summary>
+    /// <remarks>
+    /// This example demonstrates the use of <see cref="IPerMapperConfigGenerator"/>.
+    /// N mappers are instantiated, each given an integer id (1, 2, 3, ... N) with <see cref="NaturalSumPerMapperConfigGenerator"/>.
+    /// The map functions simply return the mapper's ids, and the ids get summed up via the reduce function and get passed to the updater.
+    /// The job finishes after this single iteration.
+    /// Call the <see cref="Run"/> method to run the example with custom parameters.
+    /// </remarks>
     public sealed class NaturalSum
     {
         private readonly IIMRUClient _imruClient;

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/NaturalSum/NaturalSum.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/NaturalSum/NaturalSum.cs
@@ -15,13 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System;
 using System.IO;
 using System.Linq;
 using Org.Apache.REEF.IMRU.API;
-using Org.Apache.REEF.IMRU.OnREEF.Parameters;
 using Org.Apache.REEF.IMRU.OnREEF.ResultHandler;
-using Org.Apache.REEF.IO.FileSystem.Local;
 using Org.Apache.REEF.IO.PartitionedData.Random;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
@@ -29,31 +26,31 @@ using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
 
-namespace Org.Apache.REEF.IMRU.Examples.MapperCount
+namespace Org.Apache.REEF.IMRU.Examples.NaturalSum
 {
     /// <summary>
-    /// A simple IMRU program that counts the number of map function instances launched.
+    /// A simple IMRU program that caclulates the sum of natural numbers.
     /// </summary>
-    public sealed class MapperCount
+    public sealed class NaturalSum
     {
         private readonly IIMRUClient _imruClient;
 
         [Inject]
-        private MapperCount(IIMRUClient imruClient)
+        private NaturalSum(IIMRUClient imruClient)
         {
             _imruClient = imruClient;
         }
 
         /// <summary>
-        /// Runs the actual mapper count job
+        /// Runs the actual natural sum job.
         /// </summary>
-        /// <returns>The number of MapFunction instances that are part of the job.</returns>
+        /// <returns>The result of the natural sum IMRU job.</returns>
         public int Run(int numberofMappers, string outputFile, IConfiguration fileSystemConfig)
         {
             var results = _imruClient.Submit<int, int, int, Stream>(
                 new IMRUJobDefinitionBuilder()
                     .SetMapFunctionConfiguration(IMRUMapConfiguration<int, int>.ConfigurationModule
-                        .Set(IMRUMapConfiguration<int, int>.MapFunction, GenericType<IdentityMapFunction>.Class)
+                        .Set(IMRUMapConfiguration<int, int>.MapFunction, GenericType<NaturalSumMapFunction>.Class)
                         .Build())
                     .SetUpdateFunctionConfiguration(
                         IMRUUpdateConfiguration<int, int, int>.ConfigurationModule
@@ -62,6 +59,10 @@ namespace Org.Apache.REEF.IMRU.Examples.MapperCount
                             .Build())
                     .SetMapInputCodecConfiguration(IMRUCodecConfiguration<int>.ConfigurationModule
                         .Set(IMRUCodecConfiguration<int>.Codec, GenericType<IntStreamingCodec>.Class)
+                        .Build())
+                    .SetPerMapConfigurations(IMRUPerMapperConfigGeneratorConfiguration.ConfigurationModule
+                        .Set(IMRUPerMapperConfigGeneratorConfiguration.PerMapperConfigGenerator,
+                            GenericType<NaturalSumPerMapperConfigGenerator>.Class)
                         .Build())
                     .SetUpdateFunctionCodecsConfiguration(IMRUCodecConfiguration<int>.ConfigurationModule
                         .Set(IMRUCodecConfiguration<int>.Codec, GenericType<IntStreamingCodec>.Class)
@@ -81,9 +82,7 @@ namespace Org.Apache.REEF.IMRU.Examples.MapperCount
                                 GenericType<WriteResultHandler<int>>.Class)
                             .BindNamedParameter(typeof(ResultOutputLocation), outputFile)
                             .Build())
-                    .SetMapTaskCores(2)
-                    .SetUpdateTaskCores(3)
-                    .SetJobName("MapperCount")
+                    .SetJobName("NaturalSum")
                     .SetNumberOfMappers(numberofMappers)
                     .Build());
 

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/NaturalSum/NaturalSum.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/NaturalSum/NaturalSum.cs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Org.Apache.REEF.IMRU.API;

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/NaturalSum/NaturalSumMapFunction.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/NaturalSum/NaturalSumMapFunction.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.IMRU.API;
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.IMRU.Examples.NaturalSum
+{
+    /// <summary>
+    /// Map function that returns its mapper id as output.
+    /// </summary>
+    internal sealed class NaturalSumMapFunction : IMapFunction<int, int>
+    {
+        private readonly int _mapperId;
+
+        [Inject]
+        private NaturalSumMapFunction([Parameter(typeof(NaturalSumPerMapperConfigGenerator.MapperId))] int mapperId)
+        {
+            _mapperId = mapperId;
+        }
+
+        /// <summary>
+        /// Map function that ignores the input and returns this mapper's id as output
+        /// </summary>
+        /// <param name="mapInput">input given from the Update function, but is not used</param>
+        /// <returns>id of this mapper</returns>
+        public int Map(int mapInput)
+        {
+            return _mapperId;
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/NaturalSum/NaturalSumPerMapperConfigGenerator.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/NaturalSum/NaturalSumPerMapperConfigGenerator.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Globalization;
+using Org.Apache.REEF.IMRU.API;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
+
+namespace Org.Apache.REEF.IMRU.Examples.NaturalSum
+{
+    /// <summary>
+    /// Configuration generator for assiging unique ids to each mapper.
+    /// </summary>
+    internal sealed class NaturalSumPerMapperConfigGenerator : IPerMapperConfigGenerator
+    {
+        [Inject]
+        private NaturalSumPerMapperConfigGenerator()
+        {
+        }
+
+        /// <summary>
+        /// Assign unique mapper id to each mapper. Ids start from 1.
+        /// </summary>
+        /// <param name="currentPartitionNumber">partition index of current mapper</param>
+        /// <param name="totalMappers">number of mappers, not used</param>
+        /// <returns>Configuration for <code>currentPartitionNumber</code>-th mapper</returns>
+        public IConfiguration GetMapperConfiguration(int currentPartitionNumber, int totalMappers)
+        {
+            var mapperId = currentPartitionNumber + 1;
+            return TangFactory.GetTang().NewConfigurationBuilder()
+                .BindNamedParameter(typeof(MapperId), mapperId.ToString(CultureInfo.InvariantCulture))
+                .Build();
+        }
+
+        [NamedParameter("Id number for each mapper")]
+        internal sealed class MapperId : Name<int>
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/Org.Apache.REEF.IMRU.Examples.csproj
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/Org.Apache.REEF.IMRU.Examples.csproj
@@ -44,9 +44,12 @@ under the License.
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MapperCount\IdentityMapFunction.cs" />
-    <Compile Include="MapperCount\IntSumReduceFunction.cs" />
+    <Compile Include="IntSumReduceFunction.cs" />
     <Compile Include="MapperCount\MapperCount.cs" />
-    <Compile Include="MapperCount\MapperCountUpdateFunction.cs" />
+    <Compile Include="SingleIterUpdateFunction.cs" />
+    <Compile Include="NaturalSum\NaturalSum.cs" />
+    <Compile Include="NaturalSum\NaturalSumMapFunction.cs" />
+    <Compile Include="NaturalSum\NaturalSumPerMapperConfigGenerator.cs" />
     <Compile Include="OnREEFIMRURunTimeConfiguration.cs" />
     <Compile Include="PipelinedBroadcastReduce\BroadcastReceiverReduceSenderMapFunction.cs" />
     <Compile Include="PipelinedBroadcastReduce\BroadcastReduceConfiguration.cs" />

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/SingleIterUpdateFunction.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/SingleIterUpdateFunction.cs
@@ -18,26 +18,26 @@
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.Tang.Annotations;
 
-namespace Org.Apache.REEF.IMRU.Examples.MapperCount
+namespace Org.Apache.REEF.IMRU.Examples
 {
     /// <summary>
-    /// The Update function for the mapper counting job.
+    /// A simple Update function for IMRU examples.
     /// </summary>
     /// <remarks>
-    /// Upon Initialize(), this sends `1` to all Map Function instances. Each of them returns `1`, which shows up as the
+    /// Upon Initialize(), this sends `1` to all Map Function instances. Each of them returns some result, which shows up as the
     /// parameter passed into `Update`. At that point, we can immediately terminate.
     /// </remarks>
-    public sealed class MapperCountUpdateFunction : IUpdateFunction<int, int, int>
+    public sealed class SingleIterUpdateFunction : IUpdateFunction<int, int, int>
     {
         [Inject]
-        private MapperCountUpdateFunction()
+        private SingleIterUpdateFunction()
         {
         }
 
         /// <summary>
         /// Update function
         /// </summary>
-        /// <param name="input">Input containing sum of all mappers</param>
+        /// <param name="input">Input containing sum of all mapper results</param>
         /// <returns>The Update Result with only result</returns>
         public UpdateResult<int, int> Update(int input)
         {

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/NaturalSumTest.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/NaturalSumTest.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.IMRU.Examples.NaturalSum;
+using Org.Apache.REEF.IMRU.InProcess;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Xunit;
+
+namespace Org.Apache.REEF.IMRU.Tests
+{
+    /// <summary>
+    /// Tests of the natural sum job.
+    /// </summary>
+    public class NaturalSumTest
+    {
+        private const int NumberOfMappers = 7;
+
+        /// <summary>
+        /// Tests the natural sum job using the in-process IMRU implementation.
+        /// </summary>
+        [Fact]
+        public void TestNaturalSumInProcess()
+        {
+            var naturalSumJob =
+                TangFactory.GetTang()
+                    .NewInjector(
+                        InProcessIMRUConfiguration.ConfigurationModule
+                            .Set(InProcessIMRUConfiguration.NumberOfMappers, NumberOfMappers.ToString())
+                            .Build())
+                    .GetInstance<NaturalSum>();
+            var result = naturalSumJob.Run(NumberOfMappers, string.Empty, TangFactory.GetTang().NewConfigurationBuilder().Build());
+            var expected = NumberOfMappers * (NumberOfMappers + 1) / 2; // expected = 1 + 2 + ... + NumberOfMappers
+            Assert.True(expected == result, string.Format("The result of the run should be {0} but was {1}.", expected, result));
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/Org.Apache.REEF.IMRU.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/Org.Apache.REEF.IMRU.Tests.csproj
@@ -49,6 +49,7 @@ under the License.
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MapInputWithControlMessageTests.cs" />
+    <Compile Include="NaturalSumTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MapperCountTest.cs" />
     <Compile Include="TestActiveContextManager.cs" />


### PR DESCRIPTION
…IMRU

This addressed the issue by
  * Add new example NaturalSum that uses IPerMapperConfigs
  * Add in-process test for NaturalSum
  * Move few common classes to higher directory

JIRA:
  [REEF-650](https://issues.apache.org/jira/browse/REEF-650)

Pull Request:
  Closes #

Remarks:
  The new example in this PR was added to demonstrate the use of IPerMapperConfigs that was introduced in [REEF-638](https://issues.apache.org/jira/browse/REEF-638). N mappers are instantiated, each given a integer id (1, 2, 3, ... N). The map functions simply return the mapper's ids, and the ids get summed up via the reduce function and get passed to the updater. The job finishes after this single iteration.
`NaturalSumTest` runs this example, checking whether the returned sum equals n(n+1)/2 or not.
