### PR TITLE
[REEF-1555] Refactor REEF Driver logic for code readability and add more javadocs

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatusManager.java
@@ -198,7 +198,7 @@ public final class DriverStatusManager {
   /**
    * Sends the final message to the Driver. This is used by DriverRuntimeStopHandler.onNext().
    * @param exception Exception that caused the job to end (can be absent).
-   * @deprecated [REEF-1548] Do not use DriverStatusManager as a proxy to the job client.
+   * @deprecated TODO[JIRA REEF-1548] Do not use DriverStatusManager as a proxy to the job client.
    * After release 0.16, make this method private and use it inside onRuntimeStop() method instead.
    */
   public synchronized void sendJobEndingMessageToClient(final Optional<Throwable> exception) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/DriverIdleManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/DriverIdleManager.java
@@ -32,43 +32,54 @@ import java.util.logging.Logger;
  * Handles the various sources for driver idleness and forwards decisions to DriverStatusManager.
  */
 public final class DriverIdleManager {
+
   private static final Logger LOG = Logger.getLogger(DriverIdleManager.class.getName());
   private static final Level IDLE_REASONS_LEVEL = Level.FINEST;
+
   private final Set<DriverIdlenessSource> idlenessSources;
   private final InjectionFuture<DriverStatusManager> driverStatusManager;
 
   @Inject
-  DriverIdleManager(@Parameter(DriverIdleSources.class) final Set<DriverIdlenessSource> idlenessSources,
-                    final InjectionFuture<DriverStatusManager> driverStatusManager) {
+  private DriverIdleManager(
+      @Parameter(DriverIdleSources.class) final Set<DriverIdlenessSource> idlenessSources,
+      final InjectionFuture<DriverStatusManager> driverStatusManager) {
+
     this.idlenessSources = idlenessSources;
     this.driverStatusManager = driverStatusManager;
   }
 
+  /**
+   * Check whether all Driver components are idle, and initiate driver shutdown if they are.
+   * @param reason An indication whether the component is idle, along with a descriptive message.
+   */
   public synchronized void onPotentiallyIdle(final IdleMessage reason) {
-    synchronized (driverStatusManager.get()) {
-      if (this.driverStatusManager.get().isShuttingDownOrFailing()) {
-        LOG.log(IDLE_REASONS_LEVEL, "Ignoring idle call from [{0}] for reason [{1}]",
-            new Object[]{reason.getComponentName(), reason.getReason()});
-      } else {
-        boolean isIdle = true;
-        LOG.log(IDLE_REASONS_LEVEL, "Checking for idle because {0} reported idleness for reason [{1}]",
-            new Object[]{reason.getComponentName(), reason.getReason()});
 
+    final DriverStatusManager driverStatusManagerImpl = this.driverStatusManager.get();
 
-        for (final DriverIdlenessSource idlenessSource : this.idlenessSources) {
-          final IdleMessage idleMessage = idlenessSource.getIdleStatus();
-          LOG.log(IDLE_REASONS_LEVEL, "[{0}] is reporting {1} because [{2}].",
-              new Object[]{idleMessage.getComponentName(), idleMessage.isIdle() ? "idle" : "not idle",
-                  idleMessage.getReason()}
-          );
-          isIdle &= idleMessage.isIdle();
-        }
+    if (driverStatusManagerImpl.isShuttingDownOrFailing()) {
+      LOG.log(IDLE_REASONS_LEVEL, "Ignoring idle call from [{0}] for reason [{1}]",
+          new Object[] {reason.getComponentName(), reason.getReason()});
+      return;
+    }
 
-        if (isIdle) {
-          LOG.log(Level.INFO, "All components indicated idle. Initiating Driver shutdown.");
-          this.driverStatusManager.get().onComplete();
-        }
-      }
+    LOG.log(IDLE_REASONS_LEVEL, "Checking for idle because {0} reported idleness for reason [{1}]",
+        new Object[] {reason.getComponentName(), reason.getReason()});
+
+    boolean isIdle = true;
+    for (final DriverIdlenessSource idlenessSource : this.idlenessSources) {
+
+      final IdleMessage idleMessage = idlenessSource.getIdleStatus();
+
+      LOG.log(IDLE_REASONS_LEVEL, "[{0}] is reporting {1} because [{2}].",
+          new Object[] {idleMessage.getComponentName(),
+              idleMessage.isIdle() ? "idle" : "not idle", idleMessage.getReason()});
+
+      isIdle &= idleMessage.isIdle();
+    }
+
+    if (isIdle) {
+      LOG.log(Level.INFO, "All components indicated idle. Initiating Driver shutdown.");
+      driverStatusManagerImpl.onComplete();
     }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerStatus.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerStatus.java
@@ -117,7 +117,9 @@ public final class ResourceManagerStatus implements EventHandler<RuntimeStatusEv
   }
 
   /**
-   * Driver is idle if, regardless of status, it has no evaluators allocated and no pending container requests.
+   * Driver is idle if, regardless of status, it has no evaluators allocated
+   * and no pending container requests. This method is used in the DriverIdleManager.
+   * If all DriverIdlenessSource components are idle, DriverIdleManager will initiate Driver shutdown.
    * @return idle, if there are no outstanding requests or allocations. Not idle otherwise.
    */
   @Override

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerStatus.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerStatus.java
@@ -53,7 +53,7 @@ public final class ResourceManagerStatus implements EventHandler<RuntimeStatusEv
   /** Mutable RM state. */
   private State state = State.INIT;
 
-  /** Number of container requests pending with the RM, as per latest RuntimeStatusEvent message. */
+  /** Number of container requests outstanding with the RM, as per latest RuntimeStatusEvent message. */
   private int outstandingContainerRequests = 0;
 
   /** Number of containers currently allocated, as per latest RuntimeStatusEvent message. */

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -45,14 +45,7 @@ import org.apache.reef.wake.remote.RemoteMessage;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -67,8 +60,7 @@ final class ContainerManager implements AutoCloseable {
 
   private static final Logger LOG = Logger.getLogger(ContainerManager.class.getName());
 
-  private static final Collection<String> DEFAULT_RACKS = Arrays.asList(RackNames.DEFAULT_RACK_NAME);
-
+  private static final Collection<String> DEFAULT_RACKS = Collections.singletonList(RackNames.DEFAULT_RACK_NAME);
 
   /**
    * Map from containerID -> Container.
@@ -104,7 +96,7 @@ final class ContainerManager implements AutoCloseable {
   private final Collection<String> availableRacks;
 
   @Inject
-  ContainerManager(
+  private ContainerManager(
       final RemoteManager remoteManager,
       final REEFFileNames fileNames,
       @Parameter(MaxNumberOfEvaluators.class) final int capacity,
@@ -116,6 +108,7 @@ final class ContainerManager implements AutoCloseable {
       final LocalAddressProvider localAddressProvider,
       @Parameter(DefaultMemorySize.class) final int defaultMemorySize,
       @Parameter(DefaultNumberOfCores.class) final int defaultNumberOfCores) {
+
     this.capacity = capacity;
     this.defaultMemorySize = defaultMemorySize;
     this.defaultNumberOfCores = defaultNumberOfCores;
@@ -144,55 +137,61 @@ final class ContainerManager implements AutoCloseable {
     LOG.log(Level.FINE, "Initialized Container Manager with {0} containers", capacity);
   }
 
-  private Collection<String> normalize(final Collection<String> rackNames) {
+  private static Collection<String> normalize(final Collection<String> rackNames) {
     return normalize(rackNames, true);
   }
 
   /**
-   * Normalizes the rack names.
-   *
-   * @param rackNames
-   *          the rack names to normalize
-   * @param validateEnd
-   *          if true, throws an exception if the name ends with ANY (*)
-   * @return a normalized collection
+   * Normalize rack names.
+   * @param rackNames Collection of rack names to normalize.
+   * @param validateEnd If true, throw an exception if the name ends with ANY (*)
+   * @return Collection of normalized rack names.
    */
-  private Collection<String> normalize(final Collection<String> rackNames,
-      final boolean validateEnd) {
+  private static Collection<String> normalize(final Collection<String> rackNames, final boolean validateEnd) {
+
     final List<String> normalizedRackNames = new ArrayList<>(rackNames.size());
-    final Iterator<String> it = rackNames.iterator();
-    while (it.hasNext()) {
-      String rackName = it.next().trim();
+
+    for (String rackName : rackNames) {
+
+      rackName = rackName.trim();
       Validate.notEmpty(rackName, "Rack names cannot be empty");
+
       // should start with a separator
       if (!rackName.startsWith(Constants.RACK_PATH_SEPARATOR)) {
         rackName = Constants.RACK_PATH_SEPARATOR + rackName;
       }
+
       // remove the ending separator
       if (rackName.endsWith(Constants.RACK_PATH_SEPARATOR)) {
         rackName = rackName.substring(0, rackName.length() - 1);
       }
+
       if (validateEnd) {
         Validate.isTrue(!rackName.endsWith(Constants.ANY_RACK));
       }
+
       normalizedRackNames.add(rackName);
     }
+
     return normalizedRackNames;
   }
 
   private void init() {
+
     // evenly distribute the containers among the racks
     // if rack names are not specified, the default rack will be used, so the denominator will always be > 0
-    final int capacityPerRack = capacity / availableRacks.size();
-    int missing = capacity % availableRacks.size();
+    final int capacityPerRack = this.capacity / this.availableRacks.size();
+    int missing = this.capacity % this.availableRacks.size();
+
     // initialize the freeNodesPerRackList and the capacityPerRack
-    for (final String rackName : availableRacks) {
-      this.freeNodesPerRack.put(rackName, new HashMap<String, Boolean>());
-      this.capacitiesPerRack.put(rackName, capacityPerRack);
+    for (final String rackName : this.availableRacks) {
+      int currentCapacity = capacityPerRack;
       if (missing > 0) {
-        this.capacitiesPerRack.put(rackName, this.capacitiesPerRack.get(rackName) + 1);
-        missing--;
+        ++currentCapacity;
+        --missing;
       }
+      this.capacitiesPerRack.put(rackName, currentCapacity);
+      this.freeNodesPerRack.put(rackName, new HashMap<String, Boolean>());
     }
   }
 
@@ -226,29 +225,25 @@ final class ContainerManager implements AutoCloseable {
   }
 
   private Collection<String> getRackNamesOrDefault(final List<String> rackNames) {
-    return CollectionUtils.isNotEmpty(rackNames) ? normalize(rackNames, false)
-        : DEFAULT_RACKS;
+    return CollectionUtils.isNotEmpty(rackNames) ? normalize(rackNames, false) : DEFAULT_RACKS;
   }
 
-
   /**
-   * Returns the node name of the container to be allocated if it's available, selected from the list of preferred
-   * node names. If the list is empty, then an empty optional is returned
-   *
-   * @param nodeNames
-   *          the list of preferred nodes
-   * @return the node name where to allocate the container
+   * Returns the node name of the container to be allocated if it's available,
+   * selected from the list of preferred node names.
+   * If the list is empty, then an empty optional is returned.
+   * @param nodeNames the list of preferred nodes.
+   * @return the node name where to allocate the container.
    */
   private Optional<String> getPreferredNode(final List<String> nodeNames) {
-    if (CollectionUtils.isNotEmpty(nodeNames)) {
-      for (final String nodeName : nodeNames) {
-        final String possibleRack = racksPerNode.get(nodeName);
-        if (possibleRack != null
-            && freeNodesPerRack.get(possibleRack).containsKey(nodeName)) {
-          return Optional.of(nodeName);
-        }
+
+    for (final String nodeName : nodeNames) {
+      final String possibleRack = this.racksPerNode.get(nodeName);
+      if (possibleRack != null && this.freeNodesPerRack.get(possibleRack).containsKey(nodeName)) {
+        return Optional.of(nodeName);
       }
     }
+
     return Optional.empty();
   }
 
@@ -257,60 +252,57 @@ final class ContainerManager implements AutoCloseable {
    * preferred rack names. If the list is empty, and there's space in the default
    * rack, then the default rack is returned. The relax locality semantic is
    * enabled if the list of rack names contains '/*', otherwise relax locality
-   * is considered disabled
+   * is considered disabled.
    *
-   * @param rackNames
-   *          the list of preferred racks
-   * @return the rack name where to allocate the container
+   * @param rackNames the list of preferred racks.
+   * @return the rack name where to allocate the container.
    */
   private Optional<String> getPreferredRack(final List<String> rackNames) {
-    final Collection<String> normalized = getRackNamesOrDefault(rackNames);
-    for (final String rackName : normalized) {
-      // if it does not end with the any modifier,
-      // then we should do an exact match
+
+    for (final String rackName : getRackNamesOrDefault(rackNames)) {
+
+      // if it does not end with the any modifier, then we should do an exact match
       if (!rackName.endsWith(Constants.ANY_RACK)) {
-        if (freeNodesPerRack.containsKey(rackName)
-            && freeNodesPerRack.get(rackName).size() > 0) {
+        if (freeNodesPerRack.containsKey(rackName) && freeNodesPerRack.get(rackName).size() > 0) {
           return Optional.of(rackName);
         }
       } else {
+
         // if ends with the any modifier, we do a prefix match
-        final Iterator<String> it = availableRacks.iterator();
-        while (it.hasNext()) {
-          final String possibleRackName = it.next();
+        for (final String possibleRackName : this.availableRacks) {
+
           // remove the any modifier
-          final String newRackName = rackName.substring(0,
-              rackName.length() - 1);
+          final String newRackName = rackName.substring(0, rackName.length() - 1);
+
           if (possibleRackName.startsWith(newRackName) &&
-              freeNodesPerRack.get(possibleRackName).size() > 0) {
+              this.freeNodesPerRack.get(possibleRackName).size() > 0) {
             return Optional.of(possibleRackName);
           }
         }
       }
     }
+
     return Optional.empty();
   }
 
   /**
    * Allocates a container based on a request event. First it tries to match a
-   * given node, if it cannot, it tries to get a spot in a rack
-   *
-   * @param requestEvent
-   *          the request event
-   * @return an optional with the container if allocated
+   * given node, if it cannot, it tries to get a spot in a rack.
+   * @param requestEvent resource request event.
+   * @return an optional with the container if allocated.
    */
   Optional<Container> allocateContainer(final ResourceRequestEvent requestEvent) {
+
     Container container = null;
-    final Optional<String> nodeName = getPreferredNode(requestEvent
-        .getNodeNameList());
+    final Optional<String> nodeName = getPreferredNode(requestEvent.getNodeNameList());
+
     if (nodeName.isPresent()) {
       container = allocateBasedOnNode(
           requestEvent.getMemorySize().orElse(this.defaultMemorySize),
           requestEvent.getVirtualCores().orElse(this.defaultNumberOfCores),
           nodeName.get());
     } else {
-      final Optional<String> rackName = getPreferredRack(requestEvent
-          .getRackNameList());
+      final Optional<String> rackName = getPreferredRack(requestEvent.getRackNameList());
       if (rackName.isPresent()) {
         container = allocateBasedOnRack(
             requestEvent.getMemorySize().orElse(this.defaultMemorySize),
@@ -318,11 +310,11 @@ final class ContainerManager implements AutoCloseable {
             rackName.get());
       }
     }
+
     return Optional.ofNullable(container);
   }
 
-  private Container allocateBasedOnNode(final int megaBytes,
-      final int numberOfCores, final String nodeId) {
+  private Container allocateBasedOnNode(final int megaBytes, final int numberOfCores, final String nodeId) {
     synchronized (this.containers) {
       // get the rack name
       final String rackName = this.racksPerNode.get(nodeId);
@@ -333,38 +325,41 @@ final class ContainerManager implements AutoCloseable {
     }
   }
 
-  private Container allocateBasedOnRack(final int megaBytes,
-      final int numberOfCores, final String rackName) {
+  private Container allocateBasedOnRack(final int megaBytes, final int numberOfCores, final String rackName) {
     synchronized (this.containers) {
+
       // get the first free nodeId in the rack
-      final Set<String> freeNodes = this.freeNodesPerRack.get(rackName)
-          .keySet();
-      final Iterator<String> it = freeNodes.iterator();
+      final Iterator<String> it = this.freeNodesPerRack.get(rackName).keySet().iterator();
+
       if (!it.hasNext()) {
-        throw new IllegalArgumentException(
-            "There should be a free node in the specified rack " + rackName);
+        throw new IllegalArgumentException("There should be a free node in the specified rack " + rackName);
       }
+
       final String nodeId = it.next();
-      // remove it from the free map
-      this.freeNodesPerRack.get(rackName).remove(nodeId);
+      it.remove();
+
       // allocate
       return allocate(megaBytes, numberOfCores, nodeId, rackName);
     }
   }
 
-  private Container allocate(final int megaBytes, final int numberOfCores,
-      final String nodeId, final String rackName) {
-    final String processID = nodeId + "-"
-        + String.valueOf(System.currentTimeMillis());
+  private Container allocate(
+      final int megaBytes, final int numberOfCores, final String nodeId, final String rackName) {
+
+    final String processID = nodeId + "-" + String.valueOf(System.currentTimeMillis());
+
     final File processFolder = new File(this.rootFolder, processID);
     if (!processFolder.exists() && !processFolder.mkdirs()) {
       LOG.log(Level.WARNING, "Failed to create [{0}]", processFolder.getAbsolutePath());
     }
+
     final ProcessContainer container = new ProcessContainer(
         this.errorHandlerRID, nodeId, processID, processFolder, megaBytes,
         numberOfCores, rackName, this.fileNames, this.processObserver);
+
     this.containers.put(container.getContainerID(), container);
     LOG.log(Level.FINE, "Allocated {0}", container.getContainerID());
+
     return container;
   }
 
@@ -403,13 +398,12 @@ final class ContainerManager implements AutoCloseable {
       if (this.containers.isEmpty()) {
         LOG.log(Level.FINEST, "Clean shutdown with no outstanding containers.");
       } else {
-        LOG.log(Level.WARNING, "Dirty shutdown with outstanding containers.");
+        LOG.log(Level.WARNING, "Dirty shutdown with {0} outstanding containers.", this.containers.size());
         for (final Container c : this.containers.values()) {
-          LOG.log(Level.WARNING, "Force shutdown of: {0}", c);
+          LOG.log(Level.WARNING, "Force shutdown of container: {0}", c);
           c.close();
         }
       }
     }
   }
-
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -137,17 +137,31 @@ final class ContainerManager implements AutoCloseable {
     LOG.log(Level.FINE, "Initialized Container Manager with {0} containers", capacity);
   }
 
-  private static Collection<String> normalize(final Collection<String> rackNames) {
+  /**
+   * Normalize rack names. Make sure that each rack name starts with a path separator /
+   * and does not have a path separator at the end. Also check that no rack names
+   * end with a wildcard *, and raise an exception if such rack name occurs in the input.
+   * @param rackNames Collection of rack names to normalize.
+   * @return Collection of normalized rack names.
+   * @throws IllegalArgumentException if validation of some rack names' fails.
+   */
+  private static Collection<String> normalize(
+      final Collection<String> rackNames) throws IllegalArgumentException {
+
     return normalize(rackNames, true);
   }
 
   /**
-   * Normalize rack names.
+   * Normalize rack names. Make sure that each rack name starts with a path separator /
+   * and does not have a path separator at the end. Also, if end validation is on, check
+   * that rack name does not end with a wildcard *.
    * @param rackNames Collection of rack names to normalize.
    * @param validateEnd If true, throw an exception if the name ends with ANY (*)
    * @return Collection of normalized rack names.
+   * @throws IllegalArgumentException if validation of some rack names' fails.
    */
-  private static Collection<String> normalize(final Collection<String> rackNames, final boolean validateEnd) {
+  private static Collection<String> normalize(
+      final Collection<String> rackNames, final boolean validateEnd) throws IllegalArgumentException {
 
     final List<String> normalizedRackNames = new ArrayList<>(rackNames.size());
 

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -351,13 +351,16 @@ final class YarnContainerManager
     LOG.log(Level.FINE, "Stop Runtime: RM status {0}", this.resourceManager.getServiceState());
 
     if (this.resourceManager.getServiceState() == Service.STATE.STARTED) {
+
       // invariant: if RM is still running then we declare success.
       try {
+
         this.reefEventHandlers.close();
+
         if (exception == null) {
-          this.resourceManager.unregisterApplicationMaster(
-              FinalApplicationStatus.SUCCEEDED, null, null);
+          this.resourceManager.unregisterApplicationMaster(FinalApplicationStatus.SUCCEEDED, null, null);
         } else {
+
           // Note: We don't allow RM to restart our applications if it's an application level failure.
           // If applications are to be long-running, they should catch Exceptions before the REEF level
           // instead of relying on the RM restart mechanism.
@@ -365,8 +368,8 @@ final class YarnContainerManager
           // to leak to this stage.
           final String failureMsg = String.format("Application failed due to:%n%s%n" +
               "With stack trace:%n%s", exception.getMessage(), ExceptionUtils.getStackTrace(exception));
-          this.resourceManager.unregisterApplicationMaster(
-              FinalApplicationStatus.FAILED, failureMsg, null);
+
+          this.resourceManager.unregisterApplicationMaster(FinalApplicationStatus.FAILED, failureMsg, null);
         }
 
         this.resourceManager.close();
@@ -495,7 +498,7 @@ final class YarnContainerManager
       // Therefore it is necessary avoid sending zero-container request, even if it means getting extra containers.
       // It is okay to send nonzero m-capacity and n-capacity request together since bigger containers
       // can be matched.
-      // TODO [JIRA REEF-42, REEF-942]: revisit this when implementing locality-strictness.
+      // TODO[JIRA REEF-42, REEF-942]: revisit this when implementing locality-strictness.
       // (i.e. a specific rack request can be ignored)
       if (this.requestsAfterSentToRM.size() > 1) {
         try {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -45,7 +45,6 @@ import org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod;
 import org.apache.reef.tang.InjectionFuture;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.util.Optional;
-import org.apache.reef.wake.remote.Encoder;
 import org.apache.reef.wake.remote.impl.ObjectSerializableCodec;
 
 import javax.inject.Inject;
@@ -65,15 +64,12 @@ final class YarnContainerManager
   private static final String RUNTIME_NAME = "YARN";
 
   private final YarnClient yarnClient = YarnClient.createYarnClient();
-
   private final Queue<AMRMClient.ContainerRequest> requestsBeforeSentToRM = new ConcurrentLinkedQueue<>();
-
   private final Queue<AMRMClient.ContainerRequest> requestsAfterSentToRM = new ConcurrentLinkedQueue<>();
-
   private final Map<String, String> nodeIdToRackName = new ConcurrentHashMap<>();
 
   private final YarnConfiguration yarnConf;
-  private final AMRMClientAsync resourceManager;
+  private final AMRMClientAsync<AMRMClient.ContainerRequest> resourceManager;
   private final NMClientAsync nodeManager;
   private final REEFEventHandlers reefEventHandlers;
   private final Containers containers;
@@ -87,19 +83,20 @@ final class YarnContainerManager
   private final InjectionFuture<ProgressProvider> progressProvider;
 
   @Inject
-  YarnContainerManager(
-      final YarnConfiguration yarnConf,
+  private YarnContainerManager(
       @Parameter(YarnHeartbeatPeriod.class) final int yarnRMHeartbeatPeriod,
+      @Parameter(JobSubmissionDirectory.class) final String jobSubmissionDirectory,
+      final YarnConfiguration yarnConf,
       final REEFEventHandlers reefEventHandlers,
       final Containers containers,
       final ApplicationMasterRegistration registration,
       final ContainerRequestCounter containerRequestCounter,
       final DriverStatusManager driverStatusManager,
       final REEFFileNames reefFileNames,
-      @Parameter(JobSubmissionDirectory.class) final String jobSubmissionDirectory,
       final TrackingURLProvider trackingURLProvider,
       final RackNameFormatter rackNameFormatter,
       final InjectionFuture<ProgressProvider> progressProvider) throws IOException {
+
     this.reefEventHandlers = reefEventHandlers;
     this.driverStatusManager = driverStatusManager;
 
@@ -110,43 +107,56 @@ final class YarnContainerManager
     this.trackingURLProvider = trackingURLProvider;
     this.rackNameFormatter = rackNameFormatter;
 
-
     this.yarnClient.init(this.yarnConf);
 
     this.resourceManager = AMRMClientAsync.createAMRMClientAsync(yarnRMHeartbeatPeriod, this);
     this.nodeManager = new NMClientAsyncImpl(this);
+
     this.jobSubmissionDirectory = jobSubmissionDirectory;
     this.reefFileNames = reefFileNames;
     this.progressProvider = progressProvider;
+
     LOG.log(Level.FINEST, "Instantiated YarnContainerManager");
   }
 
-
+  /**
+   * RM Callback: RM reports some completed containers. Update status of each container in the list.
+   * @param completedContainers list of completed containers.
+   */
   @Override
-  public void onContainersCompleted(final List<ContainerStatus> containerStatuses) {
-    for (final ContainerStatus containerStatus : containerStatuses) {
-      onContainerStatus(containerStatus);
+  public void onContainersCompleted(final List<ContainerStatus> completedContainers) {
+    for (final ContainerStatus containerStatus : completedContainers) {
+      this.onContainerStatus(containerStatus);
     }
   }
 
+  /**
+   * RM Callback: RM reports that some containers have been allocated.
+   * @param allocatedContainers list of containers newly allocated by RM.
+   */
   @Override
-  @SuppressWarnings("checkstyle:hiddenfield")
-  public void onContainersAllocated(final List<Container> containers) {
+  public void onContainersAllocated(final List<Container> allocatedContainers) {
 
-    // ID is used for logging only
-    final String id = String.format("%s:%d",
-        Thread.currentThread().getName().replace(' ', '_'), System.currentTimeMillis());
+    String id = "NULL_ID"; // ID is used for logging only
 
-    LOG.log(Level.FINE, "TIME: Allocated Containers {0} {1} of {2}",
-        new Object[]{id, containers.size(), this.containerRequestCounter.get()});
+    if (LOG.isLoggable(Level.FINE)) {
 
-    for (final Container container : containers) {
-      handleNewContainer(container);
+      id = String.format("%s:%d", Thread.currentThread().getName().replace(' ', '_'), System.currentTimeMillis());
+
+      LOG.log(Level.FINE, "TIME: Allocated Containers {0} {1} of {2}",
+          new Object[] {id, allocatedContainers.size(), this.containerRequestCounter.get()});
+    }
+
+    for (final Container container : allocatedContainers) {
+      this.handleNewContainer(container);
     }
 
     LOG.log(Level.FINE, "TIME: Processed Containers {0}", id);
   }
 
+  /**
+   * RM Callback: RM requests application shutdown.
+   */
   @Override
   public void onShutdownRequest() {
     this.reefEventHandlers.onRuntimeStatus(RuntimeStatusEventImpl.newBuilder()
@@ -154,14 +164,23 @@ final class YarnContainerManager
     this.driverStatusManager.onError(new Exception("Shutdown requested by YARN."));
   }
 
+  /**
+   * RM Callback: RM reports status change of some nodes.
+   * @param nodeReports list of nodes with changed status.
+   */
   @Override
   public void onNodesUpdated(final List<NodeReport> nodeReports) {
     for (final NodeReport nodeReport : nodeReports) {
       this.nodeIdToRackName.put(nodeReport.getNodeId().toString(), nodeReport.getRackName());
-      onNodeReport(nodeReport);
+      this.onNodeReport(nodeReport);
     }
   }
 
+  /**
+   * RM Callback: Report application progress to RM.
+   * Progress is a floating point number between 0 and 1.
+   * @return a floating point number between 0 and 1.
+   */
   @Override
   public float getProgress() {
     try {
@@ -174,52 +193,81 @@ final class YarnContainerManager
     }
   }
 
+  /**
+   * RM Callback: RM reports an error.
+   * @param throwable An exception thrown from RM.
+   */
   @Override
   public void onError(final Throwable throwable) {
-    onRuntimeError(throwable);
+    this.onRuntimeError(throwable);
   }
 
+  /**
+   * NM Callback: NM reports start of a container.
+   * @param containerId ID of a newly started container.
+   * @param stringByteBufferMap currently not used.
+   */
   @Override
-  public void onContainerStarted(
-      final ContainerId containerId, final Map<String, ByteBuffer> stringByteBufferMap) {
+  public void onContainerStarted(final ContainerId containerId, final Map<String, ByteBuffer> stringByteBufferMap) {
     final Optional<Container> container = this.containers.getOptional(containerId.toString());
     if (container.isPresent()) {
       this.nodeManager.getContainerStatusAsync(containerId, container.get().getNodeId());
     }
   }
 
+  /**
+   * NM Callback: NM reports container status.
+   * @param containerId ID of a container with the status being reported.
+   * @param containerStatus YARN container status.
+   */
   @Override
-  public void onContainerStatusReceived(
-      final ContainerId containerId, final ContainerStatus containerStatus) {
+  public void onContainerStatusReceived(final ContainerId containerId, final ContainerStatus containerStatus) {
     onContainerStatus(containerStatus);
   }
 
+  /**
+   * NM Callback: NM reports stop of a container.
+   * @param containerId ID of a container stopped.
+   */
   @Override
   public void onContainerStopped(final ContainerId containerId) {
     final boolean hasContainer = this.containers.hasContainer(containerId.toString());
     if (hasContainer) {
-      final ResourceStatusEventImpl.Builder resourceStatusBuilder =
-          ResourceStatusEventImpl.newBuilder().setIdentifier(containerId.toString());
-      resourceStatusBuilder.setState(State.DONE);
-      this.reefEventHandlers.onResourceStatus(resourceStatusBuilder.build());
+      this.reefEventHandlers.onResourceStatus(
+          ResourceStatusEventImpl.newBuilder()
+             .setIdentifier(containerId.toString())
+             .setState(State.DONE)
+             .build());
     }
   }
 
+  /**
+   * NM Callback: NM reports failure on container start.
+   * @param containerId ID of a container that has failed to start.
+   * @param throwable An error that caused container to fail.
+   */
   @Override
-  public void onStartContainerError(
-      final ContainerId containerId, final Throwable throwable) {
-    handleContainerError(containerId, throwable);
+  public void onStartContainerError(final ContainerId containerId, final Throwable throwable) {
+    this.handleContainerError(containerId, throwable);
   }
 
+  /**
+   * NM Callback: NM can not obtain status of the container.
+   * @param containerId ID of a container that failed to report its status.
+   * @param throwable An error that occured when querying status of a container.
+   */
   @Override
-  public void onGetContainerStatusError(
-      final ContainerId containerId, final Throwable throwable) {
-    handleContainerError(containerId, throwable);
+  public void onGetContainerStatusError(final ContainerId containerId, final Throwable throwable) {
+    this.handleContainerError(containerId, throwable);
   }
 
+  /**
+   * NM Callback: NM fails to stop the container.
+   * @param containerId ID of the container that failed to stop.
+   * @param throwable An error that occurred when trying to stop the container.
+   */
   @Override
-  public void onStopContainerError(
-      final ContainerId containerId, final Throwable throwable) {
+  public void onStopContainerError(final ContainerId containerId, final Throwable throwable) {
     handleContainerError(containerId, throwable);
   }
 
@@ -250,11 +298,17 @@ final class YarnContainerManager
     updateRuntimeStatus();
   }
 
+  /**
+   * Start the YARN container manager.
+   * This method is called from DriverRuntimeStartHandler via YARNRuntimeStartHandler.
+   */
   void onStart() {
 
     this.yarnClient.start();
+
     this.resourceManager.init(this.yarnConf);
     this.resourceManager.start();
+
     this.nodeManager.init(this.yarnConf);
     this.nodeManager.start();
 
@@ -268,21 +322,30 @@ final class YarnContainerManager
     }
 
     try {
-      this.registration.setRegistration(this.resourceManager.registerApplicationMaster(
-          "", 0, this.trackingURLProvider.getTrackingUrl()));
-      LOG.log(Level.FINE, "YARN registration: {0}", registration);
+
+      this.registration.setRegistration(
+          this.resourceManager.registerApplicationMaster("", 0, this.trackingURLProvider.getTrackingUrl()));
+
+      LOG.log(Level.FINE, "YARN registration: {0}", this.registration);
+
       final FileSystem fs = FileSystem.get(this.yarnConf);
       final Path outputFileName = new Path(this.jobSubmissionDirectory, this.reefFileNames.getDriverHttpEndpoint());
-      final FSDataOutputStream out = fs.create(outputFileName);
-      out.writeBytes(this.trackingURLProvider.getTrackingUrl() + "\n");
-      out.flush();
-      out.close();
+
+      try (final FSDataOutputStream out = fs.create(outputFileName)) {
+        out.writeBytes(this.trackingURLProvider.getTrackingUrl() + '\n');
+      }
+
     } catch (final YarnException | IOException e) {
       LOG.log(Level.WARNING, "Unable to register application master.", e);
       onRuntimeError(e);
     }
   }
 
+  /**
+   * Shut down YARN container manager.
+   * This method is called from DriverRuntimeStopHandler via YARNRuntimeStopHandler.
+   * @param exception Exception that caused driver to stop. Can be null if there was no error.
+   */
   void onStop(final Throwable exception) {
 
     LOG.log(Level.FINE, "Stop Runtime: RM status {0}", this.resourceManager.getServiceState());
@@ -325,7 +388,9 @@ final class YarnContainerManager
   // HELPER METHODS
 
   private void onNodeReport(final NodeReport nodeReport) {
+
     LOG.log(Level.FINE, "Send node descriptor: {0}", nodeReport);
+
     this.reefEventHandlers.onNodeDescriptor(NodeDescriptorEventImpl.newBuilder()
         .setIdentifier(nodeReport.getNodeId().toString())
         .setHostName(nodeReport.getNodeId().getHost())
@@ -337,19 +402,17 @@ final class YarnContainerManager
 
   private void handleContainerError(final ContainerId containerId, final Throwable throwable) {
 
-    final ResourceStatusEventImpl.Builder resourceStatusBuilder =
-        ResourceStatusEventImpl.newBuilder().setIdentifier(containerId.toString());
-
-    resourceStatusBuilder.setState(State.FAILED);
-    resourceStatusBuilder.setExitCode(1);
-    resourceStatusBuilder.setDiagnostics(throwable.getMessage());
-    this.reefEventHandlers.onResourceStatus(resourceStatusBuilder.build());
+    this.reefEventHandlers.onResourceStatus(ResourceStatusEventImpl.newBuilder()
+        .setIdentifier(containerId.toString())
+        .setState(State.FAILED)
+        .setExitCode(1)
+        .setDiagnostics(throwable.getMessage())
+        .build());
   }
 
   /**
    * Handles container status reports. Calls come from YARN.
-   *
-   * @param value containing the container status
+   * @param value containing the container status.
    */
   private void onContainerStatus(final ContainerStatus value) {
 
@@ -387,7 +450,7 @@ final class YarnContainerManager
         status.setDiagnostics(value.getDiagnostics());
       }
 
-      // The ResourceStatusHandler should close and release the Evaluator for us if the state is a terminal state.
+      // ResourceStatusHandler should close and release the Evaluator for us if the state is a terminal state.
       this.reefEventHandlers.onResourceStatus(status.build());
     }
   }
@@ -397,7 +460,7 @@ final class YarnContainerManager
     synchronized (this) {
       this.containerRequestCounter.incrementBy(containerRequests.length);
       this.requestsBeforeSentToRM.addAll(Arrays.asList(containerRequests));
-      doHomogeneousRequests();
+      this.doHomogeneousRequests();
     }
 
     this.updateRuntimeStatus();
@@ -405,55 +468,60 @@ final class YarnContainerManager
 
   /**
    * Handles new container allocations. Calls come from YARN.
-   *
-   * @param container newly allocated
+   * @param container newly allocated YARN container.
    */
   private void handleNewContainer(final Container container) {
 
     LOG.log(Level.FINE, "allocated container: id[ {0} ]", container.getId());
+
     synchronized (this) {
-      if (matchContainerWithPendingRequest(container)) {
-        final AMRMClient.ContainerRequest matchedRequest = this.requestsAfterSentToRM.peek();
-        this.containerRequestCounter.decrement();
-        this.containers.add(container);
 
-        LOG.log(Level.FINEST, "{0} matched with {1}", new Object[]{container.toString(), matchedRequest.toString()});
-
-        // Due to the bug YARN-314 and the workings of AMRMCClientAsync, when x-priority m-capacity zero-container
-        // request and x-priority n-capacity nonzero-container request are sent together, where m > n, RM ignores
-        // the latter.
-        // Therefore it is necessary avoid sending zero-container request, even it means getting extra containers.
-        // It is okay to send nonzero m-capacity and n-capacity request together since bigger containers
-        // can be matched.
-        // TODO[JIRA REEF-42, REEF-942]: revisit this when implementing locality-strictness
-        // (i.e. a specific rack request can be ignored)
-        if (this.requestsAfterSentToRM.size() > 1) {
-          try {
-            this.resourceManager.removeContainerRequest(matchedRequest);
-          } catch (final Exception e) {
-            LOG.log(Level.WARNING, "Nothing to remove from Async AMRM client's queue, " +
-                "removal attempt failed with exception", e);
-          }
-        }
-
-        this.requestsAfterSentToRM.remove();
-        doHomogeneousRequests();
-
-        LOG.log(Level.FINEST, "Allocated Container: memory = {0}, core number = {1}",
-            new Object[]{container.getResource().getMemory(), container.getResource().getVirtualCores()});
-        this.reefEventHandlers.onResourceAllocation(ResourceEventImpl.newAllocationBuilder()
-            .setIdentifier(container.getId().toString())
-            .setNodeId(container.getNodeId().toString())
-            .setResourceMemory(container.getResource().getMemory())
-            .setVirtualCores(container.getResource().getVirtualCores())
-            .setRackName(rackNameFormatter.getRackName(container))
-            .setRuntimeName(RuntimeIdentifier.RUNTIME_NAME)
-            .build());
-        this.updateRuntimeStatus();
-      } else {
+      if (!matchContainerWithPendingRequest(container)) {
         LOG.log(Level.WARNING, "Got an extra container {0} that doesn't match, releasing...", container.getId());
         this.resourceManager.releaseAssignedContainer(container.getId());
+        return;
       }
+
+      final AMRMClient.ContainerRequest matchedRequest = this.requestsAfterSentToRM.peek();
+
+      this.containerRequestCounter.decrement();
+      this.containers.add(container);
+
+      LOG.log(Level.FINEST, "{0} matched with {1}", new Object[] {container, matchedRequest});
+
+      // Due to the bug YARN-314 and the workings of AMRMCClientAsync, when x-priority m-capacity zero-container
+      // request and x-priority n-capacity nonzero-container request are sent together, where m > n, RM ignores
+      // the latter.
+      // Therefore it is necessary avoid sending zero-container request, even it means getting extra containers.
+      // It is okay to send nonzero m-capacity and n-capacity request together since bigger containers
+      // can be matched.
+      // TODO[JIRA REEF-42, REEF-942]: revisit this when implementing locality-strictness
+      // (i.e. a specific rack request can be ignored)
+      if (this.requestsAfterSentToRM.size() > 1) {
+        try {
+          this.resourceManager.removeContainerRequest(matchedRequest);
+        } catch (final Exception e) {
+          LOG.log(Level.WARNING, "Nothing to remove from Async AMRM client's queue, " +
+              "removal attempt failed with exception", e);
+        }
+      }
+
+      this.requestsAfterSentToRM.remove();
+      this.doHomogeneousRequests();
+
+      LOG.log(Level.FINEST, "Allocated Container: memory = {0}, core number = {1}",
+          new Object[] {container.getResource().getMemory(), container.getResource().getVirtualCores()});
+
+      this.reefEventHandlers.onResourceAllocation(ResourceEventImpl.newAllocationBuilder()
+          .setIdentifier(container.getId().toString())
+          .setNodeId(container.getNodeId().toString())
+          .setResourceMemory(container.getResource().getMemory())
+          .setVirtualCores(container.getResource().getVirtualCores())
+          .setRackName(rackNameFormatter.getRackName(container))
+          .setRuntimeName(RuntimeIdentifier.RUNTIME_NAME)
+          .build());
+
+      this.updateRuntimeStatus();
     }
   }
 
@@ -484,15 +552,19 @@ final class YarnContainerManager
    * up the allocation and in placing containers on other machines.
    */
   private boolean matchContainerWithPendingRequest(final Container container) {
+
     if (this.requestsAfterSentToRM.isEmpty()) {
       return false;
     }
 
     final AMRMClient.ContainerRequest request = this.requestsAfterSentToRM.peek();
+
     final boolean resourceCondition = container.getResource().getMemory() >= request.getCapability().getMemory();
+
     // TODO[JIRA REEF-35]: check vcores once YARN-2380 is resolved
     final boolean nodeCondition = request.getNodes() == null
         || request.getNodes().contains(container.getNodeId().getHost());
+
     final boolean rackCondition = request.getRacks() == null
         || request.getRacks().contains(this.nodeIdToRackName.get(container.getNodeId().toString()));
 
@@ -504,11 +576,10 @@ final class YarnContainerManager
    */
   private void updateRuntimeStatus() {
 
-    final RuntimeStatusEventImpl.Builder builder =
-        RuntimeStatusEventImpl.newBuilder()
-            .setName(RUNTIME_NAME)
-            .setState(State.RUNNING)
-            .setOutstandingContainerRequests(this.containerRequestCounter.get());
+    final RuntimeStatusEventImpl.Builder builder = RuntimeStatusEventImpl.newBuilder()
+        .setName(RUNTIME_NAME)
+        .setState(State.RUNNING)
+        .setOutstandingContainerRequests(this.containerRequestCounter.get());
 
     for (final String allocatedContainerId : this.containers.getContainerIds()) {
       builder.addContainerAllocation(allocatedContainerId);
@@ -522,26 +593,25 @@ final class YarnContainerManager
     // SHUTDOWN YARN
     try {
       this.reefEventHandlers.close();
-      this.resourceManager.unregisterApplicationMaster(
-          FinalApplicationStatus.FAILED, throwable.getMessage(), null);
+      this.resourceManager.unregisterApplicationMaster(FinalApplicationStatus.FAILED, throwable.getMessage(), null);
     } catch (final Exception e) {
       LOG.log(Level.WARNING, "Error shutting down YARN application", e);
     } finally {
       this.resourceManager.stop();
     }
 
-    final RuntimeStatusEventImpl.Builder runtimeStatusBuilder = RuntimeStatusEventImpl.newBuilder()
-        .setState(State.FAILED)
-        .setName(RUNTIME_NAME);
+    final ReefServiceProtos.RuntimeErrorProto runtimeError =
+        ReefServiceProtos.RuntimeErrorProto.newBuilder()
+            .setName(RUNTIME_NAME)
+            .setMessage(throwable.getMessage())
+            .setException(ByteString.copyFrom(new ObjectSerializableCodec<>().encode(throwable)))
+            .build();
 
-    final Encoder<Throwable> codec = new ObjectSerializableCodec<>();
-    runtimeStatusBuilder.setError(ReefServiceProtos.RuntimeErrorProto.newBuilder()
-        .setName(RUNTIME_NAME)
-        .setMessage(throwable.getMessage())
-        .setException(ByteString.copyFrom(codec.encode(throwable)))
-        .build())
-        .build();
-
-    this.reefEventHandlers.onRuntimeStatus(runtimeStatusBuilder.build());
+    this.reefEventHandlers.onRuntimeStatus(
+        RuntimeStatusEventImpl.newBuilder()
+            .setState(State.FAILED)
+            .setName(RUNTIME_NAME)
+            .setError(runtimeError)
+            .build());
   }
 }

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -137,7 +137,7 @@ final class YarnContainerManager
   @Override
   public void onContainersAllocated(final List<Container> allocatedContainers) {
 
-    String id = "NULL_ID"; // ID is used for logging only
+    String id = null; // ID is used for logging only
 
     if (LOG.isLoggable(Level.FINE)) {
 
@@ -203,9 +203,9 @@ final class YarnContainerManager
   }
 
   /**
-   * NM Callback: NM reports start of a container.
-   * @param containerId ID of a newly started container.
-   * @param stringByteBufferMap currently not used.
+   * NM Callback: NM accepts the starting container request.
+   * @param containerId ID of a new container being started.
+   * @param stringByteBufferMap a Map between the auxiliary service names and their outputs. Not used.
    */
   @Override
   public void onContainerStarted(final ContainerId containerId, final Map<String, ByteBuffer> stringByteBufferMap) {
@@ -492,17 +492,16 @@ final class YarnContainerManager
       // Due to the bug YARN-314 and the workings of AMRMCClientAsync, when x-priority m-capacity zero-container
       // request and x-priority n-capacity nonzero-container request are sent together, where m > n, RM ignores
       // the latter.
-      // Therefore it is necessary avoid sending zero-container request, even it means getting extra containers.
+      // Therefore it is necessary avoid sending zero-container request, even if it means getting extra containers.
       // It is okay to send nonzero m-capacity and n-capacity request together since bigger containers
       // can be matched.
-      // TODO[JIRA REEF-42, REEF-942]: revisit this when implementing locality-strictness
+      // TODO [JIRA REEF-42, REEF-942]: revisit this when implementing locality-strictness.
       // (i.e. a specific rack request can be ignored)
       if (this.requestsAfterSentToRM.size() > 1) {
         try {
           this.resourceManager.removeContainerRequest(matchedRequest);
         } catch (final Exception e) {
-          LOG.log(Level.WARNING, "Nothing to remove from Async AMRM client's queue, " +
-              "removal attempt failed with exception", e);
+          LOG.log(Level.WARNING, "Error removing request from Async AMRM client queue: " + matchedRequest, e);
         }
       }
 


### PR DESCRIPTION
There are virtually no changes in logic - all edits are about code readability, more idiomatic Java, and more javadoc comments.

Summary of changes:

  * Cosmetic changes + extra javadocs and comments in `DriverRuntimeStartHandler`
  * refactor `DriverStatusManager` for readability.
  * Add javadocs and deprecate the `.sendJobEndingMessageToClient()` method. No changes in the logic.
  * cosmetic changes in `DriverRuntimeStopHandler` for readability;
  * add public method `DriverStatusManager.onRuntimeStop()` to use in favor of deprecated `.sendJobEndingMessageToClient()`
  * cosmetic changes for readability + javadocs in `ResourceManagerStatus` class
  * cosmetic changes for code readability in `YarnContainerManager`
  * add javadocs to `YarnContainerManager`
  * refactor local `ContainerManager` for readability + use more idiomatic java. No changes in functionality
  * more cosmetic changes to `ContainerManager`
  * cosmetic cleanups in `RuntimesHost` code. No changes in logic

JIRA: [REEF-1555](https://issues.apache.org/jira/browse/REEF-1555)