### PR TITLE
[REEF-1500] Fix CoreCLR incompatibilities in Tang related to System.I…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
@@ -50,7 +50,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             {
                 n = ns.GetNode("System");
             }
-            catch (ApplicationException)
+            catch (TangApplicationException)
             {
             }
             catch (NameResolutionException)
@@ -66,7 +66,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
                 ns.GetNode("org.apache");
                 msg = "Didn't get expected exception";
             }
-            catch (ApplicationException)
+            catch (TangApplicationException)
             {
             }
             catch (NameResolutionException)
@@ -83,7 +83,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
             {
                 n = ns.GetNode("System");
             }
-            catch (ApplicationException)
+            catch (TangApplicationException)
             {
             }
             catch (NameResolutionException)
@@ -99,7 +99,7 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
                 ns.GetNode("org.apache");
                 msg = "Didn't get expected exception";
             }
-            catch (ApplicationException)
+            catch (TangApplicationException)
             {
             }
             catch (NameResolutionException)

--- a/lang/cs/Org.Apache.REEF.Tang/Exceptions/TangApplicationException.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Exceptions/TangApplicationException.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitationsF
+// under the License.
+
+using System;
+
+namespace Org.Apache.REEF.Tang.Exceptions
+{
+    public class TangApplicationException : Exception
+    {
+        internal TangApplicationException(string message)
+            : base(message)
+        {
+        }
+
+        internal TangApplicationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Tang/Formats/AvroConfigurationSerializer.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Formats/AvroConfigurationSerializer.cs
@@ -96,7 +96,7 @@ namespace Org.Apache.REEF.Tang.Formats
 
                 if (!WriteFile(buffer, fileName))
                 {
-                    var e = new ApplicationException("Error during file operation. Quitting method: " + fileName);
+                    var e = new TangApplicationException("Error during file operation. Quitting method: " + fileName);
                     Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
                 }
             }          
@@ -173,7 +173,7 @@ namespace Org.Apache.REEF.Tang.Formats
                 {
                     if (!ReadFile(buffer, fileName))
                     {
-                        var e = new ApplicationException("Error during file operation. Quitting method : " + fileName);
+                        var e = new TangApplicationException("Error during file operation. Quitting method : " + fileName);
                         Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
                     }
 
@@ -192,7 +192,7 @@ namespace Org.Apache.REEF.Tang.Formats
             catch (SerializationException ex)
             {
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Caught(ex, Level.Error, LOGGER);
-                var e = new ApplicationException("Cannot deserialize the file: " + fileName, ex);
+                var e = new TangApplicationException("Cannot deserialize the file: " + fileName, ex);
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
             }
 
@@ -269,7 +269,7 @@ namespace Org.Apache.REEF.Tang.Formats
             using (MemoryStream stream = new MemoryStream())
             {
                 serializer.Serialize(stream, obj);
-                return stream.GetBuffer();
+                return stream.ToArray();
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Tang/Formats/ConfigurationFile.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Formats/ConfigurationFile.cs
@@ -72,7 +72,7 @@ namespace Org.Apache.REEF.Tang.Formats
                 Type t = ReflectionUtilities.GetTypeByName(name);
                 return t.FullName;
             }
-            catch (ApplicationException e)
+            catch (TangApplicationException e)
             {
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Caught(e, Level.Warning, LOGGER);
                 return name; // if name is not a type, return as it was
@@ -86,7 +86,7 @@ namespace Org.Apache.REEF.Tang.Formats
                 Type t = ReflectionUtilities.GetTypeByName(s);
                 return ReflectionUtilities.GetAssemblyQualifiedName(t);
             }
-            catch (ApplicationException e)
+            catch (TangApplicationException e)
             {
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Caught(e, Level.Warning, LOGGER);
                 return s; // if name is not a type, return as it was
@@ -164,10 +164,10 @@ namespace Org.Apache.REEF.Tang.Formats
         }
 
         public static void AddConfigurationFromFile(IConfigurationBuilder conf, string configFileName)
-        {            
-            using (StreamReader reader = new StreamReader(configFileName))
+        {  
+            using (StreamReader reader = File.OpenText(configFileName))
             {
-                 AddConfiguration(conf, reader);
+                AddConfiguration(conf, reader);
             }
         }
 
@@ -196,7 +196,7 @@ namespace Org.Apache.REEF.Tang.Formats
                 }
                 else
                 {
-                    var e = new ApplicationException("Config data is not in format of KeyValuePair: " + line);
+                    var e = new TangApplicationException("Config data is not in format of KeyValuePair: " + line);
                     Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
                 }  
             }
@@ -206,7 +206,7 @@ namespace Org.Apache.REEF.Tang.Formats
         public static IDictionary<string, string> FromFile(string fileName)
         {
             IDictionary<string, string> property = new Dictionary<string, string>();
-            using (StreamReader sr = new StreamReader(fileName))
+            using (StreamReader sr = File.OpenText(fileName))
             {
                 while (!sr.EndOfStream)
                 {

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchy.cs
@@ -211,7 +211,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                 }
                 catch (Exception)
                 {
-                    var e = new ApplicationException(string.Format(CultureInfo.CurrentCulture, "Duplicated alias {0} on named parameter {1}.", np.GetAlias(), np.GetFullName()));
+                    var e = new TangApplicationException(string.Format(CultureInfo.CurrentCulture, "Duplicated alias {0} on named parameter {1}.", np.GetAlias(), np.GetFullName()));
                     Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
                 }
             }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchySerializer.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchySerializer.cs
@@ -78,7 +78,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
                 if (!WriteFile(buffer, fileName))
                 {
-                    var e = new ApplicationException("Error during file operation. Quitting method: " + fileName);
+                    var e = new TangApplicationException("Error during file operation. Quitting method: " + fileName);
                     Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
                 }
             }
@@ -91,9 +91,12 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         /// <param name="fileName"></param>
         public void ToTextFile(IClassHierarchy c, string fileName)
         {
-            var fp = new StreamWriter(fileName);
-            fp.WriteLine(ToString(c));
-            fp.Close();
+            using (FileStream fs = File.Open(fileName, FileMode.Create))
+            {
+                var fp = new StreamWriter(fs);
+                fp.WriteLine(ToString(c));
+                fp.Dispose();
+            }
         }
 
         /// <summary>
@@ -139,14 +142,13 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         {
             string line;
             StringBuilder b = new StringBuilder();
-
-            StreamReader file = new StreamReader(fileName);
-            while ((line = file.ReadLine()) != null)
+            using (StreamReader sr = File.OpenText(fileName))
             {
-                b.Append(line);
+                while ((line = sr.ReadLine()) != null)
+                {
+                    b.Append(line);
+                }
             }
-            file.Close();
-
             return FromString(b.ToString());
         }
 
@@ -398,7 +400,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                     if (!ReadFile(buffer, fileName))
                     {
                         var e =
-                            new ApplicationException("Error during file operation. Quitting method : " + fileName);
+                            new TangApplicationException("Error during file operation. Quitting method : " + fileName);
                         Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
                     }
 
@@ -419,7 +421,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             catch (SerializationException ex)
             {
                 Utilities.Diagnostics.Exceptions.Caught(ex, Level.Error, LOGGER);
-                var e = new ApplicationException("Cannot deserialize the file: " + fileName, ex);
+                var e = new TangApplicationException("Cannot deserialize the file: " + fileName, ex);
                 Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
             }
 
@@ -464,7 +466,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             using (MemoryStream stream = new MemoryStream())
             {
                 serializer.Serialize(stream, obj);
-                return stream.GetBuffer();
+                return stream.ToArray();
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
@@ -298,7 +298,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
                 }
                 catch (Exception)
                 {
-                    var e = new ApplicationException(string.Format(CultureInfo.CurrentCulture, "Duplicated alias {0} on named parameter {1}.", np.GetAlias(), np.GetFullName()));
+                    var e = new TangApplicationException(string.Format(CultureInfo.CurrentCulture, "Duplicated alias {0} on named parameter {1}.", np.GetAlias(), np.GetFullName()));
                     Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
                 }
             }
