### PR TITLE
[REEF-1533] Make RuntimeClock more testable and create unit tests to check graceful and forceful shutdown of RuntimeClock

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
@@ -43,12 +43,12 @@ public interface Clock extends Runnable, AutoCloseable {
 
   /**
    * Schedule a TimerEvent at the given future offset.
-   *
-   * @param handler to be called
-   * @param offset  into the future
-   * @throws IllegalStateException when the clock has been already closed
+   * @param handler Event handler to be called on alarm.
+   * @param offset Offset into the future in milliseconds.
+   * @return Newly scheduled alarm.
+   * @throws IllegalStateException When the clock has been already closed.
    */
-  void scheduleAlarm(final int offset, final EventHandler<Alarm> handler);
+  Time scheduleAlarm(final int offset, final EventHandler<Alarm> handler);
 
   /**
    * This will stop the clock after all client alarms
@@ -76,6 +76,14 @@ public interface Clock extends Runnable, AutoCloseable {
    * @return true if idle, otherwise false
    */
   boolean isIdle();
+
+  /**
+   * Clock is closed after a call to stop() or close().
+   * A closed clock cannot add new alarms to the schedule, but, in case of the
+   * graceful shutdown, can still invoke previously scheduled ones.
+   * @return true if closed, false otherwise.
+   */
+  boolean isClosed();
 
   /**
    * Bind this to an event handler to statically subscribe to the StartTime Event.

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/RuntimeClockTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/RuntimeClockTest.java
@@ -44,7 +44,7 @@ import java.util.logging.Level;
 /**
  * Tests for RuntimeClock event loop.
  */
-public class ClockTest {
+public class RuntimeClockTest {
 
   private static final Tang TANG = Tang.Factory.getTang();
 

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/util/AlarmProducer.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/util/AlarmProducer.java
@@ -26,8 +26,8 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
 /**
- * Helper class to generate alarms at user-specified intervals
- * and count down the barrier on each alarm.
+ * Helper class used in unit tests to generate alarms at user-specified intervals
+ * and count down the barrier on each alarm. It is used in RuntimeClockTest.
  */
 public abstract class AlarmProducer implements EventHandler<Alarm> {
 
@@ -61,12 +61,12 @@ public abstract class AlarmProducer implements EventHandler<Alarm> {
   public abstract int getOffset();
 
   /**
-   * Generate random number uniformly distributed between offsetMin and offsetMax.
+   * Generate random integer uniformly distributed between offsetMin and offsetMax.
    * Helper function to be used in getOffset().
    * @param rand Random number generator, and instance of Random.
    * @param offsetMin Lower bound, must be > 0.
    * @param offsetMax Upper bound, must be > offsetMin.
-   * @return Random number uniformly distributed between offsetMin and offsetMax.
+   * @return Random integer uniformly distributed between offsetMin and offsetMax.
    */
   public static int randomOffsetUniform(final Random rand, final int offsetMin, final int offsetMax) {
     assert offsetMin > 0;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/util/AlarmProducer.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/util/AlarmProducer.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.test.time.util;
+
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.Alarm;
+import org.apache.reef.wake.time.runtime.RuntimeClock;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Helper class to generate alarms at user-specified intervals
+ * and count down the barrier on each alarm.
+ */
+public abstract class AlarmProducer implements EventHandler<Alarm> {
+
+  private final RuntimeClock clock;
+  private final CountDownLatch eventCountLatch;
+
+  /**
+   * Create a new alarm producer.
+   * @param clock Event loop that processes the schedule and invokes alarm handlers.
+   * @param latch A barrier with the counter that gets decremented after each alarm.
+   */
+  public AlarmProducer(final RuntimeClock clock, final CountDownLatch latch) {
+    this.clock = clock;
+    this.eventCountLatch = latch;
+  }
+
+  /**
+   * On each alarm, schedule the next one and decrement the latch.
+   * @param value An alarm to process.
+   */
+  @Override
+  public void onNext(final Alarm value) {
+    this.clock.scheduleAlarm(this.getOffset(), this);
+    this.eventCountLatch.countDown();
+  }
+
+  /**
+   * Return offset from current time in milliseconds for when to schedule an alarm.
+   * @return Time offset in milliseconds. Must be a positive number.
+   */
+  public abstract int getOffset();
+
+  /**
+   * Generate random number uniformly distributed between offsetMin and offsetMax.
+   * Helper function to be used in getOffset().
+   * @param rand Random number generator, and instance of Random.
+   * @param offsetMin Lower bound, must be > 0.
+   * @param offsetMax Upper bound, must be > offsetMin.
+   * @return Random number uniformly distributed between offsetMin and offsetMax.
+   */
+  public static int randomOffsetUniform(final Random rand, final int offsetMin, final int offsetMax) {
+    assert offsetMin > 0;
+    assert offsetMin <= offsetMax;
+    return rand.nextInt(offsetMax - offsetMin + 1) + offsetMin;
+  }
+
+  /**
+   * Generate random integer drawn from Poisson distribution.
+   * Helper function to be used in getOffset(). Always returns a positive integer.
+   * We use normal distribution with mu=lambda and sigma=sqrt(lambda) to approximate
+   * the Poisson distribution.
+   * @param rand Random number generator, and instance of Random.
+   * @param lambda Parameter of the Poisson distribution, must be > 0.
+   * @return A rounded absolute value of a random number drawn from a Poisson distribution.
+   */
+  public static int randomOffsetPoisson(final Random rand, final double lambda) {
+    assert lambda > 0;
+    return (int)Math.round(Math.abs(rand.nextGaussian() * Math.sqrt(lambda) + lambda) + 1);
+  }
+}

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/util/EventRecorder.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/util/EventRecorder.java
@@ -29,8 +29,10 @@ import java.util.concurrent.CountDownLatch;
 
 /**
  * An EventHandler that records the events that it sees.
+ * Can optionally count down the latch on each alarm it receives.
+ * This is a helper class to be used in unit tests, e.g. RuntimeClockTest.
  */
-public class EventRecorder implements EventHandler<Alarm> {
+public final class EventRecorder implements EventHandler<Alarm> {
 
   /**
    * A synchronized List of the events recorded by this EventRecorder.
@@ -43,18 +45,35 @@ public class EventRecorder implements EventHandler<Alarm> {
     this(null);
   }
 
+  /**
+   * Create a new event recorder.
+   * If latch is not null, count it down on each event received.
+   * @param latch A count down latch. Can be null.
+   */
   public EventRecorder(final CountDownLatch latch) {
     this.eventCountLatch = latch;
   }
 
+  /**
+   * Get the number of events captured so far.
+   * @return A number of events captured.
+   */
   public int getEventCount() {
     return this.events.size();
   }
 
+  /**
+   * Get the list of events captured so far, in the order they were captured.
+   * @return A list of events. It can be empty, but never null.
+   */
   public List<Time> getEvents() {
     return this.events;
   }
 
+  /**
+   * Add a new event to the list.
+   * @param event An event to capture.
+   */
   @Override
   public void onNext(final Alarm event) {
     this.events.add(event);

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/util/EventRecorder.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/util/EventRecorder.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.test.time.util;
+
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.Time;
+import org.apache.reef.wake.time.event.Alarm;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * An EventHandler that records the events that it sees.
+ */
+public class EventRecorder implements EventHandler<Alarm> {
+
+  /**
+   * A synchronized List of the events recorded by this EventRecorder.
+   */
+  private final List<Time> events = Collections.synchronizedList(new ArrayList<Time>());
+
+  private final CountDownLatch eventCountLatch;
+
+  public EventRecorder() {
+    this(null);
+  }
+
+  public EventRecorder(final CountDownLatch latch) {
+    this.eventCountLatch = latch;
+  }
+
+  public int getEventCount() {
+    return this.events.size();
+  }
+
+  public List<Time> getEvents() {
+    return this.events;
+  }
+
+  @Override
+  public void onNext(final Alarm event) {
+    this.events.add(event);
+    if (this.eventCountLatch != null) {
+      this.eventCountLatch.countDown();
+    }
+  }
+}

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/util/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/util/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Helper classes for unit tests in org.apache.reef.wake.test.time package.
+ */
+package org.apache.reef.wake.test.time.util;


### PR DESCRIPTION
  * Refactor `ClockTest` for readability and add more Javadoc comments;
  * Add unit tests for graceful and forceful shutdown of the clock.
  * Move alarm producing functionality into a separate class and factor out the delay logic as an abstract method.
  * Add helper functions to generate random delays to `AlarmProducer`
  * Move `EventRecorder` into a separate class
  * Refactor the `EventRecorder` helper class - do not track timestamps separately from events + minor style cleanups.
  * Implement `Clock.isClosed()` method
  * Minor fixes in other unit tests around the `RuntimeClock` logic.
  * Add some javadocs and do minor clean-ups in the clock tests.

JIRA:
  [REEF-1533](https://issues.apache.org/jira/browse/REEF-1533) close