### PR TITLE
[REEF-1476] Fix race condition in TestTwoSuccessiveTasksOnSameContext

### DIFF
--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/ContextRuntimeTests.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/ContextRuntimeTests.cs
@@ -291,9 +291,9 @@ namespace Org.Apache.REEF.Evaluator.Tests
                 testTask.StartEvent.Wait();
                 testTask.CountDownEvent.Signal();
                 testTask.StopEvent.Wait();
-                Assert.False(contextRuntime.GetTaskStatus().IsPresent());
-
                 taskThread.Join();
+
+                Assert.False(contextRuntime.GetTaskStatus().IsPresent());
 
                 taskThread = contextRuntime.StartTaskOnNewThread(taskConfig);
                 var secondTestTask = contextRuntime.TaskRuntime.Value.Task as TestTask;


### PR DESCRIPTION
This addressed the issue by
  * Join the task thread before checking the task status.

JIRA:
  [REEF-1476](https://issues.apache.org/jira/browse/REEF-1476)