@@ -432,7 +432,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             {
                 t = loader.GetType(fullName);
             }
-            catch (ApplicationException)
+            catch (TangApplicationException)
             {
                 IDictionary<string, string> mapping = null;
                 _aliasLookupTable.TryGetValue(aliasLanguage, out mapping);

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
@@ -156,7 +156,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
                 if (type == null)
                 {
-                    Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new ApplicationException("Exception"), LOGGER);
+                    Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new TangApplicationException("Exception"), LOGGER);
                 }
 
                 string typename = ReflectionUtilities.GetAssemblyQualifiedName(type);

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectorImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectorImpl.cs
@@ -101,7 +101,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                     }
                     else
                     {
-                        var ex = new ApplicationException("Unexpected node type. Wanted ClassNode or NamedParameterNode.  Got: " + node);
+                        var ex = new TangApplicationException("Unexpected node type. Wanted ClassNode or NamedParameterNode.  Got: " + node);
                         Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
                     }
                     
@@ -216,7 +216,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                 }
                 else
                 {
-                    Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new ApplicationException("Unknown node type :" + n.ToString()), LOGGER);
+                    Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new TangApplicationException("Unknown node type :" + n.ToString()), LOGGER);
                 }
 
                 Type t = classHierarchy.ClassForName(typeOfSet);
