### PR TITLE
[REEF-1490] Remove ITaskMessageSource.Message.Set

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Context/IContextMessageSource.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Context/IContextMessageSource.cs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using Org.Apache.REEF.Common.Context.Defaults;
+using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Utilities;
 
 namespace Org.Apache.REEF.Common.Context
@@ -23,6 +25,7 @@ namespace Org.Apache.REEF.Common.Context
     ///     Implement (and bind) this interface to send messages from a context as part of a heartbeat from Evaluator to
     ///     Driver.
     /// </summary>
+    [DefaultImplementation(typeof(DefaultContextMessageSource))]
     public interface IContextMessageSource
     {
         Optional<ContextMessage> Message { get; }

--- a/lang/cs/Org.Apache.REEF.Common/Tasks/Defaults/DefaultTaskMessageSource.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Tasks/Defaults/DefaultTaskMessageSource.cs
@@ -33,14 +33,7 @@ namespace Org.Apache.REEF.Common.Tasks.Defaults
         {
             get
             {
-                TaskMessage defaultTaskMessage = TaskMessage.From(
-                    "defaultSourceId", 
-                    ByteUtilities.StringToByteArrays("default message generated at " + DateTime.Now.ToString(CultureInfo.InvariantCulture)));
-                return Optional<TaskMessage>.Of(defaultTaskMessage);
-            }
-
-            set
-            {
+                return Optional<TaskMessage>.Empty();
             }
         }
     }

--- a/lang/cs/Org.Apache.REEF.Common/Tasks/ITaskMessageSource.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Tasks/ITaskMessageSource.cs
@@ -21,9 +21,12 @@ using Org.Apache.REEF.Utilities;
 
 namespace Org.Apache.REEF.Common.Tasks
 {
+    /// <summary>
+    /// Implement (and bind) this interface to send messages from a task as part of a heartbeat from Evaluator to Driver.
+    /// </summary>
     [DefaultImplementation(typeof(DefaultTaskMessageSource))]
     public interface ITaskMessageSource
     {
-        Optional<TaskMessage> Message { get; set; }
+        Optional<TaskMessage> Message { get; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Examples/Tasks/HelloTask/HelloTaskMessage.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/Tasks/HelloTask/HelloTaskMessage.cs
@@ -39,10 +39,6 @@ namespace Org.Apache.REEF.Examples.Tasks.HelloTask
                     ByteUtilities.StringToByteArrays("hello message generated at " + DateTime.Now.ToString(CultureInfo.InvariantCulture)));
                 return Optional<TaskMessage>.Of(defaultTaskMessage);
             }
-
-            set
-            {
-            }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/MessageTask.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Messaging/MessageTask.cs
@@ -63,10 +63,6 @@ namespace Org.Apache.REEF.Tests.Functional.Messaging
 
                 return Optional<TaskMessage>.Of(defaultTaskMessage);
             }
-
-            set
-            {
-            }
         }
 
         public byte[] Call(byte[] memento)


### PR DESCRIPTION
This change:
 * removes unused method ITaskMessageSource.Message.Set
 * adds documentation for ITaskMessageSource interface
 * modifies DefaultTaskMessageSource to return empty message
 * adds DefaultContextMessageSource as default implementation
   for IContextMessageSource

JIRA:
  [REEF-1490](https://issues.apache.org/jira/browse/REEF-1490)

Pull request:
  This closes #