### PR TITLE
[REEF-68] Make Wake unit tests robust to port conflicts

### DIFF
--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/LargeMsgTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/LargeMsgTest.java
@@ -90,8 +90,8 @@ public class LargeMsgTest {
         new ServerHandler(monitor, dataSize), 1, new LoggingEventHandler<Throwable>());
 
     final String hostAddress = this.localAddressProvider.getLocalAddress();
-    final int port = 7001;
-    final Transport transport = tpFactory.newInstance(hostAddress, port, clientStage, serverStage, 1, 10000);
+    final Transport transport = tpFactory.newInstance(hostAddress, 0, clientStage, serverStage, 1, 10000);
+    final int port = transport.getListeningPort();
     final Link<byte[]> link = transport.open(new InetSocketAddress(hostAddress, port), new PassThroughEncoder(), null);
     final EStage<byte[]> writeSubmitter = new ThreadPoolStage<>("Submitter", new EventHandler<byte[]>() {
 

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteIdentifierFactoryTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteIdentifierFactoryTest.java
@@ -65,14 +65,13 @@ public class RemoteIdentifierFactoryTest {
     final RemoteManagerFactory remoteManagerFactory = Tang.Factory.getTang().newInjector()
         .getInstance(RemoteManagerFactory.class);
 
-    final int port = 9100;
     final Map<Class<?>, Codec<?>> clazzToCodecMap = new HashMap<>();
     clazzToCodecMap.put(TestEvent.class, new TestEventCodec());
     final Codec<?> codec = new MultiCodec<Object>(clazzToCodecMap);
 
 
     try (final RemoteManager rm =
-             remoteManagerFactory.getInstance("TestRemoteManager", port, codec, new LoggingEventHandler<Throwable>())) {
+             remoteManagerFactory.getInstance("TestRemoteManager", 0, codec, new LoggingEventHandler<Throwable>())) {
       final RemoteIdentifier id = rm.getMyIdentifier();
 
       final IdentifierFactory factory = new DefaultIdentifierFactory();

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteManagerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteManagerTest.java
@@ -67,7 +67,6 @@ public class RemoteManagerTest {
   public final TestName name = new TestName();
 
   private static final String LOG_PREFIX = "TEST ";
-  private static final int PORT = 9100;
 
   @Test
   public void testRemoteManagerTest() throws Exception {
@@ -87,11 +86,10 @@ public class RemoteManagerTest {
     final String hostAddress = localAddressProvider.getLocalAddress();
 
     final RemoteManager rm = this.remoteManagerFactory.getInstance(
-        "name", hostAddress, PORT, codec, new LoggingEventHandler<Throwable>(), false, 3, 10000,
+        "name", hostAddress, 0, codec, new LoggingEventHandler<Throwable>(), false, 3, 10000,
         localAddressProvider, Tang.Factory.getTang().newInjector().getInstance(TcpPortProvider.class));
 
-    final RemoteIdentifierFactory factory = new DefaultRemoteIdentifierFactoryImplementation();
-    final RemoteIdentifier remoteId = factory.getNewInstance("socket://" + hostAddress + ":" + PORT);
+    final RemoteIdentifier remoteId = rm.getMyIdentifier();
     Assert.assertTrue(rm.getMyIdentifier().equals(remoteId));
 
     final EventHandler<StartEvent> proxyConnection = rm.getHandler(remoteId, StartEvent.class);
@@ -191,11 +189,10 @@ public class RemoteManagerTest {
     final String hostAddress = localAddressProvider.getLocalAddress();
 
     final RemoteManager rm = this.remoteManagerFactory.getInstance(
-        "name", hostAddress, PORT, codec, new LoggingEventHandler<Throwable>(), true, 3, 10000,
+        "name", hostAddress, 0, codec, new LoggingEventHandler<Throwable>(), true, 3, 10000,
         localAddressProvider, Tang.Factory.getTang().newInjector().getInstance(TcpPortProvider.class));
 
-    final RemoteIdentifierFactory factory = new DefaultRemoteIdentifierFactoryImplementation();
-    final RemoteIdentifier remoteId = factory.getNewInstance("socket://" + hostAddress + ":" + PORT);
+    final RemoteIdentifier remoteId = rm.getMyIdentifier();
 
     final EventHandler<StartEvent> proxyConnection = rm.getHandler(remoteId, StartEvent.class);
     final EventHandler<TestEvent1> proxyHandler1 = rm.getHandler(remoteId, TestEvent1.class);
@@ -235,11 +232,10 @@ public class RemoteManagerTest {
     final String hostAddress = localAddressProvider.getLocalAddress();
 
     final RemoteManager rm = this.remoteManagerFactory.getInstance(
-        "name", hostAddress, PORT, codec, new LoggingEventHandler<Throwable>(), false, 3, 10000,
+        "name", hostAddress, 0, codec, new LoggingEventHandler<Throwable>(), false, 3, 10000,
         localAddressProvider, Tang.Factory.getTang().newInjector().getInstance(TcpPortProvider.class));
 
-    final RemoteIdentifierFactory factory = new DefaultRemoteIdentifierFactoryImplementation();
-    final RemoteIdentifier remoteId = factory.getNewInstance("socket://" + hostAddress + ":" + PORT);
+    final RemoteIdentifier remoteId = rm.getMyIdentifier();
 
     final EventHandler<TestEvent> proxyHandler = rm.getHandler(remoteId, TestEvent.class);
 
@@ -270,13 +266,10 @@ public class RemoteManagerTest {
     clazzToCodecMap.put(TestEvent.class, new ObjectSerializableCodec<TestEvent>());
     final Codec<?> codec = new MultiCodec<Object>(clazzToCodecMap);
 
-    final String hostAddress = localAddressProvider.getLocalAddress();
-
     final ExceptionHandler errorHandler = new ExceptionHandler(monitor);
 
-    try (final RemoteManager rm = remoteManagerFactory.getInstance("name", PORT, codec, errorHandler)) {
-      final RemoteIdentifierFactory factory = new DefaultRemoteIdentifierFactoryImplementation();
-      final RemoteIdentifier remoteId = factory.getNewInstance("socket://" + hostAddress + ":" + PORT);
+    try (final RemoteManager rm = remoteManagerFactory.getInstance("name", 0, codec, errorHandler)) {
+      final RemoteIdentifier remoteId = rm.getMyIdentifier();
 
       final EventHandler<StartEvent> proxyConnection = rm.getHandler(remoteId, StartEvent.class);
       rm.registerHandler(StartEvent.class, new ExceptionGenEventHandler<StartEvent>("recvExceptionGen"));

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteTest.java
@@ -117,9 +117,6 @@ public class RemoteTest {
     final Monitor monitor = new Monitor();
     final TimerStage timer = new TimerStage(new TimeoutHandler(monitor), 5000, 5000);
 
-    // port
-    final int port = 9101;
-
     // receiver stage
     // decoder map
     final Map<Class<?>, Decoder<?>> clazzToDecoderMap = new HashMap<>();
@@ -142,7 +139,10 @@ public class RemoteTest {
     final String hostAddress = this.localAddressProvider.getLocalAddress();
 
     // transport
-    final Transport transport = tpFactory.newInstance(hostAddress, port, reRecvStage, reRecvStage, 1, 10000);
+    final Transport transport = tpFactory.newInstance(hostAddress, 0, reRecvStage, reRecvStage, 1, 10000);
+
+    // port
+    final int port = transport.getListeningPort();
 
     // mux encoder with encoder map
     final Map<Class<?>, Encoder<?>> clazzToEncoderMap = new HashMap<>();

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/SmallMessagesTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/SmallMessagesTest.java
@@ -69,9 +69,6 @@ public class SmallMessagesTest {
     final Monitor monitor = new Monitor();
     final TimerStage timer = new TimerStage(new TimeoutHandler(monitor), 60000, 60000);
 
-    // port
-    final int port = 9101;
-
     // receiver stage
     // decoder map
     final Map<Class<?>, Decoder<?>> clazzToDecoderMap = new HashMap<>();
@@ -94,7 +91,10 @@ public class SmallMessagesTest {
     final String hostAddress = this.localAddressProvider.getLocalAddress();
 
     // transport
-    final Transport transport = tpFactory.newInstance(hostAddress, port, reRecvStage, reRecvStage, 1, 10000);
+    final Transport transport = tpFactory.newInstance(hostAddress, 0, reRecvStage, reRecvStage, 1, 10000);
+
+    // port
+    final int port = transport.getListeningPort();
 
     // mux encoder with encoder map
     final Map<Class<?>, Encoder<?>> clazzToEncoderMap = new HashMap<>();

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportRaceTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportRaceTest.java
@@ -68,9 +68,8 @@ public class TransportRaceTest {
     final EStage<TransportEvent> serverStage = new ThreadPoolStage<>("server@7001",
         serverHandler, 1, new LoggingEventHandler<Throwable>());
     final String hostAddress = this.localAddressProvider.getLocalAddress();
-    final int port = 7001;
-    final Transport transport = tpFactory.newInstance(
-        hostAddress, port, clientStage, serverStage, 1, 10000);
+    final Transport transport = tpFactory.newInstance(hostAddress, 0, clientStage, serverStage, 1, 10000);
+    final int port = transport.getListeningPort();
 
     final String value = "Test Race";
 

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportTest.java
@@ -71,12 +71,12 @@ public class TransportTest {
 
     final int expected = 2;
     final String hostAddress = this.localAddressProvider.getLocalAddress();
-    final int port = 9100;
 
     // Codec<String>
     final ReceiverStage<String> stage =
         new ReceiverStage<>(new ObjectSerializableCodec<String>(), monitor, expected);
-    final Transport transport = tpFactory.newInstance(hostAddress, port, stage, stage, 1, 10000);
+    final Transport transport = tpFactory.newInstance(hostAddress, 0, stage, stage, 1, 10000);
+    final int port = transport.getListeningPort();
 
     // sending side
     final Link<String> link = transport.open(
@@ -103,12 +103,12 @@ public class TransportTest {
 
     final int expected = 2;
     final String hostAddress = this.localAddressProvider.getLocalAddress();
-    final int port = 9100;
 
     // Codec<TestEvent>
     final ReceiverStage<TestEvent> stage =
         new ReceiverStage<>(new ObjectSerializableCodec<TestEvent>(), monitor, expected);
-    final Transport transport = tpFactory.newInstance(hostAddress, port, stage, stage, 1, 10000);
+    final Transport transport = tpFactory.newInstance(hostAddress, 0, stage, stage, 1, 10000);
+    final int port = transport.getListeningPort();
 
     // sending side
     final Link<TestEvent> link = transport.open(


### PR DESCRIPTION
This addressed the issue by
* Giving 0 for port numbers which leads to using random numbers as port numbers,
* Getting port numbers with getListeningPort() for reuse.

JIRA:
[REEF-68](https://issues.apache.org/jira/browse/REEF-68)