@@ -252,7 +252,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                 }
                 else
                 {
-                    Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new ApplicationException("Unknown node type :" + n.ToString()), LOGGER);
+                    Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new TangApplicationException("Unknown node type :" + n.ToString()), LOGGER);
                 }
 
                 Type t = classHierarchy.ClassForName(typeOfList);
@@ -318,7 +318,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
 
             if (cons == null)
             {
-                Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new ApplicationException("Failed to look up constructor: " + constructor.ToString()), LOGGER);
+                Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new TangApplicationException("Failed to look up constructor: " + constructor.ToString()), LOGGER);
             }
             return cons;
         }
@@ -749,7 +749,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
             }
             if (ret2.Count > 0 && ret3.Count > 0)
             {
-                Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new ApplicationException("Set contains different types of object"), LOGGER);
+                Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new TangApplicationException("Set contains different types of object"), LOGGER);
             }
             return ret2;
         }
@@ -813,7 +813,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
         {
             if (!ReflectionUtilities.IsAssignableFromIgnoreGeneric(typeof(Name<>), t))
             {
-                var ex = new ApplicationException(string.Format(CultureInfo.CurrentCulture, "The parameter {0} is not inherit from Name<>", t));
+                var ex = new TangApplicationException(string.Format(CultureInfo.CurrentCulture, "The parameter {0} is not inherit from Name<>", t));
                 Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
             }
             return GetInstance(classHierarchy.GetNode(t));

--- a/lang/cs/Org.Apache.REEF.Tang/Org.Apache.REEF.Tang.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang/Org.Apache.REEF.Tang.csproj
@@ -57,6 +57,7 @@ under the License.
     <Compile Include="Exceptions\InjectionException.cs" />
     <Compile Include="Exceptions\NameResolutionException.cs" />
     <Compile Include="Exceptions\ParseException.cs" />
+    <Compile Include="Exceptions\TangApplicationException.cs" />
     <Compile Include="Formats\AvroConfigurationDataContract\AvroConfiguration.cs" />
     <Compile Include="Formats\AvroConfigurationDataContract\ConfigurationEntry.cs" />
     <Compile Include="Formats\AvroConfigurationSerializer.cs" />
@@ -75,22 +76,22 @@ under the License.
     <Compile Include="Implementations\ClassHierarchy\AvroClassHierarchy.cs" />
     <Compile Include="Implementations\ClassHierarchy\AvroClassHierarchySerializer.cs" />
     <Compile Include="Implementations\ClassHierarchy\AvroDataContract\AvroClassNode.cs">
-        <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Implementations\ClassHierarchy\AvroDataContract\AvroConstructorArg.cs">
-        <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Implementations\ClassHierarchy\AvroDataContract\AvroConstructorDef.cs">
-        <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Implementations\ClassHierarchy\AvroDataContract\AvroNamedParameterNode.cs">
-        <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Implementations\ClassHierarchy\AvroDataContract\AvroNode.cs">
-        <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Implementations\ClassHierarchy\AvroDataContract\AvroPackageNode.cs">
-        <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Implementations\ClassHierarchy\ClassHierarchyImpl.cs" />
     <Compile Include="Implementations\ClassHierarchy\ClassNodeImpl.cs" />
@@ -130,10 +131,10 @@ under the License.
     <Compile Include="Interface\ITang.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Protobuf\class_hierarchy.cs">
-        <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Protobuf\injection_plan.cs">
-        <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Protobuf\ProtocolBufferClassHierarchy.cs" />
     <Compile Include="Protobuf\ProtocolBufferInjectionPlan.cs" />

--- a/lang/cs/Org.Apache.REEF.Tang/Protobuf/ProtocolBufferClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Protobuf/ProtocolBufferClassHierarchy.cs
@@ -316,7 +316,7 @@ namespace Org.Apache.REEF.Tang.Protobuf
                 }
                 catch (Exception)
                 {
-                    var e = new ApplicationException(string.Format(CultureInfo.CurrentCulture, "Duplicated alias {0} on named parameter {1}.", np.GetAlias(), np.GetFullName()));
+                    var e = new TangApplicationException(string.Format(CultureInfo.CurrentCulture, "Duplicated alias {0} on named parameter {1}.", np.GetAlias(), np.GetFullName()));
                     Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
                 }
             }

