### PR TITLE
[REEF-1503] Do not shut down driver on attempt to send close message …

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/RunningTaskImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/RunningTaskImpl.java
@@ -92,7 +92,7 @@ public final class RunningTaskImpl implements RunningTask {
           .build();
       this.evaluatorManager.sendContextControlMessage(contextControlProto);
     } else {
-      LOG.log(Level.FINE, "Ignoring call to .close() because the task is no longer RUNNING.");
+      LOG.log(Level.INFO, "Ignoring call to .close() because the task is no longer RUNNING.");
     }
   }
 
@@ -107,7 +107,8 @@ public final class RunningTaskImpl implements RunningTask {
           .build();
       this.evaluatorManager.sendContextControlMessage(contextControlProto);
     } else {
-      throw new RuntimeException("Trying to send a message to a Task that is no longer RUNNING.");
+      LOG.log(Level.INFO, "Ignoring call to .close(byte[] message) because the task is no longer RUNNING "
+          + "(see REEF-1503 for an example of scenario in which this happens).");
     }
   }
 


### PR DESCRIPTION
…to a non-running task

This change replaces throwing exception on attempt to send close message
to a task which is not running with writing a log.

JIRA:
  [REEF-1503](https://issues.apache.org/jira/browse/REEF-1503)

Pull request:
  This closes #