### PR TITLE
[REEF-832] Add CLOSING state to EvaluatorState

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/RunningTask.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/RunningTask.java
@@ -23,6 +23,7 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.io.naming.Identifiable;
+import org.apache.reef.runtime.common.driver.task.TaskRepresenter;
 
 /**
  * Represents a running Task.
@@ -70,4 +71,10 @@ public interface RunningTask extends Identifiable, AutoCloseable {
    */
   @Override
   void close();
+
+  /**
+   * Gets the representer of task.
+   * @return the representer of task
+   */
+  TaskRepresenter getTaskRepresenter();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
@@ -52,9 +52,10 @@ final class EvaluatorStatusManager {
       switch(to) {
       case SUBMITTED:
       case DONE:
+      case CLOSING:
       case FAILED:
-      case KILLED:
         return true;
+      case KILLED:
       case RUNNING:
         break;
       default:
@@ -65,10 +66,11 @@ final class EvaluatorStatusManager {
       switch(to) {
       case RUNNING:
       case DONE:
+      case CLOSING:
       case FAILED:
-      case KILLED:
         return true;
       case ALLOCATED:
+      case KILLED:
         break;
       default:
         throw new RuntimeException("Unknown state: " + to);
@@ -77,11 +79,26 @@ final class EvaluatorStatusManager {
     case RUNNING: {
       switch(to) {
       case DONE:
+      case CLOSING:
       case FAILED:
-      case KILLED:
         return true;
       case ALLOCATED:
       case SUBMITTED:
+      case KILLED:
+        break;
+      default:
+        throw new RuntimeException("Unknown state: " + to);
+      }
+    }
+    case CLOSING: {
+      switch(to) {
+      case KILLED:
+      case DONE:
+      case FAILED:
+        return true;
+      case ALLOCATED:
+      case SUBMITTED:
+      case RUNNING:
         break;
       default:
         throw new RuntimeException("Unknown state: " + to);
@@ -111,6 +128,10 @@ final class EvaluatorStatusManager {
 
   synchronized void setSubmitted() {
     this.setState(EvaluatorState.SUBMITTED);
+  }
+
+  synchronized void setClosing() {
+    this.setState(EvaluatorState.CLOSING);
   }
 
   synchronized void setDone() {
@@ -149,6 +170,10 @@ final class EvaluatorStatusManager {
 
   synchronized boolean isFailedOrKilled() {
     return EvaluatorState.FAILED == this.state || EvaluatorState.KILLED == this.state;
+  }
+
+  synchronized boolean isClosing() {
+    return EvaluatorState.CLOSING == this.state;
   }
 
   @Override

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
@@ -67,7 +67,7 @@ public final class Evaluators implements AutoCloseable {
     }
     for (final EvaluatorManager evaluatorManager : evaluatorsCopy) {
       LOG.log(Level.WARNING, "Unclean shutdown of evaluator {0}", evaluatorManager.getId());
-      if (!evaluatorManager.isClosed()) {
+      if (!evaluatorManager.isClosedOrClosing()) {
         evaluatorManager.close();
       }
     }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/RunningTaskImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/RunningTaskImpl.java
@@ -137,4 +137,8 @@ public final class RunningTaskImpl implements RunningTask {
   public String toString() {
     return "RunningTask{taskId='" + taskId + "'}";
   }
+
+  public TaskRepresenter getTaskRepresenter() {
+    return taskRepresenter;
+  }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
@@ -220,4 +220,20 @@ public final class TaskRepresenter {
         new Object[]{this.taskId, this.state, newState});
     this.state = newState;
   }
+
+  /**
+   * Check whether this evaluator is in closing state.
+   * @return whether this evaluator is in closing state.
+   */
+  public boolean evaluatorIsClosing() {
+    return evaluatorManager.isClosing();
+  }
+
+  /**
+   * Check whether this evaluator is in closed state.
+   * @return whether this evaluator is in closed state.
+   */
+  public boolean evaluatorIsClosed() {
+    return evaluatorManager.isClosed();
+  }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorRuntime.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorRuntime.java
@@ -130,6 +130,7 @@ final class EvaluatorRuntime implements EventHandler<EvaluatorControlProto> {
         if (message.hasKillEvaluator()) {
           LOG.log(Level.SEVERE, "Evaluator {0} has been killed by the driver.", this.evaluatorIdentifier);
           this.state = ReefServiceProtos.State.KILLED;
+          this.heartBeatManager.sendEvaluatorStatus(this.getEvaluatorStatus());
           this.clock.close();
         }
       }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/AllTestsSuite.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/AllTestsSuite.java
@@ -22,6 +22,7 @@ import org.apache.reef.tests.applications.ApplicationTestSuite;
 import org.apache.reef.tests.close_eval.CloseEvaluatorTest;
 import org.apache.reef.tests.configurationproviders.ConfigurationProviderTest;
 import org.apache.reef.tests.driver.DriverTest;
+import org.apache.reef.tests.evaluatorclose.EvaluatorCloseTest;
 import org.apache.reef.tests.runtimename.RuntimeNameTest;
 import org.apache.reef.tests.evaluatorfailure.EvaluatorFailureTest;
 import org.apache.reef.tests.evaluatorreuse.EvaluatorReuseTest;
@@ -60,6 +61,7 @@ import org.junit.runners.Suite;
     ApplicationTestSuite.class,
     RuntimeNameTest.class,
     WatcherTest.class,
+    EvaluatorCloseTest.class,
     })
 public final class AllTestsSuite {
 }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorclose/EvaluatorCloseDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorclose/EvaluatorCloseDriver.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.evaluatorclose;
+
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.task.RunningTask;
+import org.apache.reef.driver.task.TaskConfiguration;
+import org.apache.reef.runtime.common.driver.task.TaskRepresenter;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.annotations.Unit;
+import org.apache.reef.tests.library.exceptions.DriverSideFailure;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.StopTime;
+
+import javax.inject.Inject;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Unit
+final class EvaluatorCloseDriver {
+  private static final Logger LOG = Logger.getLogger(EvaluatorCloseDriver.class.getName());
+  private final AtomicBoolean changedToClosing = new AtomicBoolean(false);
+  private TaskRepresenter taskRepresenter;
+  private AllocatedEvaluator evaluator;
+
+  @Inject
+  EvaluatorCloseDriver() {
+  }
+
+  final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
+
+    @Override
+    public void onNext(final AllocatedEvaluator allocatedEvaluator) {
+      LOG.log(Level.FINE, "Received a AllocatedEvaluator for Evaluator {0}", allocatedEvaluator.getId());
+      evaluator = allocatedEvaluator;
+      final Configuration taskConfiguration = TaskConfiguration.CONF
+          .set(TaskConfiguration.IDENTIFIER, "EvaluatorCloseTestTask")
+          .set(TaskConfiguration.TASK, EvaluatorCloseTestTask.class)
+          .build();
+      allocatedEvaluator.submitTask(taskConfiguration);
+    }
+  }
+
+  final class TaskRunningHandler implements EventHandler<RunningTask> {
+
+    @Override
+    public void onNext(final RunningTask runningTask) {
+      LOG.log(Level.FINE, "Received a RunningTask on Evaluator {0}", runningTask.getActiveContext().getEvaluatorId());
+      taskRepresenter = runningTask.getTaskRepresenter();
+      evaluator.close();
+      changedToClosing.set(taskRepresenter.evaluatorIsClosing());
+    }
+  }
+
+  final class StopHandler implements EventHandler<StopTime> {
+
+    @Override
+    public void onNext(final StopTime stopTime) {
+      if (!changedToClosing.get()) {
+        throw new DriverSideFailure("Evaluator's state was not changed to closing.");
+      } else if (!taskRepresenter.evaluatorIsClosed()){
+        throw new DriverSideFailure("Evaluator's state was not changed to closed after completion.");
+      } else {
+        LOG.log(Level.FINEST, "Evaluator state was changed properly (RUNNING -> CLOSING -> CLOSED).");
+      }
+    }
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorclose/EvaluatorCloseTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorclose/EvaluatorCloseTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.evaluatorclose;
+
+import org.apache.reef.client.DriverConfiguration;
+import org.apache.reef.client.DriverLauncher;
+import org.apache.reef.client.LauncherStatus;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tests.TestEnvironment;
+import org.apache.reef.tests.TestEnvironmentFactory;
+import org.apache.reef.tests.library.driver.OnDriverStartedAllocateOne;
+import org.apache.reef.util.EnvironmentUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests whether evaluator's state is properly changed during closing.
+ */
+public class EvaluatorCloseTest {
+
+  private final TestEnvironment testEnvironment = TestEnvironmentFactory.getNewTestEnvironment();
+
+  @Before
+  public void setUp() throws Exception {
+    testEnvironment.setUp();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    this.testEnvironment.tearDown();
+  }
+
+  /**
+   * Tests that an evaluator's state is changed to closing and closed in order during closing.
+   */
+  @Test
+  public void testEvaluatorClosingState() throws InjectionException {
+    final Configuration runtimeConfiguration = this.testEnvironment.getRuntimeConfiguration();
+
+    final Configuration driverConfiguration = DriverConfiguration.CONF
+        .set(DriverConfiguration.GLOBAL_LIBRARIES,
+            EnvironmentUtils.getClassLocation(EvaluatorCloseDriver.class))
+        .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_EvaluatorCloseTest")
+        .set(DriverConfiguration.ON_DRIVER_STARTED, OnDriverStartedAllocateOne.class)
+        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, EvaluatorCloseDriver.EvaluatorAllocatedHandler.class)
+        .set(DriverConfiguration.ON_TASK_RUNNING, EvaluatorCloseDriver.TaskRunningHandler.class)
+        .set(DriverConfiguration.ON_DRIVER_STOP, EvaluatorCloseDriver.StopHandler.class)
+        .build();
+
+    final LauncherStatus status = DriverLauncher.getLauncher(runtimeConfiguration)
+        .run(driverConfiguration, this.testEnvironment.getTestTimeout());
+
+    Assert.assertTrue("The result state of evaluator closing state test is " + status,
+        status.isSuccess());
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorclose/EvaluatorCloseTestTask.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorclose/EvaluatorCloseTestTask.java
@@ -16,23 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runtime.common.driver.evaluator;
+package org.apache.reef.tests.evaluatorclose;
 
-import org.apache.reef.annotations.audience.DriverSide;
-import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.task.Task;
+
+import javax.inject.Inject;
 
 /**
- * Various states that the EvaluatorManager could be in. The EvaluatorManager is
- * created when a resource has been allocated by the ResourceManager.
+ * The task for testing the evaluator's state changing during close.
  */
-@DriverSide
-@Private
-enum EvaluatorState {
-  ALLOCATED,  // initial state
-  SUBMITTED,  // client called AllocatedEvaluator.submitTask() and we're waiting for first contact
-  RUNNING,    // first contact received, all communication channels established, Evaluator sent to client.
-  CLOSING,    // evaluator is asked shutdown, but not closed yet.
-  DONE,       // clean shutdown
-  FAILED,     // some failure occurred.
-  KILLED      // unclean shutdown
+final class EvaluatorCloseTestTask implements Task {
+
+  @Inject
+  EvaluatorCloseTestTask() {
+  }
+
+  @Override
+  public byte[] call(final byte[] memento) {
+    while(true) {
+      // Busy loop
+    }
+  }
 }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorclose/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorclose/package-info.java
@@ -16,23 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runtime.common.driver.evaluator;
-
-import org.apache.reef.annotations.audience.DriverSide;
-import org.apache.reef.annotations.audience.Private;
-
 /**
- * Various states that the EvaluatorManager could be in. The EvaluatorManager is
- * created when a resource has been allocated by the ResourceManager.
+ * Tests of closing evaluator.
  */
-@DriverSide
-@Private
-enum EvaluatorState {
-  ALLOCATED,  // initial state
-  SUBMITTED,  // client called AllocatedEvaluator.submitTask() and we're waiting for first contact
-  RUNNING,    // first contact received, all communication channels established, Evaluator sent to client.
-  CLOSING,    // evaluator is asked shutdown, but not closed yet.
-  DONE,       // clean shutdown
-  FAILED,     // some failure occurred.
-  KILLED      // unclean shutdown
-}
+package org.apache.reef.tests.evaluatorclose;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/EvaluatorFailureDuringAlarmDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/EvaluatorFailureDuringAlarmDriver.java
@@ -91,7 +91,6 @@ final class EvaluatorFailureDuringAlarmDriver {
     public void onNext(final FailedTask failedTask) {
       LOG.log(Level.SEVERE, "Received FailedTask: {0}", failedTask);
       otherFailuresReceived.set(true);
-
     }
   }
 


### PR DESCRIPTION
This addressed the issue by
  * When `EvaluatorManager` close a running evaluator, it turn into CLOSING state instead of KILLED.
  * Adding ACK logic from `EvaluatorRuntime` to `EvaluatorManager` during killing.
  * After `EvaluatorManager` ACK this message, it turn into KILLED state.

JIRA:
  [REEF-832](https://issues.apache.org/jira/browse/REEF-832)