### PR TITLE
[REEF-1502] Fix remaining Core .NET incompatibilities in REEF.Driver.

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
@@ -336,7 +336,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrBuffered
   try {
     if (!JavaClrBridge::LoggerWrapper::initialized) {
       ManagedLog::LOGGER->Log("Initializing CLRBufferedLogHandler in java bridge...");
-      JavaClrBridge::LoggerWrapper::logger->Listeners->Add(gcnew System::Diagnostics::ConsoleTraceListener());
+      JavaClrBridge::LoggerWrapper::logger->Listeners->Add(gcnew System::Diagnostics::TextWriterTraceListener(System::Console::Out));
       JavaClrBridge::LoggerWrapper::initialized = true;
     }
 

--- a/lang/cs/Org.Apache.REEF.Driver/Defaults/DefaultCustomTraceListener.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Defaults/DefaultCustomTraceListener.cs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
 using System.Diagnostics;
 using Org.Apache.REEF.Tang.Annotations;
 
@@ -27,7 +28,7 @@ namespace Org.Apache.REEF.Driver.Defaults
         [Inject]
         public DefaultCustomTraceListener()
         {
-            _listener = new ConsoleTraceListener();
+            _listener = new TextWriterTraceListener(Console.Out);
         }
 
         public override void Write(string message)

--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/HelloTraceListener.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/HelloTraceListener.cs
@@ -30,7 +30,7 @@ namespace Org.Apache.REEF.Examples.AllHandlers
         [Inject]
         private HelloTraceListener()
         {
-            _listener = new ConsoleTraceListener();
+            _listener = new TextWriterTraceListener(System.Console.Out);
         }
 
         public override void Write(string message)

--- a/lang/cs/Org.Apache.REEF.Utilities/Logging/Logger.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Logging/Logger.cs
@@ -64,7 +64,7 @@ namespace Org.Apache.REEF.Utilities.Logging
             if (TraceListeners.Count == 0)
             {
                 // before customized listener is added, we would need to log to console
-                _traceSource.Listeners.Add(new ConsoleTraceListener());
+                _traceSource.Listeners.Add(new TextWriterTraceListener(Console.Out));
             }
             else
             {


### PR DESCRIPTION
 This check in addresses the issue by replacing the ConsoleTextWriter class
 which is unavailable in Core .NET with TextWriterTraceListener writing to
 standard out. Necessary changes rippled into the Bridge, Examples, and
 Utilities projects.

JIRA:
  [REEF-1502](https://issues.apache.org/jira/browse/REEF-1502)