### PR TITLE
[REEF-1530] Fix CoreCLR incompatibilities in Tang related to String.S…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
@@ -513,9 +513,10 @@ namespace Org.Apache.REEF.Tang.Util
             if (type != null)
             {
                 // HACK: The only way to detect anonymous types right now.
+                CompareInfo myComp = CultureInfo.CurrentCulture.CompareInfo;
                 return CustomAttributeExtensions.IsDefined(type, typeof(CompilerGeneratedAttribute), false)
                        && type.IsGenericType && type.Name.Contains("AnonymousType")
-                       && (type.Name.StartsWith("<>", true, CultureInfo.CurrentCulture) || type.Name.StartsWith("VB$", true, CultureInfo.CurrentCulture))
+                       && (myComp.IsPrefix(type.Name, "<>", CompareOptions.IgnoreCase) || myComp.IsPrefix(type.Name, "VB$", CompareOptions.IgnoreCase))
                        && (type.Attributes & TypeAttributes.NotPublic) == TypeAttributes.NotPublic;
             }
             return false;


### PR DESCRIPTION
…tartsWith method

This addresses the issue by:
*Replacing the String.StartsWith method, which is incompatible with
CoreCLR, with CompareInfo.IsPrefix

JIRA:
  [REEF-1530](https://issues.apache.org/jira/browse/REEF-1530)

This closes #