### PR TITLE
[REEF-1499] Fix CoreCLR incompatibility in Tang

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
@@ -513,7 +513,7 @@ namespace Org.Apache.REEF.Tang.Util
             if (type != null)
             {
                 // HACK: The only way to detect anonymous types right now.
-                return Attribute.IsDefined(type, typeof(CompilerGeneratedAttribute), false)
+                return CustomAttributeExtensions.IsDefined(type, typeof(CompilerGeneratedAttribute), false)
                        && type.IsGenericType && type.Name.Contains("AnonymousType")
                        && (type.Name.StartsWith("<>", true, CultureInfo.CurrentCulture) || type.Name.StartsWith("VB$", true, CultureInfo.CurrentCulture))
                        && (type.Attributes & TypeAttributes.NotPublic) == TypeAttributes.NotPublic;


### PR DESCRIPTION
This addresses the issue by:
 *replacing call to Attribute.IsDefined with
  CustomAttributeExtensions.IsDefined, which is part of CoreCLR

JIRA:
  [REEF-1499](https://issues.apache.org/jira/browse/REEF-1499)

This closes #