### PR TITLE
[REEF-1139] Raises checkstyle warning on System.exit() call

### DIFF
--- a/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
@@ -245,6 +245,15 @@
             <property name="ignoredClassNameFormat" value="UnsupportedOperationException|NotImplementedException|NoSuchElementException" />
         </module>
 
+        <!-- Checks for System.exit() call -->
+        <!-- See https://issues.apache.org/jira/browse/REEF-1139 -->
+        <module name="Regexp">
+            <property name="severity" value="warning"/>
+            <property name="format" value="System\.exit\("/>
+            <property name="illegalPattern" value="true"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
     </module>
 
 </module>

--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -247,6 +247,15 @@
           <property name="ignoredClassNameFormat" value="UnsupportedOperationException|NotImplementedException|NoSuchElementException" />
         </module>
 
+        <!-- Checks for System.exit() call -->
+        <!-- See https://issues.apache.org/jira/browse/REEF-1139 -->
+        <module name="Regexp">
+            <property name="severity" value="warning"/>
+            <property name="format" value="System\.exit\("/>
+            <property name="illegalPattern" value="true"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
     </module>
 
 </module>


### PR DESCRIPTION
This patch:

- Adds System.exit() call check as a warning to checkstyle.xml and checkstyle-strict.xml

JIRA:
[REEF-1139](https://issues.apache.org/jira/browse/REEF-1139)