### PR TITLE
[REEF-1510] Fix .NET Core System.Type.get_Assembly incompatibility in Tang.Tests

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestAnonymousType.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestAnonymousType.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using Org.Apache.REEF.Tang.Examples;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -34,7 +35,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         public void TestAnonymousTypeWithDictionary()
         {
             List<string> appDlls = new List<string>();
-            appDlls.Add(typeof(AnonymousType).Assembly.GetName().Name);
+            appDlls.Add(typeof(AnonymousType).GetTypeInfo().Assembly.GetName().Name);
             var c = TangFactory.GetTang().GetClassHierarchy(appDlls.ToArray());
             c.GetNode(typeof(AnonymousType).AssemblyQualifiedName);
 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestAvroSerialization.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestAvroSerialization.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using Microsoft.Hadoop.Avro;
 using Org.Apache.REEF.Examples.Tasks.HelloTask;
 using Org.Apache.REEF.Tang.Examples;
@@ -46,7 +47,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Type simpleConstructorType = typeof(SimpleConstructors);
 
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(
-                new string[] { typeof(Timer).Assembly.GetName().Name, typeof(SimpleConstructors).Assembly.GetName().Name });
+                new string[] { typeof(Timer).GetTypeInfo().Assembly.GetName().Name, typeof(SimpleConstructors).GetTypeInfo().Assembly.GetName().Name });
             IClassNode timerClassNode = (IClassNode)ns.GetNode(timerType.AssemblyQualifiedName);
             INode secondNode = ns.GetNode(secondType.AssemblyQualifiedName);
             IClassNode simpleConstructorsClassNode = (IClassNode)ns.GetNode(simpleConstructorType.AssemblyQualifiedName);
@@ -84,14 +85,14 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         public void TestAvroClassHierarchyMerge()
         {
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(
-                new string[] { typeof(Timer).Assembly.GetName().Name });
+                new string[] { typeof(Timer).GetTypeInfo().Assembly.GetName().Name });
             IClassNode timerClassNode = (IClassNode)ns.GetNode(typeof(Timer).AssemblyQualifiedName);
 
             AvroNode n = _serializer.ToAvroNode(ns);
             IClassHierarchy ns2 = _serializer.FromAvroNode(n);
 
             IClassHierarchy ns3 = TangFactory.GetTang().GetClassHierarchy(
-                    new string[] { typeof(AvroNode).Assembly.GetName().Name });
+                    new string[] { typeof(AvroNode).GetTypeInfo().Assembly.GetName().Name });
             IClassNode avroNodeClassNode = (IClassNode)ns3.GetNode(typeof(AvroNode).AssemblyQualifiedName);
 
             AvroNode n2 = _serializer.ToAvroNode(ns3);
@@ -112,7 +113,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         [Fact]
         public void TestToTextFileForTask()
         {
-            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(HelloTask).Assembly.GetName().Name });
+            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(HelloTask).GetTypeInfo().Assembly.GetName().Name });
             _serializer.ToTextFile(ns, "avroTask.bin");
             Assert.True(File.Exists("avroTask.bin"));
         }
@@ -123,7 +124,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         [Fact]
         public void TestToString()
         {
-            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(HelloTask).Assembly.GetName().Name });
+            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(HelloTask).GetTypeInfo().Assembly.GetName().Name });
             string s = _serializer.ToString(ns);
             Assert.NotNull(s);
         }
@@ -142,7 +143,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Type simpleConstructorType = typeof(SimpleConstructors);
 
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(
-                new string[] { typeof(Timer).Assembly.GetName().Name, typeof(SimpleConstructors).Assembly.GetName().Name });
+                new string[] { typeof(Timer).GetTypeInfo().Assembly.GetName().Name, typeof(SimpleConstructors).GetTypeInfo().Assembly.GetName().Name });
             IClassNode timerClassNode = (IClassNode)ns.GetNode(timerType.AssemblyQualifiedName);
             INode secondNode = ns.GetNode(secondType.AssemblyQualifiedName);
             IClassNode simpleConstructorsClassNode = (IClassNode)ns.GetNode(simpleConstructorType.AssemblyQualifiedName);
@@ -173,7 +174,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Type simpleConstructorType = typeof(SimpleConstructors);
 
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(
-                new string[] { typeof(Timer).Assembly.GetName().Name, typeof(SimpleConstructors).Assembly.GetName().Name });
+                new string[] { typeof(Timer).GetTypeInfo().Assembly.GetName().Name, typeof(SimpleConstructors).GetTypeInfo().Assembly.GetName().Name });
             IClassNode timerClassNode = (IClassNode)ns.GetNode(timerType.AssemblyQualifiedName);
             INode secondNode = ns.GetNode(secondType.AssemblyQualifiedName);
             IClassNode simpleConstructorsClassNode = (IClassNode)ns.GetNode(simpleConstructorType.AssemblyQualifiedName);
@@ -202,7 +203,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Type simpleConstructorType = typeof(SimpleConstructors);
 
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(
-                new string[] { typeof(Timer).Assembly.GetName().Name, typeof(SimpleConstructors).Assembly.GetName().Name });
+                new string[] { typeof(Timer).GetTypeInfo().Assembly.GetName().Name, typeof(SimpleConstructors).GetTypeInfo().Assembly.GetName().Name });
             IClassNode timerClassNode = (IClassNode)ns.GetNode(timerType.AssemblyQualifiedName);
             INode secondNode = ns.GetNode(secondType.AssemblyQualifiedName);
             IClassNode simpleConstructorsClassNode = (IClassNode)ns.GetNode(simpleConstructorType.AssemblyQualifiedName);
