### PR TITLE
[REEF-1474] TestTask tests should wait for StartEvent to be signaled …

### DIFF
--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/ContextRuntimeTests.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/ContextRuntimeTests.cs
@@ -288,6 +288,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
                     throw new Exception();
                 }
 
+                testTask.StartEvent.Wait();
                 testTask.CountDownEvent.Signal();
                 testTask.StopEvent.Wait();
                 Assert.False(contextRuntime.GetTaskStatus().IsPresent());
@@ -295,13 +296,14 @@ namespace Org.Apache.REEF.Evaluator.Tests
                 taskThread.Join();
 
                 taskThread = contextRuntime.StartTaskOnNewThread(taskConfig);
-                Assert.Equal(contextRuntime.GetTaskStatus().Value.state, State.RUNNING);
-
                 var secondTestTask = contextRuntime.TaskRuntime.Value.Task as TestTask;
                 if (secondTestTask == null)
                 {
                     throw new Exception();
                 }
+
+                secondTestTask.StartEvent.Wait();
+                Assert.Equal(contextRuntime.GetTaskStatus().Value.state, State.RUNNING);
 
                 Assert.False(ReferenceEquals(testTask, secondTestTask));
 

--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/TaskRuntimeTests.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/TaskRuntimeTests.cs
@@ -173,6 +173,9 @@ namespace Org.Apache.REEF.Evaluator.Tests
 
             var taskThread = taskRuntime.StartTaskOnNewThread();
 
+            var task = injector.GetInstance<TestTask>();
+            task.StartEvent.Wait();
+
             Assert.True(testTaskEventStartHandler.StartInvoked.IsPresent());
             Assert.Equal(testTaskEventStartHandler.StartInvoked.Value, taskId);
             Assert.False(testTaskEventStartHandler.StopInvoked.IsPresent());
@@ -180,7 +183,6 @@ namespace Org.Apache.REEF.Evaluator.Tests
             var countDownAction = injector.GetInstance<CountDownAction>();
             countDownAction.CountdownEvent.Signal();
 
-            var task = injector.GetInstance<TestTask>();
             task.FinishCountdownEvent.Wait();
             task.DisposeCountdownEvent.Wait();
 
@@ -218,6 +220,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
             var taskThread = taskRuntime.StartTaskOnNewThread();
 
             var task = injector.GetInstance<TestTask>();
+            task.StartEvent.Wait();
             task.FinishCountdownEvent.Wait();
             task.DisposeCountdownEvent.Wait();
 
@@ -257,6 +260,7 @@ namespace Org.Apache.REEF.Evaluator.Tests
                 throw new Exception("Task is expected to be an instance of TestTask.");
             }
 
+            task.StartEvent.Wait();
             taskRuntime.Suspend(null);
 
             task.FinishCountdownEvent.Wait();


### PR DESCRIPTION
…before test verifications

This addressed the issue by
  * Waiting for StartEvent to be signaled for tests that use TestTask.

JIRA:
  [REEF-1474](https://issues.apache.org/jira/browse/REEF-1474)