### PR TITLE
[REEF-31] Introduce NamedObject to bind multiple non-singleton instances

### DIFF
--- a/lang/java/reef-tang/tang/src/main/avro/configuration.avsc
+++ b/lang/java/reef-tang/tang/src/main/avro/configuration.avsc
@@ -20,10 +20,22 @@
 {
     "namespace":"org.apache.reef.tang.formats.avro",
     "type":"record",
+    "name":"AvroNamedObject",
+    "fields":[
+      {"name":"type","type":"string"},
+      {"name":"name","type":"string"},
+      {"name":"isGlobal","type":"boolean"}
+    ]
+},
+{
+    "namespace":"org.apache.reef.tang.formats.avro",
+    "type":"record",
     "name":"ConfigurationEntry",
     "fields":[
       {"name":"key","type":"string"},
-      {"name":"value","type":"string"}
+      {"name":"value","type":["string","AvroNamedObject"]},
+      {"name":"namedObject", "type":"AvroNamedObject",
+        "default": {"type":"", "name":"", "isGlobal":true}}
     ]
 },
 {

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configuration.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configuration.java
@@ -18,9 +18,7 @@
  */
 package org.apache.reef.tang;
 
-import org.apache.reef.tang.types.ClassNode;
-import org.apache.reef.tang.types.ConstructorDef;
-import org.apache.reef.tang.types.NamedParameterNode;
+import org.apache.reef.tang.types.*;
 
 import java.util.List;
 import java.util.Set;
@@ -73,34 +71,45 @@ public interface Configuration {
   ConfigurationBuilder newBuilder();
 
   /**
-   * Return the value of the given named parameter as an unparsed string.
+   * Return the value of the given named parameter and named node object as an unparsed string.
    * <p>
    * If nothing was explicitly bound, this method returns null (it does not
    * return default values).
    *
    * @param np A NamedParameter object from this Configuration's class hierarchy.
-   * @return The validated string that this parameter is bound to, or null.
+   * @param noe A NamedObjectElement which np belongs to
+   * @return The validated string (could be either a primitive value or class name)
+   * or a NamedObjectElement that this NamedParameter is bound to.
+   * If nothing is bound to this NamedParameter, then it returns null.
    * @see #getClassHierarchy()
    */
-  String getNamedParameter(NamedParameterNode<?> np);
+  Object getNamedParameter(NamedParameterNode<?> np, NamedObjectElement noe);
+
+  Object getNamedParameter(NamedParameterNode<?> np);
 
   /**
-   * Obtain the set of class hierarchy nodes or strings that were bound to a given NamedParameterNode.
+   * Obtain the set of class hierarchy nodes or strings that were bound to a given NamedParameterNode
+   * and NamedNodeObject.
    * If nothing was explicitly bound, the set will be empty (it will not reflect any default values).
    *
    * @param np A NamedParameterNode from this Configuration's class hierarchy.
+   * @param noe A NamedObjectElement which np belongs to
    * @return A set of ClassHierarchy Node objects or a set of strings, depending on
    * whether the NamedParameterNode refers to an interface or configuration options, respectively.
    * @see #getClassHierarchy()
    */
+  Set<Object> getBoundSet(NamedParameterNode<Set<?>> np, NamedObjectElement noe);
+
   Set<Object> getBoundSet(NamedParameterNode<Set<?>> np);
 
   /**
-   * Get the list bound to a given NamedParameterNode. The list will be empty if nothing was bound.
+   * Get the list bound to a given NamedParameterNode and NamedNodeObject. The list will be empty if nothing was bound.
    *
    * @param np Target NamedParameter
    * @return A list bound to np
    */
+  List<Object> getBoundList(NamedParameterNode<List<?>> np, NamedObjectElement noe);
+
   List<Object> getBoundList(NamedParameterNode<List<?>> np);
 
   /**
@@ -115,11 +124,12 @@ public interface Configuration {
   /**
    * Returns the bound implementation.
    *
-   * @param <T> a type
    * @param cn a class node
    * @return the implementation that cn has been explicitly bound to, or null.  Defaults are not returned.
    */
-  <T> ClassNode<T> getBoundImplementation(ClassNode<T> cn);
+  Boundable getBoundImplementation(ClassNode cn, NamedObjectElement noe);
+
+  Boundable getBoundImplementation(ClassNode cn);
 
   /**
    * Return the LegacyConstructor that has been bound to this Class.
@@ -139,6 +149,8 @@ public interface Configuration {
    * @return the set of all interfaces (or super-classes) that have been explicitly
    * bound to an implementation sub-class.
    */
+  Set<ClassNode<?>> getBoundImplementations(NamedObjectElement noe);
+
   Set<ClassNode<?>> getBoundImplementations();
 
   /**
@@ -149,6 +161,8 @@ public interface Configuration {
   /**
    * @return the set of all the named parameters that have been explicitly bound to something.
    */
+  Set<NamedParameterNode<?>> getNamedParameters(NamedObjectElement noe);
+
   Set<NamedParameterNode<?>> getNamedParameters();
 
   /**
@@ -166,11 +180,18 @@ public interface Configuration {
   /**
    * @return the set of all NamedParameterNodes explicitly bound to sets.
    */
+  Set<NamedParameterNode<Set<?>>> getBoundSets(NamedObjectElement noe);
+
   Set<NamedParameterNode<Set<?>>> getBoundSets();
 
   /**
    * @return the set of all NamedParameterNodes explicitly bound to lists.
    */
+  Set<NamedParameterNode<List<?>>> getBoundLists(NamedObjectElement noe);
+
   Set<NamedParameterNode<List<?>>> getBoundLists();
 
+  <T> NamedObjectElement<T> getNamedObjectElement(NamedObject<T> no);
+
+  Set<NamedObjectElement> getNamedObjectElements();
 }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ConfigurationBuilder.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ConfigurationBuilder.java
@@ -19,10 +19,7 @@
 package org.apache.reef.tang;
 
 import org.apache.reef.tang.exceptions.BindException;
-import org.apache.reef.tang.types.ClassNode;
-import org.apache.reef.tang.types.ConstructorArg;
-import org.apache.reef.tang.types.NamedParameterNode;
-import org.apache.reef.tang.types.Node;
+import org.apache.reef.tang.types.*;
 
 import java.util.List;
 import java.util.Set;
@@ -129,7 +126,8 @@ public interface ConfigurationBuilder {
 
   /**
    * Bind classes to each other, based on their full class names; alternatively,
-   * bound a NamedParameter configuration option to a configuration value.
+   * bound a NamedParameter configuration option to a configuration value. You can
+   * not bind a NamedObject using this method.
    *
    * @param <T> a type
    * @param iface The full name of the interface that should resolve to impl,
@@ -147,6 +145,17 @@ public interface ConfigurationBuilder {
       throws BindException;
 
   /**
+   * Bind a NamedNodeObject to an interface / NamedParameter.
+   *
+   * @param iface The interface / NamedParameter to be bound
+   * @param impl  The NamedNodeObject implementation to be bound
+   * @throws BindException
+   * @see bind(String, String) for a more complete description.
+   *
+   */
+  <T> void bind(String iface, NamedObjectElement<T> impl) throws BindException;
+
+  /**
    * Bind classes to each other, based on their full class names; alternatively,
    * bound a NamedParameter configuration option to a configuration value.
    * <p>
@@ -160,6 +169,26 @@ public interface ConfigurationBuilder {
    * See {@link #bind(String, String) bind(String,String)} for a more complete description.
    */
   void bind(Node iface, Node impl) throws BindException;
+
+  /**
+   +   * Bind a NamedNodeObject to an interface / NamedParameter.
+   +   * @param iface The interface / NamedParameter to be bound
+   +   * @param impl The NamedNodeObject implementation to be bound
+   +   * @throws BindException
+   +   * @see bind(String, String) for a more complete description.
+   +   */
+  void bind(Node iface, NamedObjectElement impl) throws BindException;
+
+  /**
+   * Extension methods for bind() for supporting NamedObjects.
+   */
+  void bind(String iface, String impl, NamedObjectElement namedObjectElement) throws BindException;
+
+  void bind(Node iface, Node impl, NamedObjectElement namedObjectElement) throws BindException;
+
+  <T> void bind(String iface, NamedObjectElement<T> impl, NamedObjectElement namedObjectElement) throws BindException;
+
+  void bind(Node iface, NamedObjectElement impl, NamedObjectElement namedObjectElement) throws BindException;
 
   /**
    * Register an ExternalConstructor implementation with Tang.
@@ -236,9 +265,33 @@ public interface ConfigurationBuilder {
   <T> void bindSetEntry(NamedParameterNode<Set<T>> iface, String impl)
       throws BindException;
 
+  <T> void bindSetEntry(NamedParameterNode<Set<T>> iface, NamedObjectElement<? extends T> impl)
+      throws BindException;
+
   void bindSetEntry(String iface, String impl) throws BindException;
 
   void bindSetEntry(String iface, Node impl) throws BindException;
+
+  void bindSetEntry(String iface, NamedObjectElement impl) throws BindException;
+
+  /**
+   * Extension methods for bindSetEntry() for supporting NamedObjects.
+   */
+  <T> void bindSetEntry(NamedParameterNode<Set<T>> iface, Node impl, NamedObjectElement namedObjectElement)
+      throws BindException;
+
+  <T> void bindSetEntry(NamedParameterNode<Set<T>> iface, String impl, NamedObjectElement namedObjectElement)
+      throws BindException;
+
+  <T> void bindSetEntry(NamedParameterNode<Set<T>> iface, NamedObjectElement<? extends T> impl,
+                        NamedObjectElement namedObjectElement) throws BindException;
+
+  <T> void bindSetEntry(String iface, String impl, NamedObjectElement namedObjectElement) throws BindException;
+
+  <T> void bindSetEntry(String iface, Node impl, NamedObjectElement namedObjectElement) throws BindException;
+
+  <T> void bindSetEntry(String iface, NamedObjectElement impl, NamedObjectElement namedObjectElement)
+      throws BindException;
 
   /**
    * Bind an list of implementations(Class or String) to an given NamedParameter.
@@ -248,7 +301,8 @@ public interface ConfigurationBuilder {
    * Since ordering of the list is important, list binding cannot be repeated or
    * merged unlike set binding. If the elements of the list are Classes, the objects
    * created by the Classes will be injected. If the elements are Strings, the values
-   * will be injected directly to a given list parameter.
+   * will be injected directly to a given list parameter. If the elements are NamedObjects,
+   * independently configured named objects will be injected to a list.
    *
    * @param <T> a type
    * @param iface    The list named parameter to be instantiated
@@ -259,4 +313,12 @@ public interface ConfigurationBuilder {
 
   void bindList(String iface, List implList) throws BindException;
 
+  /**
+   * Extension methods for bindList() for supporting NamedObjects.
+   */
+
+  <T> void bindList(NamedParameterNode<List<T>> iface, List implList,
+                    NamedObjectElement namedObjectElement) throws BindException;
+
+  <T> void bindList(String iface, List implList, NamedObjectElement namedObjectElement) throws BindException;
 }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Injector.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Injector.java
@@ -23,6 +23,7 @@ import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.tang.exceptions.NameResolutionException;
 import org.apache.reef.tang.implementation.InjectionPlan;
+import org.apache.reef.tang.types.NamedObject;
 
 public interface Injector {
 
@@ -38,6 +39,10 @@ public interface Injector {
    * @throws InjectionException if it fails to find corresponding class
    */
   <U> U getInstance(Class<U> iface) throws InjectionException;
+
+  <U> U getInstance(Class<U> iface, NamedObject namedObject) throws InjectionException;
+
+  <U> U getInstance(String iface, NamedObject namedObject) throws InjectionException, NameResolutionException;
 
   /**
    * Gets an instance of iface, or the implementation that has been bound to it.
@@ -63,8 +68,22 @@ public interface Injector {
    * given interface class.
    * @throws InjectionException if name resolution fails
    */
+  <U> U getNamedInstance(Class<? extends Name<U>> iface, NamedObject namedObject)
+      throws InjectionException;
+
   <U> U getNamedInstance(Class<? extends Name<U>> iface)
       throws InjectionException;
+
+  /**
+   * Gets an instance of the implementation that has been bound to the type of namedObject
+   * in the space of namedObject.
+   *
+   * @param namedObject
+   * @param <U>
+   * @return an Instance of the NamedObject.
+   * @throws InjectionException
+   */
+  <U> U getNamedObjectInstance(NamedObject<U> namedObject) throws InjectionException;
 
   /**
    * Binds the given object to the class. Note that this only affects objects
@@ -77,7 +96,13 @@ public interface Injector {
    * @param inst an instance
    * @throws BindException when trying to re-bind
    */
+  <T> void bindVolatileInstance(Class<T> iface, T inst, NamedObject o)
+      throws BindException;
+
   <T> void bindVolatileInstance(Class<T> iface, T inst)
+      throws BindException;
+
+  <T> void bindVolatileParameter(Class<? extends Name<T>> iface, T inst, NamedObject o)
       throws BindException;
 
   <T> void bindVolatileParameter(Class<? extends Name<T>> iface, T inst)
@@ -133,13 +158,23 @@ public interface Injector {
    */
   boolean isInjectable(String name) throws BindException;
 
+  boolean isInjectable(String name, NamedObject no) throws NameResolutionException;
+
   boolean isParameterSet(String name) throws BindException;
+
+  boolean isParameterSet(String name, NamedObject no) throws NameResolutionException;
 
   boolean isInjectable(Class<?> clazz) throws BindException;
 
+  boolean isInjectable(Class<?> clazz, NamedObject no) throws BindException;
+
   boolean isParameterSet(Class<? extends Name<?>> name) throws BindException;
 
+  boolean isParameterSet(Class<? extends Name<?>> name, NamedObject no) throws BindException;
+
   InjectionPlan<?> getInjectionPlan(String name) throws NameResolutionException;
+
+  InjectionPlan<?> getInjectionPlan(String name, NamedObject no) throws NameResolutionException;
 
   <T> InjectionPlan<T> getInjectionPlan(Class<T> name);
 

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaConfigurationBuilder.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaConfigurationBuilder.java
@@ -21,6 +21,7 @@ package org.apache.reef.tang;
 
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.exceptions.BindException;
+import org.apache.reef.tang.types.NamedObject;
 
 import java.util.List;
 import java.util.Set;
@@ -28,7 +29,7 @@ import java.util.Set;
 /**
  * Convenience methods that extend the ConfigurationBuilder but assume that
  * the underlying ClassHierarchy delegates to the default Java classloader.
- * <p>
+ * <p/>
  * In addition to being less verbose, this interface expresses many of Tang's
  * type checks in Java's generic type system.  This improves IDE
  * auto-completion.  It also allows the errors to be caught at compile time
@@ -52,16 +53,50 @@ public interface JavaConfigurationBuilder extends ConfigurationBuilder {
   <T> JavaConfigurationBuilder bind(Class<T> iface, Class<?> impl) throws BindException;
 
   /**
+   * Bind named parameters or implementations to a named object depending on the types of the classes
+   * passed in.
+   *
+   * @param iface
+   * @param impl
+   *
+   */
+  <T> JavaConfigurationBuilder bind(Class<T> iface, NamedObject<?> impl) throws BindException;
+
+  /**
+   * Extension methods for supporting NamedObject for bind().
+   */
+  <T> JavaConfigurationBuilder bind(Class<T> iface, Class<?> impl, NamedObject namedObject) throws BindException;
+
+  <T> JavaConfigurationBuilder bind(Class<T> iface, NamedObject<?> impl, NamedObject namedObject)
+      throws BindException;
+
+
+  /**
    * Binds the Class impl as the implementation of the interface iface.
    *
    * @param <T> a type
    * @param iface an interface class
-   * @param impl an implementation class
+   * @param impl  an implementation class
    * @return the configuration builder
    */
   <T> JavaConfigurationBuilder bindImplementation(Class<T> iface, Class<? extends T> impl)
       throws BindException;
 
+  /**
+   * Binds the NamedObject impl as the implementation of the interface iface.
+   */
+
+  <T> JavaConfigurationBuilder bindImplementation(Class<T> iface, NamedObject<? extends T> impl)
+      throws BindException;
+
+  /**
+   * Extension methods for supporting NamedObject for bindImplementation().
+   */
+  <T> JavaConfigurationBuilder bindImplementation(Class<T> iface, Class<? extends T> impl,
+                                                  NamedObject namedObject) throws BindException;
+
+  <T> JavaConfigurationBuilder bindImplementation(Class<T> iface, NamedObject<? extends T> impl,
+                                                  NamedObject namedObject) throws BindException;
 
   /**
    * Set the value of a named parameter.
@@ -75,9 +110,39 @@ public interface JavaConfigurationBuilder extends ConfigurationBuilder {
   JavaConfigurationBuilder bindNamedParameter(Class<? extends Name<?>> name, String value)
       throws BindException;
 
+  /**
+   * Binds the Class impl as the implementation of the named parameter iface.
+   */
   <T> JavaConfigurationBuilder bindNamedParameter(Class<? extends Name<T>> iface,
                                                   Class<? extends T> impl) throws BindException;
 
+  /**
+   * Binds the NamedObject impl as the implementation of the named parameter iface.
+   */
+  <T> JavaConfigurationBuilder bindNamedParameter(Class<? extends Name<T>> iface,
+                                                  NamedObject<? extends T> impl) throws BindException;
+
+  /**
+   * Extension methods for supporting NamedObject for bindNamedParameter().
+   */
+  JavaConfigurationBuilder bindNamedParameter(Class<? extends Name<?>> name, String value, NamedObject namedObject);
+
+  <T> JavaConfigurationBuilder bindNamedParameter(Class<? extends Name<T>> iface,
+                                                  Class<? extends T> impl, NamedObject namedObject)
+      throws BindException;
+
+  <T> JavaConfigurationBuilder bindNamedParameter(Class<? extends Name<T>> iface,
+                                                  NamedObject<? extends T> impl, NamedObject namedObject)
+      throws BindException;
+
+  /**
+   * Bind external constructors for concrete classes used for instance instantiation.
+   * @param c a class
+   * @param v an external constructor
+   * @param <T> a type of the target class
+   * @return
+   * @throws BindException
+   */
   <T> JavaConfigurationBuilder bindConstructor(Class<T> c,
                                                Class<? extends ExternalConstructor<? extends T>> v)
       throws BindException;
@@ -86,6 +151,21 @@ public interface JavaConfigurationBuilder extends ConfigurationBuilder {
 
   <T> JavaConfigurationBuilder bindSetEntry(Class<? extends Name<Set<T>>> iface, Class<? extends T> impl)
       throws BindException;
+
+  <T> JavaConfigurationBuilder bindSetEntry(Class<? extends Name<Set<T>>> iface, NamedObject<? extends T> impl)
+      throws BindException;
+
+  /**
+   * Extension methods for supporting NamedObject for bindSetEntry().
+   */
+  <T> JavaConfigurationBuilder bindSetEntry(Class<? extends Name<Set<T>>> iface, String value,
+                                            NamedObject namedObject) throws BindException;
+
+  <T> JavaConfigurationBuilder bindSetEntry(Class<? extends Name<Set<T>>> iface, Class<? extends T> impl,
+                                            NamedObject namedObject) throws BindException;
+
+  <T> JavaConfigurationBuilder bindSetEntry(Class<? extends Name<Set<T>>> iface, NamedObject<? extends T> impl,
+                                            NamedObject namedObject) throws BindException;
 
   /**
    * Binds a specific list to a named parameter. List's elements can be string values or class implementations.
@@ -99,5 +179,11 @@ public interface JavaConfigurationBuilder extends ConfigurationBuilder {
    * @throws BindException It occurs when iface is not a named parameter or impl is not compatible to bind
    */
   <T> JavaConfigurationBuilder bindList(Class<? extends Name<List<T>>> iface, List impl)
+      throws BindException;
+
+  /**
+   * An extension method for supporting NamedObject for bindList().
+   */
+  <T> JavaConfigurationBuilder bindList(Class<? extends Name<List<T>>> iface, List impl, NamedObject namedObject)
       throws BindException;
 }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Tang.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Tang.java
@@ -20,6 +20,7 @@ package org.apache.reef.tang;
 
 import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.implementation.TangImpl;
+import org.apache.reef.tang.types.NamedObject;
 
 import java.net.URL;
 
@@ -136,6 +137,12 @@ public interface Tang {
    * @return a configuration builder
    */
   JavaConfigurationBuilder newConfigurationBuilder();
+
+  /**
+   * Create a new NamedObject which is backed by default NamedObjectImpl
+   * implementation. NamedObject should be provided with its type and name.
+   */
+  <T> NamedObject<T> newNamedObject(Class<T> namedObjectType, String namedObjectName);
 
   /**
    * @return an instance of JavaClassHierarchy that is backed by the default

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
@@ -332,7 +332,7 @@ public class ConfigurationModule {
     for (final NamedParameterNode<?> opt : conf.getNamedParameters()) {
       l.add(opt.getFullName()
           + '='
-          + escape(conf.getNamedParameter(opt)));
+          + escape(conf.getNamedParameter(opt).toString()));
     }
     for (final ClassNode<?> cn : conf.getLegacyConstructors()) {
       final StringBuilder sb = new StringBuilder();

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/NamedObjectInjectionPlan.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/NamedObjectInjectionPlan.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.tang.implementation;
+
+import org.apache.reef.tang.types.NamedObjectElement;
+
+public class NamedObjectInjectionPlan<T> extends InjectionPlan<T> {
+  private final InjectionPlan<? extends T> typePlan;
+  private final NamedObjectElement namedObjectElement;
+
+  public NamedObjectInjectionPlan(final NamedObjectElement namedObjectElement,
+                                  final InjectionPlan<? extends T> typePlan) {
+    super(namedObjectElement.getTypeNode());
+    this.namedObjectElement = namedObjectElement;
+    this.typePlan = typePlan;
+  }
+
+  public NamedObjectElement getNamedObjectElement() {
+    return namedObjectElement;
+  }
+
+  public InjectionPlan<? extends T> getTypePlan() {
+    return typePlan;
+  }
+  @Override
+  public int getNumAlternatives() {
+    return typePlan.getNumAlternatives();
+  }
+
+  @Override
+  public boolean isAmbiguous() {
+    return typePlan.isAmbiguous();
+  }
+
+  @Override
+  public boolean isInjectable() {
+    return typePlan.isInjectable();
+  }
+
+  @Override
+  protected String toAmbiguousInjectString() {
+    String s = "Plan of [" + namedObjectElement.getTypeNode().getFullName() +
+        ", " + namedObjectElement.getName() + "] (NamedObject) is Ambiguous: \n";
+    s += typePlan.toInfeasibleInjectString();
+    return s;
+  }
+
+  @Override
+  protected String toInfeasibleInjectString() {
+    String s = "Plan of [" + namedObjectElement.getTypeNode().getFullName() +
+        ", " + namedObjectElement.getName() + "] (NamedObject) is Infeasible: \n";
+    s += typePlan.toInfeasibleInjectString();
+    return s;
+  }
+
+  @Override
+  protected boolean isInfeasibleLeaf() {
+    return false;
+  }
+
+  @Override
+  public String toShallowString() {
+    return "NamedObjectInjectionPlan<" + getNode().getFullName() + ", " + getNamedObjectElement().getName() + ">";
+  }
+
+}

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/TangImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/TangImpl.java
@@ -23,7 +23,10 @@ import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.implementation.java.ClassHierarchyImpl;
 import org.apache.reef.tang.implementation.java.InjectorImpl;
 import org.apache.reef.tang.implementation.java.JavaConfigurationBuilderImpl;
+import org.apache.reef.tang.implementation.types.NamedObjectImpl;
+import org.apache.reef.tang.types.NamedObject;
 
+import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.*;
 
@@ -126,6 +129,14 @@ public class TangImpl implements Tang {
     } catch (final BindException e) {
       throw new IllegalStateException("Unexpected error from empty configuration", e);
     }
+  }
+
+  @Override
+  public <T> NamedObject newNamedObject(final Class<T> namedObjectType, final String name) {
+    if (namedObjectType.isInterface() || Modifier.isAbstract(namedObjectType.getModifiers())) {
+      throw new IllegalArgumentException("Every NamedObject should have a concrete class type.");
+    }
+    return new NamedObjectImpl<>(namedObjectType, name);
   }
 
   private class SetValuedKey {

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/NamedObjectElementImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/NamedObjectElementImpl.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tang.implementation.types;
+
+import org.apache.reef.tang.types.ClassNode;
+import org.apache.reef.tang.types.NamedObjectElement;
+
+/**
+ * Default implementation class for NamedObject interface.
+ */
+public final class NamedObjectElementImpl<T> implements NamedObjectElement<T> {
+
+  private ClassNode<T> typeNode;
+  private String name;
+  private boolean isNull;
+  private Class<T> implementationClass;
+
+  public NamedObjectElementImpl(final ClassNode<T> typeNode,
+                                final Class implementationClass,
+                                final String name,
+                                final boolean isNull) {
+    if (isNull) {
+      this.typeNode = null;
+      this.implementationClass = null;
+      this.name = "NULL_NAMED_OBJECT";
+    } else {
+      this.typeNode = typeNode;
+      this.implementationClass = implementationClass;
+      this.name = name;
+    }
+    this.isNull = isNull;
+  }
+
+  public boolean isNull() {
+    return isNull;
+  }
+
+  @Override
+  public int compareTo(final NamedObjectElement noe) {
+    if (isNull) {
+      if (noe.isNull()) {
+        return 0;
+      } else {
+        return 1;
+      }
+    } else if (noe.isNull()) {
+      return -1;
+    }
+    return getFullName().compareTo(noe.getFullName());
+  }
+
+  @Override
+  public ClassNode<T> getTypeNode() {
+    return typeNode;
+  }
+
+  @Override
+  public Class<T> getImplementationClass() {
+    return implementationClass;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  // TODO: full name should include full name of the type.
+  @Override
+  public String getFullName() {
+    return name;
+  }
+
+  @Override
+  public int hashCode() {
+    if (isNull) {
+      return ("NULL:" + getName()).hashCode();
+    } else {
+      return ("NOTNULL:" + getName()).hashCode();
+    }
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NamedObjectElementImpl noe = (NamedObjectElementImpl) o;
+    if (isNull) {
+      return noe.isNull;
+    }
+    return this.typeNode.equals(noe.typeNode) && (this.name.equals(noe.name));
+  }
+
+  @Override
+  public String toString() {
+    if (isNull) {
+      return String.format("[%s]", getName());
+    } else {
+      return String.format("[%s '%s]", this.getClass().getSimpleName(), getName());
+    }
+  }
+}

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/NamedObjectImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/NamedObjectImpl.java
@@ -16,27 +16,30 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.tang.types;
+package org.apache.reef.tang.implementation.types;
 
-import java.util.Collection;
+import org.apache.reef.tang.types.NamedObject;
 
-public interface Node extends Comparable<Node>, Traversable<Node>, Boundable {
+/**
+ * Default implementation class for NamedObject interface.
+ */
+public final class NamedObjectImpl<T> implements NamedObject {
 
-  String getName();
+  private Class<T> type;
+  private String name;
 
-  String getFullName();
-
-  boolean contains(String key);
-
-  Node get(String key);
-
-  Node getParent();
-
-  void put(Node node);
-
-  @Override
-  Collection<Node> getChildren();
+  public NamedObjectImpl(final Class<T> type, final String name) {
+    this.type = type;
+    this.name = name;
+  }
 
   @Override
-  String toString();
+  public Class<T> getType() {
+    return type;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
 }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/Boundable.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/Boundable.java
@@ -18,25 +18,11 @@
  */
 package org.apache.reef.tang.types;
 
-import java.util.Collection;
-
-public interface Node extends Comparable<Node>, Traversable<Node>, Boundable {
-
+/**
+ * Basic interface for all elements which can be used for Configuration,
+ * such as NamedObjectElement and Node. All elements should have its name.
+ */
+public interface Boundable {
   String getName();
-
   String getFullName();
-
-  boolean contains(String key);
-
-  Node get(String key);
-
-  Node getParent();
-
-  void put(Node node);
-
-  @Override
-  Collection<Node> getChildren();
-
-  @Override
-  String toString();
 }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/NamedObject.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/NamedObject.java
@@ -18,25 +18,11 @@
  */
 package org.apache.reef.tang.types;
 
-import java.util.Collection;
-
-public interface Node extends Comparable<Node>, Traversable<Node>, Boundable {
-
+/**
+ * NamedObject is used for providing a unique configuration
+ * for a specific object statically, within a Tang Configuration.
+ */
+public interface NamedObject<T> {
   String getName();
-
-  String getFullName();
-
-  boolean contains(String key);
-
-  Node get(String key);
-
-  Node getParent();
-
-  void put(Node node);
-
-  @Override
-  Collection<Node> getChildren();
-
-  @Override
-  String toString();
+  Class<T> getType();
 }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/NamedObjectElement.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/NamedObjectElement.java
@@ -18,25 +18,12 @@
  */
 package org.apache.reef.tang.types;
 
-import java.util.Collection;
-
-public interface Node extends Comparable<Node>, Traversable<Node>, Boundable {
-
-  String getName();
-
-  String getFullName();
-
-  boolean contains(String key);
-
-  Node get(String key);
-
-  Node getParent();
-
-  void put(Node node);
-
-  @Override
-  Collection<Node> getChildren();
-
-  @Override
-  String toString();
+/**
+ * NamedObject is used for providing a unique configuration
+ * for a specific object statically, within a Tang Configuration.
+ */
+public interface NamedObjectElement<T> extends Comparable<NamedObjectElement>, Boundable {
+  ClassNode<T> getTypeNode();
+  Class<T> getImplementationClass();
+  boolean isNull();
 }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/TracingMonotonicTreeMap.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/TracingMonotonicTreeMap.java
@@ -22,6 +22,7 @@ import org.apache.reef.tang.BindLocation;
 import org.apache.reef.tang.implementation.StackBindLocation;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -44,8 +45,14 @@ public final class TracingMonotonicTreeMap<K, V> implements TracingMonotonicMap<
   }
 
   @Override
-  public Set<Entry<K, V>> entrySet() {
-    throw new UnsupportedOperationException();
+  public Set<Map.Entry<K, V>> entrySet() {
+    // This implementation is not efficient, but we need to use entrySet() to pass findbugs' static code analysis
+    final Set<Map.Entry<K, EntryImpl>> innerMapEntrySet = innerMap.entrySet();
+    final Set<Map.Entry<K, V>> entrySet = new HashSet<>();
+    for(final Map.Entry<K, EntryImpl> entry: innerMapEntrySet) {
+      entrySet.add(new Entry(entry.getKey(), entry.getValue().getKey()));
+    }
+    return entrySet;
   }
 
   @Override
@@ -142,6 +149,34 @@ public final class TracingMonotonicTreeMap<K, V> implements TracingMonotonicMap<
     public String toString() {
       return "[" + key + "] set by " + value;
     }
-
   }
+
+  /**
+   * An implementation class for representing TracingMonotoricTreeMap's entry.
+   */
+  private class Entry implements Map.Entry<K, V> {
+    private final K key;
+    private final V value;
+
+    Entry(final K key, final V value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    @Override
+    public K getKey() {
+      return key;
+    }
+
+    @Override
+    public V getValue() {
+      return value;
+    }
+
+    @Override
+    public V setValue(final V newValue) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
 }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizConfigVisitor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizConfigVisitor.java
@@ -19,10 +19,7 @@
 package org.apache.reef.tang.util.walk.graphviz;
 
 import org.apache.reef.tang.Configuration;
-import org.apache.reef.tang.types.ClassNode;
-import org.apache.reef.tang.types.NamedParameterNode;
-import org.apache.reef.tang.types.Node;
-import org.apache.reef.tang.types.PackageNode;
+import org.apache.reef.tang.types.*;
 import org.apache.reef.tang.util.walk.AbstractClassHierarchyNodeVisitor;
 import org.apache.reef.tang.util.walk.EdgeVisitor;
 import org.apache.reef.tang.util.walk.Walk;
@@ -136,7 +133,7 @@ public final class GraphvizConfigVisitor
 //            .append(config.isSingleton(node) ? ", style=filled" : "")
         .append("];\n");
 
-    final ClassNode<?> boundImplNode = config.getBoundImplementation(node);
+    final Boundable boundImplNode = (Boundable) config.getBoundImplementation(node);
     if (boundImplNode != null) {
       this.graphStr
           .append("  ")

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestNamedObject.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestNamedObject.java
@@ -1,0 +1,520 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tang;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.tang.exceptions.BindException;
+import org.apache.reef.tang.exceptions.ClassHierarchyException;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.types.NamedObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import java.util.*;
+
+/**
+ * A class contains tests for Tang NamedObject features.
+ */
+public class TestNamedObject {
+
+  private final Tang tang = Tang.Factory.getTang();
+  private final NamedObject dummyNo0 = tang.newNamedObject(EmptyClass.class, "dummyNo0");
+  private final NamedObject dummyNo1 = tang.newNamedObject(EmptyClass.class, "dummyNo1");
+
+  /**
+   * Test code for binding different values to the same NamedParameters in separate NamedObjects.
+   *
+   * @throws InjectionException
+   */
+  @Test
+  public void testNamedParameterInt() throws InjectionException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    cb.bindNamedParameter(IntegerNP.class, "0", dummyNo0)
+        .bindNamedParameter(IntegerNP.class, "1", dummyNo1);
+    final Injector injector = Tang.Factory.getTang().newInjector(cb.build());
+    final Integer int0 = injector.getNamedInstance(IntegerNP.class, dummyNo0);
+    final Integer int1 = injector.getNamedInstance(IntegerNP.class, dummyNo1);
+
+    Assert.assertEquals(int0, new Integer(0));
+    Assert.assertEquals(int1, new Integer(1));
+  }
+
+  /**
+   * Test code for binding different implementations to the same NamedParameters in separate NamedObjects.
+   *
+   * @throws InjectionException
+   */
+  @Test
+  public void testNamedParameterImpl() throws InjectionException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    cb.bindNamedParameter(SimpleNP.class, SimpleImpl.class, dummyNo0)
+        .bindNamedParameter(SimpleNP.class, SimpleImplMinus.class, dummyNo1);
+    final Injector injector = Tang.Factory.getTang().newInjector(cb.build());
+    final SimpleIface s0 = injector.getNamedInstance(SimpleNP.class, dummyNo0);
+    final SimpleIface s1 = injector.getNamedInstance(SimpleNP.class, dummyNo1);
+
+    Assert.assertEquals(s0.getValue(), 1);
+    Assert.assertEquals(s1.getValue(), -1);
+  }
+
+  /**
+   * Test code for binding a implementation to a NamedObject.
+   *
+   * @throws InjectionException
+   */
+  @Test
+  public void testNamedObjectBasic() throws InjectionException {
+    final NamedObject<SimpleImpl> no0 = tang.newNamedObject(SimpleImpl.class, "no0");
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    cb.bindNamedParameter(IntegerNP.class, "2", no0);
+    final SimpleImpl s0 = Tang.Factory.getTang().newInjector(cb.build()).getNamedObjectInstance(no0);
+
+    Assert.assertEquals(s0.getValue(), 2);
+  }
+
+  /**
+   * Test code for binding a NamedObject to a interface.
+   *
+   * @throws InjectionException
+   */
+  @Test
+  public void testBindNamedObject() throws InjectionException {
+    final NamedObject no0 = tang.newNamedObject(SimpleImpl.class, "no0");
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder()
+        .bindImplementation(SimpleIface.class, no0, null)
+        .bindNamedParameter(IntegerNP.class, "2", no0);
+    final SimpleIface s0 = Tang.Factory.getTang().newInjector(cb.build()).getInstance(SimpleIface.class);
+
+    Assert.assertEquals(s0.getValue(), 2);
+  }
+
+  /**
+   * Test code for separating a space of the NamedObject in a NamedObject.
+   *
+   * @throws InjectionException
+   */
+  @Test
+  public void testNamedObjectInNamedObject() throws InjectionException {
+    final NamedObject outerNo = tang.newNamedObject(WrapperImpl.class, "out");
+    final NamedObject innerNo = tang.newNamedObject(SimpleImpl.class, "in");
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder()
+        .bindNamedParameter(IntegerNP.class, "2", outerNo)
+        .bindNamedParameter(IntegerNP.class, "3", innerNo)
+        .bindNamedParameter(SimpleNP.class, innerNo, outerNo);
+    final WrapperImpl w = Tang.Factory.getTang().newInjector(cb.build())
+        .getNamedObjectInstance((NamedObject<WrapperImpl>)outerNo);
+
+    Assert.assertEquals(w.getValue(), 2);
+    Assert.assertEquals(w.getInnerValue(), 3);
+  }
+
+  @Test
+  public void testVolatileInstance() throws InjectionException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    final Injector injector = Tang.Factory.getTang().newInjector(cb.build());
+    final SimpleImpl si0 = new SimpleImpl(2);
+    injector.bindVolatileInstance(SimpleImpl.class, si0, dummyNo0);
+    final SimpleImpl si1 = injector.getInstance(SimpleImpl.class, dummyNo0);
+
+    Assert.assertEquals(si1.getValue(), 2);
+  }
+
+  @Test
+  public void testVolatileParameter() throws InjectionException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    final Injector injector = Tang.Factory.getTang().newInjector(cb.build());
+    final SimpleImpl si0 = new SimpleImpl(2);
+    injector.bindVolatileParameter(SimpleImplNP.class, si0, dummyNo0);
+    final SimpleImpl si1 = injector.getNamedInstance(SimpleImplNP.class, dummyNo0);
+    Assert.assertEquals(si1.getValue(), 2);
+  }
+
+  @Test
+  public void testNamedObjectSetBinding() throws InjectionException {
+    final NamedObject<SimpleImpl> setNo1 = tang.newNamedObject(SimpleImpl.class, "SetNo1");
+    final NamedObject<SimpleImpl> setNo2 = tang.newNamedObject(SimpleImpl.class, "SetNo2");
+    final NamedObject<SimpleImpl> setNo3 = tang.newNamedObject(SimpleImpl.class, "SetNo3");
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    cb.bindNamedParameter(IntegerNP.class, "1", setNo1);
+    cb.bindNamedParameter(IntegerNP.class, "2", setNo2);
+    cb.bindNamedParameter(IntegerNP.class, "3", setNo3);
+    cb.bindSetEntry(SimpleSetNP.class, setNo1);
+    cb.bindSetEntry(SimpleSetNP.class, setNo2);
+    cb.bindSetEntry(SimpleSetNP.class, setNo3);
+    final Injector injector = tang.newInjector(cb.build());
+    final SimpleSetImpl simpleSetImpl = injector.getInstance(SimpleSetImpl.class);
+    final Set<SimpleImpl> expectedSet = new HashSet<>(Arrays.asList(new SimpleImpl(2), new SimpleImpl(1), new
+        SimpleImpl(3)));
+    Assert.assertEquals(simpleSetImpl.getSimpleSet(), expectedSet);
+  }
+
+  @Test
+  public void testNamedObjectListBinding() throws InjectionException {
+    final NamedObject<SimpleImpl> listNo1 = tang.newNamedObject(SimpleImpl.class, "ListNo1");
+    final NamedObject<SimpleImpl> listNo2 = tang.newNamedObject(SimpleImpl.class, "ListNo2");
+    final NamedObject<SimpleImpl> listNo3 = tang.newNamedObject(SimpleImpl.class, "ListNo3");
+    final List<NamedObject<SimpleImpl>> boundList = Arrays.asList(listNo1, listNo2, listNo3);
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    cb.bindList(SimpleListNP.class, boundList);
+    cb.bindNamedParameter(IntegerNP.class, "2", listNo1);
+    cb.bindNamedParameter(IntegerNP.class, "1", listNo2);
+    cb.bindNamedParameter(IntegerNP.class, "3", listNo3);
+    final Injector injector = tang.newInjector(cb.build());
+    final SimpleListImpl simpleListImpl = injector.getInstance(SimpleListImpl.class);
+    final List<SimpleImpl> expectedList = Arrays.asList(new SimpleImpl(2), new SimpleImpl(1), new SimpleImpl(3));
+    Assert.assertEquals(expectedList, simpleListImpl.getSimpleList());
+  }
+
+  @Test
+  public void testNamedObjectDAGBinding() throws InjectionException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    final NamedObject<NodeImpl> nodeA = tang.newNamedObject(NodeImpl.class, "A");
+    final NamedObject<NodeImpl> nodeB = tang.newNamedObject(NodeImpl.class, "B");
+    final NamedObject<NodeImpl> nodeC = tang.newNamedObject(NodeImpl.class, "C");
+    final NamedObject<NodeImpl> nodeD = tang.newNamedObject(NodeImpl.class, "D");
+
+    final String nodeNameA = "A";
+    final String nodeNameB = "B";
+    final String nodeNameC = "C";
+    final String nodeNameD = "D";
+
+    cb.bindNamedParameter(NodeName.class, nodeNameA, nodeA);
+    cb.bindSetEntry(NextNodes.class, nodeB, nodeA);
+    cb.bindSetEntry(NextNodes.class, nodeC, nodeA);
+
+    cb.bindNamedParameter(NodeName.class, nodeNameB, nodeB);
+    cb.bindSetEntry(NextNodes.class, nodeD, nodeB);
+
+    cb.bindNamedParameter(NodeName.class, nodeNameC, nodeC);
+    cb.bindSetEntry(NextNodes.class, nodeD, nodeC);
+
+    cb.bindNamedParameter(NodeName.class, nodeNameD, nodeD);
+
+    final Injector injector = Tang.Factory.getTang().newInjector(cb.build());
+    final Node a = injector.getNamedObjectInstance(nodeA);
+    Assert.assertEquals(a.getNodeName(), nodeNameA);
+    Assert.assertEquals(a.getNextNodeNames(), new HashSet<>(Arrays.asList(nodeNameB, nodeNameC)));
+    final Node b = injector.getNamedObjectInstance(nodeB);
+    Assert.assertEquals(b.getNodeName(), nodeNameB);
+    Assert.assertEquals(b.getNextNodeNames(), new HashSet<>(Arrays.asList(nodeNameD)));
+    final Node c = injector.getNamedObjectInstance(nodeC);
+    Assert.assertEquals(c.getNodeName(), nodeNameC);
+    Assert.assertEquals(c.getNextNodeNames(), new HashSet<>(Arrays.asList(nodeNameD)));
+    final Node d = injector.getNamedObjectInstance(nodeD);
+    Assert.assertEquals(d.getNodeName(), nodeNameD);
+    Assert.assertEquals(d.getNextNodeNames(), new HashSet<>());
+  }
+
+  @Test
+  public void testNamedObjectCyclicInjectionInjectionFuture() throws InjectionException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    final NamedObject<WrapperImpl> wrapperANo = tang.newNamedObject(WrapperImpl.class, "WrapperA");
+    final NamedObject<WrapperFuturistImpl> wrapperBNo = tang.newNamedObject(WrapperFuturistImpl.class,
+        "WrapperB");
+    final int wrapperAInteger = 1;
+    final int wrapperBInteger = 2;
+
+    cb.bindNamedParameter(IntegerNP.class, String.valueOf(wrapperAInteger), wrapperANo);
+    cb.bindNamedParameter(SimpleNP.class, wrapperBNo, wrapperANo);
+    cb.bindNamedParameter(IntegerNP.class, String.valueOf(wrapperBInteger), wrapperBNo);
+    cb.bindImplementation(SimpleIface.class, wrapperANo, wrapperBNo);
+    final Injector injector = tang.newInjector(cb.build());
+    final WrapperImpl wrapperA = injector.getNamedObjectInstance(wrapperANo);
+    final WrapperFuturistImpl wrapperB = injector.getNamedObjectInstance(wrapperBNo);
+    Assert.assertEquals(wrapperA.getInnerValue(), wrapperBInteger);
+    Assert.assertEquals(wrapperB.getInnerValue(), wrapperAInteger);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDuplicatedConfigurationInNamedObject() throws BindException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    final NamedObject<SimpleImpl> simpleNamedObject = tang.newNamedObject(SimpleImpl.class, "Simple");
+    cb.bindNamedParameter(IntegerNP.class, "1", simpleNamedObject);
+    cb.bindNamedParameter(IntegerNP.class, "2", simpleNamedObject);
+    cb.build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDuplicatedNamedObjectName() throws BindException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    final NamedObject<SimpleImpl> simpleNamedObject = tang.newNamedObject(SimpleImpl.class, "A");
+    final NamedObject<NodeImpl> nodeNamedObject = tang.newNamedObject(NodeImpl.class, "A");
+    cb.bindNamedParameter(IntegerNP.class, "1", simpleNamedObject);
+    cb.bindNamedParameter(NodeName.class, "A", nodeNamedObject);
+    cb.build();
+  }
+
+  @Test(expected = BindException.class)
+  public void testNamedObjectTypeMismatchInImplementation() throws BindException {
+    final NamedObject simpleImplNO = tang.newNamedObject(NodeImpl.class, "SimpleImpl");
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    cb.bindImplementation(SimpleIface.class, simpleImplNO);
+  }
+
+  @Test(expected = BindException.class)
+  public void testNamedObjectTypeMismatchInNamedParameter() throws BindException {
+    final NamedObject simpleImplNO = tang.newNamedObject(NodeImpl.class, "SimpleImpl");
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    cb.bindNamedParameter(SimpleNP.class, simpleImplNO);
+  }
+
+  @Test(expected = BindException.class)
+  public void testNamedObjectTypeMismatchInSet() throws BindException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    final NamedObject simpleNamedObject = tang.newNamedObject(NodeImpl.class, "SimpleImpl");
+    cb.bindSetEntry(SimpleSetNP.class, simpleNamedObject);
+    cb.build();
+  }
+
+  @Test(expected = BindException.class)
+  public void testNamedObjectTypeMismatchInList() throws BindException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    final NamedObject simpleNamedObject = tang.newNamedObject(NodeImpl.class, "SimpleImpl");
+    final List<NamedObject> boundList = Arrays.asList(simpleNamedObject);
+    cb.bindList(SimpleListNP.class, boundList);
+    cb.build();
+  }
+
+  @Test(expected = ClassHierarchyException.class)
+  public void testNamedObjectCycleInjection() throws InjectionException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    final NamedObject<WrapperImpl> wrapperANo = tang.newNamedObject(WrapperImpl.class, "WrapperA");
+    final NamedObject<WrapperImpl> wrapperBNo = tang.newNamedObject(WrapperImpl.class, "WrapperB");
+
+    cb.bindNamedParameter(SimpleNP.class, wrapperBNo, wrapperANo);
+    cb.bindNamedParameter(SimpleNP.class, wrapperANo, wrapperBNo);
+    tang.newInjector(cb.build()).getNamedObjectInstance(wrapperANo);
+  }
+
+  @Test(expected = InjectionException.class)
+  public void testNamedObjectMissingConfiguration() throws InjectionException {
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
+    final NamedObject<WrapperImpl> wrapperNo = tang.newNamedObject(WrapperImpl.class, "Wrapper");
+    cb.bindNamedParameter(IntegerNP.class, "1", wrapperNo);
+    tang.newInjector(cb.build()).getNamedObjectInstance(wrapperNo);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInterfaceTypedNamedObject() throws IllegalArgumentException {
+    final NamedObject<SimpleIface> invalidNo = tang.newNamedObject(SimpleIface.class, "SimpleIface");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAbstractTypedNamedObject() throws IllegalArgumentException {
+    final NamedObject<NodeAbstractImpl> invalidNo = tang.newNamedObject(NodeAbstractImpl.class, "NAI");
+  }
+}
+
+class EmptyClass {
+}
+
+interface SimpleIface {
+  int getValue();
+}
+
+class SimpleImpl implements SimpleIface {
+  private final int value;
+
+  @Inject
+  SimpleImpl() {
+    value = 1;
+  }
+
+  @Inject
+  SimpleImpl(@Parameter(IntegerNP.class) final Integer i) {
+    value = i;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o.getClass() != this.getClass()) {
+      return false;
+    } else {
+      SimpleImpl simpleImpl = (SimpleImpl) o;
+      return this.getValue() == simpleImpl.getValue();
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return new Integer(this.getValue()).hashCode();
+  }
+}
+
+class SimpleImplMinus implements SimpleIface {
+  private final int value;
+
+  @Inject
+  SimpleImplMinus() {
+    value = -1;
+  }
+
+  @Inject
+  SimpleImplMinus(@Parameter(IntegerNP.class) final Integer i) {
+    value = -i;
+  }
+
+  @Override
+  public int getValue() {
+    return value;
+  }
+}
+
+class WrapperImpl implements SimpleIface {
+  private final int value;
+  private final SimpleIface inner;
+
+  @Inject
+  WrapperImpl(@Parameter(IntegerNP.class) final Integer i, @Parameter(SimpleNP.class) final SimpleIface inner) {
+    value = i;
+    this.inner = inner;
+  }
+
+  @Override
+  public int getValue() {
+    return value;
+  }
+
+  public int getInnerValue() {
+    return inner.getValue();
+  }
+}
+
+class WrapperFuturistImpl implements SimpleIface {
+  private final int value;
+  private final InjectionFuture<SimpleIface> innerInjectionFuture;
+
+  @Inject
+  WrapperFuturistImpl(@Parameter(IntegerNP.class) final Integer i, final InjectionFuture<SimpleIface> inner) {
+    this.value = i;
+    this.innerInjectionFuture = inner;
+  }
+
+  @Override
+  public int getValue() {
+    return value;
+  }
+
+  public int getInnerValue() {
+    return innerInjectionFuture.get().getValue();
+  }
+}
+
+class SimpleListImpl {
+
+  private final List<SimpleImpl> simpleList;
+
+  @Inject
+  SimpleListImpl(@Parameter(SimpleListNP.class) final List<SimpleImpl> simpleList) {
+    this.simpleList = simpleList;
+  }
+
+  public List<SimpleImpl> getSimpleList() {
+    return simpleList;
+  }
+}
+
+class SimpleSetImpl {
+  private final Set<SimpleImpl> simpleSet;
+
+  @Inject
+  SimpleSetImpl(@Parameter(SimpleSetNP.class) final Set<SimpleImpl> simpleSet) {
+    this.simpleSet = simpleSet;
+  }
+
+  public Set<SimpleImpl> getSimpleSet() {
+    return simpleSet;
+  }
+}
+
+@NamedParameter()
+class IntegerNP implements Name<Integer> {
+}
+
+@NamedParameter()
+class SimpleNP implements Name<SimpleIface> {
+}
+
+@NamedParameter()
+class SimpleImplNP implements Name<SimpleImpl> {
+}
+
+@NamedParameter()
+class SimpleSetNP implements Name<Set<SimpleIface>> {
+}
+
+@NamedParameter()
+class SimpleListNP implements Name<List<SimpleIface>> {
+}
+
+@NamedParameter()
+class NodeName implements Name<String> {
+}
+
+@NamedParameter
+class NextNodes implements Name<Set<Node>> {
+}
+
+interface Node {
+
+  Set<String> getNextNodeNames();
+
+  String getNodeName();
+}
+
+abstract class NodeAbstractImpl implements Node {
+  @Override
+  public abstract Set<String> getNextNodeNames();
+
+  @Override
+  public abstract String getNodeName();
+}
+
+class NodeImpl implements Node {
+
+  private final Set<String> nextNodeNames;
+  private final String nodeName;
+
+  @Inject
+  NodeImpl(@Parameter(NextNodes.class) final Set<Node> nextNodes,
+           @Parameter(NodeName.class) final String nodeName) {
+    this.nextNodeNames = new HashSet<>();
+    for(final Node nextNode: nextNodes) {
+      this.nextNodeNames.add(nextNode.getNodeName());
+    }
+    this.nodeName = nodeName;
+  }
+
+  @Override
+  public Set<String> getNextNodeNames() {
+    return nextNodeNames;
+  }
+
+  @Override
+  public String getNodeName() {
+    return nodeName;
+  }
+}


### PR DESCRIPTION
  This expands the current Tang to be able to bind multiple non-singleton
  instances using NamedObject. The main concept of NamedObject is allowing
  users to configure non-singleton instances which are not affected by
  other bindings in a Configuration. Details about Newly added APIs are
  explained in the JIRA link below. This work is done with
  Hyeonmin Ha(hhm8247@gmail.com).

JIRA:
  [REEF-31](https://issues.apache.org/jira/browse/REEF-31)