@@ -231,7 +232,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Type simpleConstructorType = typeof(SimpleConstructors);
 
             IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(
-                new string[] { typeof(Timer).Assembly.GetName().Name, typeof(SimpleConstructors).Assembly.GetName().Name });
+                new string[] { typeof(Timer).GetTypeInfo().Assembly.GetName().Name, typeof(SimpleConstructors).GetTypeInfo().Assembly.GetName().Name });
             IClassNode timerClassNode = (IClassNode)ns.GetNode(timerType.AssemblyQualifiedName);
             INode secondNode = ns.GetNode(secondType.AssemblyQualifiedName);
             IClassNode simpleConstructorsClassNode = (IClassNode)ns.GetNode(simpleConstructorType.AssemblyQualifiedName);

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestGeneric.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestGeneric.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System.Collections.Generic;
+using System.Reflection;
 using Org.Apache.REEF.Tang.Examples;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Wake.RX;
@@ -29,8 +30,8 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         public void TestGenericClassWithT()
         {
             List<string> appDlls = new List<string>();
-            appDlls.Add(typeof(GenericArgument<>).Assembly.GetName().Name);
-            appDlls.Add(typeof(AbstractObserver<>).Assembly.GetName().Name);
+            appDlls.Add(typeof(GenericArgument<>).GetTypeInfo().Assembly.GetName().Name);
+            appDlls.Add(typeof(AbstractObserver<>).GetTypeInfo().Assembly.GetName().Name);
             TangFactory.GetTang().GetClassHierarchy(appDlls.ToArray());
         }
     }  

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestSerilization.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestSerilization.cs
@@ -44,7 +44,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         [Fact]
         public void TestSerializeClassHierarchy()
         {            
-            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Timer).Assembly.GetName().Name });
+            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Timer).GetTypeInfo().Assembly.GetName().Name });
             ProtocolBufferClassHierarchy.Serialize("node.bin", ns);
         }
 
@@ -55,7 +55,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Type secondType = typeof(Timer.Seconds);
             Type simpleCOnstuctorType = typeof(SimpleConstructors);
 
-            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Timer).Assembly.GetName().Name });
+            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Timer).GetTypeInfo().Assembly.GetName().Name });
             IClassNode timerClassNode = (IClassNode)ns.GetNode(timerType.AssemblyQualifiedName);
             INode secondNode = (INode)ns.GetNode(secondType.AssemblyQualifiedName);
             IClassNode simpleConstructorsClassNode = (IClassNode)ns.GetNode(simpleCOnstuctorType.AssemblyQualifiedName);
@@ -82,7 +82,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Type streamTask1Type = typeof(StreamTask1);
             Type helloTaskType = typeof(HelloTask);
 
-            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(HelloTask).Assembly.GetName().Name });
+            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(HelloTask).GetTypeInfo().Assembly.GetName().Name });
             IClassNode streamTask1ClassNode = (IClassNode)ns.GetNode(streamTask1Type.AssemblyQualifiedName);
             IClassNode helloTaskClassNode = (IClassNode)ns.GetNode(helloTaskType.AssemblyQualifiedName);
 
@@ -108,7 +108,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         [Fact]
         public void TestSerializeClassHierarchyForAvro()
         {
-            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Microsoft.Hadoop.Avro.AvroSerializer).Assembly.GetName().Name });
+            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Microsoft.Hadoop.Avro.AvroSerializer).GetTypeInfo().Assembly.GetName().Name });
             Assert.NotNull(ns);
             ProtocolBufferClassHierarchy.Serialize("avro.bin", ns);
             IClassHierarchy ch = ProtocolBufferClassHierarchy.DeSerialize("avro.bin");
@@ -121,7 +121,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             Type streamTask1Type = typeof(StreamTask1);
             Type helloTaskType = typeof(HelloTask);
 
-            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(HelloTask).Assembly.GetName().Name });
+            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(HelloTask).GetTypeInfo().Assembly.GetName().Name });
             IClassNode streamTask1ClassNode = (IClassNode)ns.GetNode(streamTask1Type.AssemblyQualifiedName);
             IClassNode helloTaskClassNode = (IClassNode)ns.GetNode(helloTaskType.AssemblyQualifiedName);
 
@@ -182,7 +182,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         [Fact]
         public void TestGenericClass()
         {
-            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Timer).Assembly.GetName().Name });
+            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(Timer).GetTypeInfo().Assembly.GetName().Name });
 
             Type t = typeof(Timer);
             IClassNode eventClassNode = (IClassNode)ns.GetNode(t.AssemblyQualifiedName);
@@ -195,7 +195,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         [Fact]
         public void TestGenericArgument()
         {
-            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(ClassWithGenericArgument<>).Assembly.GetName().Name });
+            IClassHierarchy ns = TangFactory.GetTang().GetClassHierarchy(new string[] { typeof(ClassWithGenericArgument<>).GetTypeInfo().Assembly.GetName().Name });
 
             Type t = typeof(ClassWithGenericArgument<>);
             IClassNode classNode = (IClassNode)ns.GetNode(t.AssemblyQualifiedName);


### PR DESCRIPTION
This addressed the issue by
  * inserting System.Reflection.GetTypeInfo() to get the full TypeInfo

JIRA:
  [REEF-1510](https://issues.apache.org/jira/browse/REEF-1510)