### PR TITLE
[REEF-1497] Fix .NET Core compatibility issues in REEF.Driver

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/HttpServerHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/HttpServerHandler.cs
@@ -58,7 +58,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                     Exceptions.Throw(new ArgumentException("spec cannot contain :"), "The http spec given is " + spec, LOGGER);
                 }
                 LOGGER.Log(Level.Info, "HttpHandler spec:" + spec);   
-                eventHandlers.Add(spec.ToLower(CultureInfo.CurrentCulture), h);
+                eventHandlers.Add(CultureInfo.CurrentCulture.TextInfo.ToLower(spec), h);
             }
             this.httpServerPort = httpServerPort;
         }
@@ -99,7 +99,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                     ReefHttpResponse response = new ReefHttpResponse();
 
                     IHttpHandler handler;
-                    eventHandlers.TryGetValue(spec.ToLower(CultureInfo.CurrentCulture), out handler);
+                    eventHandlers.TryGetValue(CultureInfo.CurrentCulture.TextInfo.ToLower(spec), out handler);
 
                     byte[] responseData;
                     if (handler != null)


### PR DESCRIPTION
    Replace calls to System.String.toLowe() which are not supported in .NET
    Core with calls to CultureInfo.CurrentCulture.TextInfo.ToLower().

JIRA:
    [REEF-1497](https://issues.apache.org/jira/browse/REEF-1497)