### PR TITLE
[REEF-1539] Fix memory leak in InteropUtil.cpp

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.cpp
@@ -101,7 +101,7 @@ array<byte>^ ManagedByteArrayFromJavaByteArray(
     for (int i = 0; i < len; i++) {
       managedByteArray[i] = bytes[i];
     }
-	env->ReleaseByteArrayElements(javaByteArray, (jbyte*)bytes, JNI_ABORT);
+    env->ReleaseByteArrayElements(javaByteArray, (jbyte*)bytes, JNI_ABORT);
     return managedByteArray;
   }
   return nullptr;

--- a/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.cpp
@@ -101,6 +101,7 @@ array<byte>^ ManagedByteArrayFromJavaByteArray(
     for (int i = 0; i < len; i++) {
       managedByteArray[i] = bytes[i];
     }
+	env->ReleaseByteArrayElements(javaByteArray, (jbyte*)bytes, JNI_ABORT);
     return managedByteArray;
   }
   return nullptr;


### PR DESCRIPTION
This addressed the issue by
  * Release the bytes generated in ManagedByteArrayFromJavaByteArray.

JIRA:
  [REEF-1539](https://issues.apache.org/jira/browse/REEF-1539)