### PR TITLE
[REEF-1528] Refactor dependency between yarn runtime and reef-webserv…

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
@@ -47,6 +47,7 @@ public final class EvaluatorRequestorImpl implements EvaluatorRequestor {
   /**
    * @param resourceCatalog
    * @param resourceRequestHandler
+   * @param loggingScopeFactory
    */
   @Inject
   public EvaluatorRequestorImpl(final ResourceCatalog resourceCatalog,
@@ -98,7 +99,7 @@ public final class EvaluatorRequestorImpl implements EvaluatorRequestor {
       relaxLocality = false;
     }
 
-    try (LoggingScope ls = loggingScopeFactory.evaluatorSubmit(req.getNumber())) {
+    try (LoggingScope ls = this.loggingScopeFactory.evaluatorSubmit(req.getNumber())) {
       final ResourceRequestEvent request = ResourceRequestEventImpl
           .newBuilder()
           .setResourceCount(req.getNumber())

--- a/lang/java/reef-runtime-yarn/pom.xml
+++ b/lang/java/reef-runtime-yarn/pom.xml
@@ -42,6 +42,11 @@ under the License.
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>reef-webserver</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>reef-utils-hadoop</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -63,6 +68,11 @@ under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/HttpTrackingURLProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/HttpTrackingURLProvider.java
@@ -48,9 +48,9 @@ public final class HttpTrackingURLProvider implements TrackingURLProvider {
    */
   @Inject
   public HttpTrackingURLProvider(final HttpServer httpServer) {
-    if(httpServer instanceof DefaultHttpServerImpl){
+    if(httpServer instanceof DefaultHttpServerImpl) {
       this.httpServer = null;
-    }else {
+    } else {
       this.httpServer = httpServer;
     }
   }
@@ -62,7 +62,7 @@ public final class HttpTrackingURLProvider implements TrackingURLProvider {
    */
   @Override
   public String getTrackingUrl() {
-    if(this.httpServer == null){
+    if(this.httpServer == null) {
       return "";
     }
 

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/HttpTrackingURLProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/HttpTrackingURLProvider.java
@@ -48,7 +48,7 @@ public final class HttpTrackingURLProvider implements TrackingURLProvider {
    */
   @Inject
   public HttpTrackingURLProvider(final HttpServer httpServer) {
-    if(httpServer instanceof DefaultHttpServerImpl) {
+    if (httpServer instanceof DefaultHttpServerImpl) {
       this.httpServer = null;
     } else {
       this.httpServer = httpServer;
@@ -62,7 +62,7 @@ public final class HttpTrackingURLProvider implements TrackingURLProvider {
    */
   @Override
   public String getTrackingUrl() {
-    if(this.httpServer == null) {
+    if (this.httpServer == null) {
       return "";
     }
 

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/HttpTrackingURLProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/HttpTrackingURLProvider.java
@@ -16,9 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.webserver;
+package org.apache.reef.runtime.yarn.driver;
 
-import org.apache.reef.runtime.yarn.driver.TrackingURLProvider;
+import org.apache.reef.webserver.DefaultHttpServerImpl;
+import org.apache.reef.webserver.HttpServer;
 
 import javax.inject.Inject;
 import java.net.InetAddress;
@@ -47,7 +48,11 @@ public final class HttpTrackingURLProvider implements TrackingURLProvider {
    */
   @Inject
   public HttpTrackingURLProvider(final HttpServer httpServer) {
-    this.httpServer = httpServer;
+    if(httpServer instanceof DefaultHttpServerImpl){
+      this.httpServer = null;
+    }else {
+      this.httpServer = httpServer;
+    }
   }
 
   /**
@@ -57,6 +62,10 @@ public final class HttpTrackingURLProvider implements TrackingURLProvider {
    */
   @Override
   public String getTrackingUrl() {
+    if(this.httpServer == null){
+      return "";
+    }
+
     try {
       return InetAddress.getLocalHost().getHostAddress() + ":" + httpServer.getPort();
     } catch (final UnknownHostException e) {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/HttpTrackingURLProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/HttpTrackingURLProvider.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.runtime.yarn.driver;
 
-import org.apache.reef.webserver.DefaultHttpServerImpl;
+import org.apache.reef.webserver.NoOpHttpServerImpl;
 import org.apache.reef.webserver.HttpServer;
 
 import javax.inject.Inject;
@@ -48,11 +48,7 @@ public final class HttpTrackingURLProvider implements TrackingURLProvider {
    */
   @Inject
   public HttpTrackingURLProvider(final HttpServer httpServer) {
-    if (httpServer instanceof DefaultHttpServerImpl) {
-      this.httpServer = null;
-    } else {
-      this.httpServer = httpServer;
-    }
+    this.httpServer = httpServer instanceof NoOpHttpServerImpl ? null : httpServer;
   }
 
   /**

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/TrackingURLProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/TrackingURLProvider.java
@@ -23,7 +23,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 /**
  * Implement this interface to set the tracking URL reported to YARN.
  */
-@DefaultImplementation(DefaultTrackingURLProvider.class)
+@DefaultImplementation(HttpTrackingURLProvider.class)
 public interface TrackingURLProvider {
   String getTrackingUrl();
 }

--- a/lang/java/reef-runtime-yarn/src/main/test/java/org/apache/reef/runtime/yarn/driver/TestTrackingUri.java
+++ b/lang/java/reef-runtime-yarn/src/main/test/java/org/apache/reef/runtime/yarn/driver/TestTrackingUri.java
@@ -16,15 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.webserver;
+package org.apache.reef.runtime.yarn.driver;
 
-import org.apache.reef.runtime.yarn.driver.TrackingURLProvider;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.JavaConfigurationBuilder;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
+import org.apache.reef.webserver.HttpHandlerConfiguration;
+import org.apache.reef.webserver.HttpServer;
+import org.apache.reef.webserver.HttpServerImpl;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/lang/java/reef-runtime-yarn/src/main/test/java/org/apache/reef/runtime/yarn/driver/YarnResourceRequestHandlerTest.java
+++ b/lang/java/reef-runtime-yarn/src/main/test/java/org/apache/reef/runtime/yarn/driver/YarnResourceRequestHandlerTest.java
@@ -70,27 +70,24 @@ public final class YarnResourceRequestHandlerTest {
         .setMemory(128)
         .setNumberOfCores(2)
         .build();
-    {
+
       evaluatorRequestor.submit(requestOne);
       Assert.assertEquals("Request in REEF and YARN form should have the same amount of memory",
           requestOne.getMegaBytes(),
           containerRequestHandler.getRequests()[0].getCapability().getMemory()
       );
-    }
-    {
+
       evaluatorRequestor.submit(requestTwo);
       Assert.assertEquals("Request in REEF and YARN form should have the same amount of memory",
           requestTwo.getMegaBytes(),
           containerRequestHandler.getRequests()[0].getCapability().getMemory()
       );
-    }
-    {
+
       evaluatorRequestor.submit(requestOne);
       Assert.assertNotEquals("Request in REEF and YARN form should have the same amount of memory",
           requestTwo.getMegaBytes(),
           containerRequestHandler.getRequests()[0].getCapability().getMemory()
       );
-    }
   }
 
   @Test
@@ -107,26 +104,23 @@ public final class YarnResourceRequestHandlerTest {
         .setMemory(128)
         .setNumberOfCores(2)
         .build();
-    {
+
       evaluatorRequestor.submit(requestOne);
       Assert.assertEquals("Request in REEF and YARN form should have the same number of Evaluators",
           requestOne.getNumber(),
           containerRequestHandler.getRequests().length
       );
-    }
-    {
+
       evaluatorRequestor.submit(requestTwo);
       Assert.assertEquals("Request in REEF and YARN form should have the same number of Evaluators",
           requestTwo.getNumber(),
           containerRequestHandler.getRequests().length
       );
-    }
-    {
+
       evaluatorRequestor.submit(requestTwo);
       Assert.assertNotEquals("Request in REEF and YARN form should have the same number of Evaluators",
           requestOne.getNumber(),
           containerRequestHandler.getRequests().length
       );
-    }
   }
 }

--- a/lang/java/reef-runtime-yarn/src/main/test/java/org/apache/reef/runtime/yarn/driver/YarnResourceRequestHandlerTest.java
+++ b/lang/java/reef-runtime-yarn/src/main/test/java/org/apache/reef/runtime/yarn/driver/YarnResourceRequestHandlerTest.java
@@ -61,34 +61,34 @@ public final class YarnResourceRequestHandlerTest {
     final EvaluatorRequestor evaluatorRequestor = new EvaluatorRequestorImpl(resourceCatalog, resourceRequestHandler, loggingScopeFactory);
 
     final EvaluatorRequest requestOne = EvaluatorRequest.newBuilder()
-            .setNumber(1)
-            .setMemory(64)
-            .setNumberOfCores(1)
-            .build();
+        .setNumber(1)
+        .setMemory(64)
+        .setNumberOfCores(1)
+        .build();
     final EvaluatorRequest requestTwo = EvaluatorRequest.newBuilder()
-            .setNumber(1)
-            .setMemory(128)
-            .setNumberOfCores(2)
-            .build();
+        .setNumber(1)
+        .setMemory(128)
+        .setNumberOfCores(2)
+        .build();
     {
       evaluatorRequestor.submit(requestOne);
       Assert.assertEquals("Request in REEF and YARN form should have the same amount of memory",
-              requestOne.getMegaBytes(),
-              containerRequestHandler.getRequests()[0].getCapability().getMemory()
+          requestOne.getMegaBytes(),
+          containerRequestHandler.getRequests()[0].getCapability().getMemory()
       );
     }
     {
       evaluatorRequestor.submit(requestTwo);
       Assert.assertEquals("Request in REEF and YARN form should have the same amount of memory",
-              requestTwo.getMegaBytes(),
-              containerRequestHandler.getRequests()[0].getCapability().getMemory()
+          requestTwo.getMegaBytes(),
+          containerRequestHandler.getRequests()[0].getCapability().getMemory()
       );
     }
     {
       evaluatorRequestor.submit(requestOne);
       Assert.assertNotEquals("Request in REEF and YARN form should have the same amount of memory",
-              requestTwo.getMegaBytes(),
-              containerRequestHandler.getRequests()[0].getCapability().getMemory()
+          requestTwo.getMegaBytes(),
+          containerRequestHandler.getRequests()[0].getCapability().getMemory()
       );
     }
   }
@@ -98,34 +98,34 @@ public final class YarnResourceRequestHandlerTest {
     final LoggingScopeFactory loggingScopeFactory = Tang.Factory.getTang().newInjector().getInstance(LoggingScopeFactory.class);
     final EvaluatorRequestor evaluatorRequestor = new EvaluatorRequestorImpl(resourceCatalog, resourceRequestHandler, loggingScopeFactory);
     final EvaluatorRequest requestOne = EvaluatorRequest.newBuilder()
-            .setNumber(1)
-            .setMemory(64)
-            .setNumberOfCores(1)
-            .build();
+        .setNumber(1)
+        .setMemory(64)
+        .setNumberOfCores(1)
+        .build();
     final EvaluatorRequest requestTwo = EvaluatorRequest.newBuilder()
-            .setNumber(2)
-            .setMemory(128)
-            .setNumberOfCores(2)
-            .build();
+        .setNumber(2)
+        .setMemory(128)
+        .setNumberOfCores(2)
+        .build();
     {
       evaluatorRequestor.submit(requestOne);
       Assert.assertEquals("Request in REEF and YARN form should have the same number of Evaluators",
-              requestOne.getNumber(),
-              containerRequestHandler.getRequests().length
+          requestOne.getNumber(),
+          containerRequestHandler.getRequests().length
       );
     }
     {
       evaluatorRequestor.submit(requestTwo);
       Assert.assertEquals("Request in REEF and YARN form should have the same number of Evaluators",
-              requestTwo.getNumber(),
-              containerRequestHandler.getRequests().length
+          requestTwo.getNumber(),
+          containerRequestHandler.getRequests().length
       );
     }
     {
       evaluatorRequestor.submit(requestTwo);
       Assert.assertNotEquals("Request in REEF and YARN form should have the same number of Evaluators",
-              requestOne.getNumber(),
-              containerRequestHandler.getRequests().length
+          requestOne.getNumber(),
+          containerRequestHandler.getRequests().length
       );
     }
   }

--- a/lang/java/reef-webserver/pom.xml
+++ b/lang/java/reef-webserver/pom.xml
@@ -107,11 +107,6 @@ under the License.
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>reef-runtime-yarn</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>reef-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/DefaultHttpServerImpl.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/DefaultHttpServerImpl.java
@@ -16,18 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runtime.yarn.driver;
+
+package org.apache.reef.webserver;
 
 import javax.inject.Inject;
 
-final class DefaultTrackingURLProvider implements TrackingURLProvider {
-
+/**
+ * Empty implementation for the HttpServer.
+ */
+public final class DefaultHttpServerImpl implements HttpServer{
   @Inject
-  DefaultTrackingURLProvider() {
+  DefaultHttpServerImpl(){
   }
 
   @Override
-  public String getTrackingUrl() {
-    return "";
+  public void start() throws Exception {
+  }
+
+  @Override
+  public void stop() throws Exception {
+  }
+
+  @Override
+  public int getPort() {
+    return 0;
+  }
+
+  @Override
+  public void addHttpHandler(final HttpHandler httpHandler) {
   }
 }

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/DefaultHttpServerImpl.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/DefaultHttpServerImpl.java
@@ -24,9 +24,9 @@ import javax.inject.Inject;
 /**
  * Empty implementation for the HttpServer.
  */
-public final class DefaultHttpServerImpl implements HttpServer{
+public final class DefaultHttpServerImpl implements HttpServer {
   @Inject
-  DefaultHttpServerImpl(){
+  DefaultHttpServerImpl() {
   }
 
   @Override

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandlerConfiguration.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandlerConfiguration.java
@@ -18,7 +18,6 @@
  */
 package org.apache.reef.webserver;
 
-import org.apache.reef.runtime.yarn.driver.TrackingURLProvider;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.tang.formats.OptionalParameter;
@@ -38,6 +37,5 @@ public final class HttpHandlerConfiguration extends ConfigurationModuleBuilder {
    */
   public static final ConfigurationModule CONF = new HttpHandlerConfiguration().merge(HttpRuntimeConfiguration.CONF)
       .bindSetEntry(HttpEventHandlers.class, HTTP_HANDLERS)
-      .bindImplementation(TrackingURLProvider.class, HttpTrackingURLProvider.class)
       .build();
 }

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServer.java
@@ -18,9 +18,12 @@
  */
 package org.apache.reef.webserver;
 
+import org.apache.reef.tang.annotations.DefaultImplementation;
+
 /**
  * HttpServer interface.
  */
+@DefaultImplementation(DefaultHttpServerImpl.class)
 public interface HttpServer {
 
   /**

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServer.java
@@ -23,7 +23,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 /**
  * HttpServer interface.
  */
-@DefaultImplementation(DefaultHttpServerImpl.class)
+@DefaultImplementation(NoOpHttpServerImpl.class)
 public interface HttpServer {
 
   /**

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/NoOpHttpServerImpl.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/NoOpHttpServerImpl.java
@@ -23,10 +23,11 @@ import javax.inject.Inject;
 
 /**
  * Empty implementation for the HttpServer.
+ * It has no functionality and serves only as an injectable placeholder.
  */
-public final class DefaultHttpServerImpl implements HttpServer {
+public final class NoOpHttpServerImpl implements HttpServer {
   @Inject
-  DefaultHttpServerImpl() {
+  NoOpHttpServerImpl() {
   }
 
   @Override


### PR DESCRIPTION
…er projects

This addressed the issue by
  * Reverting teh dependency between reef-webserver and reef-runtime
  * Fixing tests
  * Adding Empty implementation for the HttpServer
  * Changing default implementation of TrackingURLProvider to HttpTrackingURLProvider
  * Changing HttpTrackingURLProvider to return empty URL when http server is not configured (DefaultHttpServerImpl is configured)

JIRA:
  [REEF-1528](https://issues.apache.org/jira/browse/REEF-1528)