--- a/lang/cs/Org.Apache.REEF.Tang/Util/AssemblyLoader.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/AssemblyLoader.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Tang.Exceptions;
 
 namespace Org.Apache.REEF.Tang.Util
 {
@@ -71,7 +72,7 @@ namespace Org.Apache.REEF.Tang.Util
 
             if (t == null)
             {
-                Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new ApplicationException("Not able to get Type from the name provided: " + name), LOGGER);
+                Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new TangApplicationException("Not able to get Type from the name provided: " + name), LOGGER);
             }
             return t;
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
@@ -129,7 +129,7 @@ namespace Org.Apache.REEF.Tang.Util
         {
             if (iface == null || type == null)
             {
-                var ex = new ApplicationException(string.Format(CultureInfo.CurrentCulture,
+                var ex = new TangApplicationException(string.Format(CultureInfo.CurrentCulture,
                                                              "The type passed in IsGenericTypeof is null: iface : {0} type: {1}. ",
                                                              iface, type));
                 Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
@@ -372,7 +372,7 @@ namespace Org.Apache.REEF.Tang.Util
             if (t == null)
             {
                 Utilities.Diagnostics.Exceptions.Throw(
-                    new ApplicationException("Not able to get Type from the name provided: " + name), LOGGER);
+                    new TangApplicationException("Not able to get Type from the name provided: " + name), LOGGER);
             }
 
             return t;
@@ -406,7 +406,7 @@ namespace Org.Apache.REEF.Tang.Util
         {
             if (t == null)
             {
-                Utilities.Diagnostics.Exceptions.Throw(new ApplicationException("The Type passed to GetEnclosingClassShortNames is null"), LOGGER);
+                Utilities.Diagnostics.Exceptions.Throw(new TangApplicationException("The Type passed to GetEnclosingClassShortNames is null"), LOGGER);
             }
             Type[] ts = GetEnclosingClasses(t);
             string[] result = new string[ts.Length];
@@ -428,7 +428,7 @@ namespace Org.Apache.REEF.Tang.Util
         {
             if (fullName == null)
             {
-                Utilities.Diagnostics.Exceptions.Throw(new ApplicationException("The name passed to GetEnclosingClassShortNames is null"), LOGGER);
+                Utilities.Diagnostics.Exceptions.Throw(new TangApplicationException("The name passed to GetEnclosingClassShortNames is null"), LOGGER);
             }
             Type t = ReflectionUtilities.GetTypeByName(fullName);
             return GetEnclosingClassNames(t);


### PR DESCRIPTION
…O and Application Exceptions

This addresses the issue by:
*replacing all ApplicationException instances in Tang, which are
incompatible with CoreCLR, with instances of a newly defined TangApplicationException
*Replacing MemoryStream.GetBuffer(), which is incompatible with CoreCLR,
with toArray() which is slightly less efficient but only results in neglible overhead
*replacing other System.IO function calls and constructors with
alternatives compatible with CoreCLR

JIRA:
  [REEF-1500](https://issues.apache.org/jira/browse/REEF-1500)

This closes #