### PR TITLE
[REEF-1556] Adding allowed failure number for IMRU fault tolerant tes…

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/PipelinedBroadcastReduce/FaultTolerantPipelinedBroadcastAndReduce.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/PipelinedBroadcastReduce/FaultTolerantPipelinedBroadcastAndReduce.cs
@@ -50,7 +50,7 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
         internal void Run(int numberofMappers, int chunkSize, int numIterations, int dim, int mapperMemory, int updateTaskMemory, int maxRetryNumberInRecovery, int totalNumberOfForcedFailures)
         {
             var results = _imruClient.Submit<int[], int[], int[], Stream>(
-                BuildJobDefinationBuilder(numberofMappers, chunkSize, numIterations, dim, mapperMemory, updateTaskMemory)
+                CreateJobDefinationBuilder(numberofMappers, chunkSize, numIterations, dim, mapperMemory, updateTaskMemory)
                     .SetMapFunctionConfiguration(BuildMapperFunctionConfig(maxRetryNumberInRecovery, totalNumberOfForcedFailures))
                     .SetMaxRetryNumberInRecovery(maxRetryNumberInRecovery)
                     .Build());

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/PipelinedBroadcastReduce/FaultTolerantPipelinedBroadcastAndReduce.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/PipelinedBroadcastReduce/FaultTolerantPipelinedBroadcastAndReduce.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.IMRU.API;
@@ -34,21 +35,45 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
     /// <summary>
     /// IMRU program that performs broadcast and reduce with fault tolerance.
     /// </summary>
-    public class FaultTolerantPipelinedBroadcastAndReduce : PipelinedBroadcastAndReduce
+    public sealed class FaultTolerantPipelinedBroadcastAndReduce : PipelinedBroadcastAndReduce
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(FaultTolerantPipelinedBroadcastAndReduce));
 
         [Inject]
-        protected FaultTolerantPipelinedBroadcastAndReduce(IIMRUClient imruClient) : base(imruClient)
+        private FaultTolerantPipelinedBroadcastAndReduce(IIMRUClient imruClient) : base(imruClient)
         {
         }
-        
+
+        /// <summary>
+        /// Runs the actual broadcast and reduce job with fault tolerance
+        /// </summary>
+        internal void Run(int numberofMappers, int chunkSize, int numIterations, int dim, int mapperMemory, int updateTaskMemory, int maxRetryNumberInRecovery, int totalAllowedFailurNumber)
+        {
+            var results = ImruClient.Submit<int[], int[], int[], Stream>(
+                new IMRUJobDefinitionBuilder()
+                    .SetMapFunctionConfiguration(BuildMapperFunctionConfig(maxRetryNumberInRecovery, totalAllowedFailurNumber))
+                    .SetUpdateFunctionConfiguration(UpdateFunctionConfig(numberofMappers, numIterations, dim))
+                    .SetMapInputCodecConfiguration(MapInputCodecConfiguration())
+                    .SetUpdateFunctionCodecsConfiguration(UpdateFunctionCodecsConfiguration())
+                    .SetReduceFunctionConfiguration(ReduceFunctionConfiguration())
+                    .SetMapInputPipelineDataConverterConfiguration(MapInputDataConverterConfig(chunkSize))
+                    .SetMapOutputPipelineDataConverterConfiguration(MapOutputDataConverterConfig(chunkSize))
+                    .SetPartitionedDatasetConfiguration(PartitionedDatasetConfiguration(numberofMappers))
+                    .SetJobName("BroadcastReduce")
+                    .SetNumberOfMappers(numberofMappers)
+                    .SetMapperMemory(mapperMemory)
+                    .SetMaxRetryNumberInRecovery(maxRetryNumberInRecovery)
+                    .SetUpdateTaskMemory(updateTaskMemory)
+                    .Build());
+        }
+
         /// <summary>
         /// Build a test mapper function configuration
         /// </summary>
         /// <param name="maxRetryInRecovery">Number of retries done if first run failed.</param>
+        /// <param name="totalAllowedFailures">Number of allowed failure times in recovery.</param>
         /// <returns></returns>
-        protected override IConfiguration BuildMapperFunctionConfig(int maxRetryInRecovery)
+        private static IConfiguration BuildMapperFunctionConfig(int maxRetryInRecovery, int totalAllowedFailures)
         {
             var c1 = IMRUMapConfiguration<int[], int[]>.ConfigurationModule
                 .Set(IMRUMapConfiguration<int[], int[]>.MapFunction,
@@ -60,18 +85,19 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
                 .BindSetEntry<TaskIdsToFail, string>(GenericType<TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-3-")
                 .BindIntNamedParam<FailureType>(FailureType.EvaluatorFailureDuringTaskExecution.ToString())
                 .BindNamedParameter(typeof(MaxRetryNumberInRecovery), maxRetryInRecovery.ToString())
+                .BindNamedParameter(typeof(TotalNumberOfAllowedFailures), totalAllowedFailures.ToString())
                 .Build();
 
             return Configurations.Merge(c1, c2);
         }
 
         [NamedParameter(Documentation = "Set of task ids which will produce task/evaluator failure")]
-        public class TaskIdsToFail : Name<ISet<string>>
+        internal class TaskIdsToFail : Name<ISet<string>>
         {
         }
 
         [NamedParameter(Documentation = "Type of failure to simulate")]
-        public class FailureType : Name<int>
+        internal class FailureType : Name<int>
         {
             internal static readonly int EvaluatorFailureDuringTaskExecution = 0;
             internal static readonly int TaskFailureDuringTaskExecution = 1;
@@ -85,35 +111,54 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
             }
         }
 
+        [NamedParameter(Documentation = "Total number of failures in recovery.", DefaultValue = "2")]
+        internal class TotalNumberOfAllowedFailures : Name<int>
+        {
+        }
+
         /// <summary>
         /// The function is to simulate Evaluator/Task failure for mapper evaluator
         /// </summary>
-        public sealed class TestSenderMapFunction : IMapFunction<int[], int[]>
+        internal sealed class TestSenderMapFunction : IMapFunction<int[], int[]>
         {
             private int _iterations;
             private readonly string _taskId;
             private readonly ISet<string> _taskIdsToFail;
-            private int _failureType;
+            private readonly int _failureType;
             private readonly int _maxRetryInRecovery;
+            private readonly int _totalNumberOfAllowedFailurs;
+            private readonly int _numberOfRetry = 0;
 
             [Inject]
             private TestSenderMapFunction(
                 [Parameter(typeof(TaskConfigurationOptions.Identifier))] string taskId,
                 [Parameter(typeof(TaskIdsToFail))] ISet<string> taskIdsToFail,
                 [Parameter(typeof(FailureType))] int failureType,
-                [Parameter(typeof(MaxRetryNumberInRecovery))] int maxRetryNumberInRecovery)
+                [Parameter(typeof(MaxRetryNumberInRecovery))] int maxRetryNumberInRecovery,
+                [Parameter(typeof(TotalNumberOfAllowedFailures))] int totalNumberOfAllowedFailurs)
             {
                 _taskId = taskId;
                 _taskIdsToFail = taskIdsToFail;
                 _failureType = failureType;
                 _maxRetryInRecovery = maxRetryNumberInRecovery;
-                Logger.Log(Level.Info, "TestSenderMapFunction: TaskId: {0}, _maxRetryInRecovery {1},  Failure type: {2}.", _taskId, _maxRetryInRecovery, _failureType);
+                _totalNumberOfAllowedFailurs = totalNumberOfAllowedFailurs;
+
+                var taskIdSplit = taskId.Split('-');
+                _numberOfRetry = int.Parse(taskIdSplit[taskIdSplit.Length - 1]);
+
+                Logger.Log(Level.Info,
+                    "TestSenderMapFunction: TaskId: {0}, _maxRetryInRecovery {1}, totalNumberOfAllowedFailurs: {2}, RetryNumber: {3}, Failure type: {4}.",
+                    _taskId,
+                    _maxRetryInRecovery,
+                    _totalNumberOfAllowedFailurs,
+                    _numberOfRetry,
+                    _failureType);
                 foreach (var n in _taskIdsToFail)
                 {
                     Logger.Log(Level.Info, "TestSenderMapFunction: taskIdsToFail: {0}", n);
                 }
 
-                if (_failureType == FailureType.EvaluatorFailureDuringTaskInitialization || 
+                if (_failureType == FailureType.EvaluatorFailureDuringTaskInitialization ||
                     _failureType == FailureType.TaskFailureDuringTaskInitialization)
                 {
                     SimulateFailure(0);
@@ -138,7 +183,10 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
 
                 if (mapInput[0] != _iterations)
                 {
-                    Exceptions.Throw(new Exception("Expected value in mappers (" + _iterations + ") different from actual value (" + mapInput[0] + ")"), Logger);
+                    Exceptions.Throw(
+                        new Exception("Expected value in mappers (" + _iterations + ") different from actual value (" +
+                                      mapInput[0] + ")"),
+                        Logger);
                 }
 
                 return mapInput;
@@ -148,9 +196,11 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
             {
                 if (_iterations == onIteration &&
                     _taskIdsToFail.FirstOrDefault(e => _taskId.StartsWith(e)) != null &&
-                    _taskIdsToFail.FirstOrDefault(e => _taskId.Equals(e + _maxRetryInRecovery)) == null)
+                    _taskIdsToFail.FirstOrDefault(e => _taskId.Equals(e + _maxRetryInRecovery)) == null &&
+                    _numberOfRetry < _totalNumberOfAllowedFailurs)
                 {
-                    Logger.Log(Level.Warning, "Simulating {0} failure for taskId {1}",
+                    Logger.Log(Level.Warning,
+                        "Simulating {0} failure for taskId {1}",
                         FailureType.IsEvaluatorFailure(_failureType) ? "evaluator" : "task",
                         _taskId);
                     if (FailureType.IsEvaluatorFailure(_failureType))

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/PipelinedBroadcastReduce/PipelinedBroadcastAndReduce.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/PipelinedBroadcastReduce/PipelinedBroadcastAndReduce.cs
@@ -32,12 +32,12 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
     /// </summary>
     public class PipelinedBroadcastAndReduce
     {
-        protected readonly IIMRUClient ImruClient;
+        protected readonly IIMRUClient _imruClient;
 
         [Inject]
         protected PipelinedBroadcastAndReduce(IIMRUClient imruClient)
         {
-            ImruClient = imruClient;
+            _imruClient = imruClient;
         }
 
         /// <summary>
@@ -45,10 +45,16 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
         /// </summary>
         internal void Run(int numberofMappers, int chunkSize, int numIterations, int dim, int mapperMemory, int updateTaskMemory)
         {
-            var results = ImruClient.Submit<int[], int[], int[], Stream>(
-                new IMRUJobDefinitionBuilder()
+            var results = _imruClient.Submit<int[], int[], int[], Stream>(
+                BuildJobDefinationBuilder(numberofMappers, chunkSize, numIterations, dim, mapperMemory, updateTaskMemory)
                     .SetMapFunctionConfiguration(BuildMapperFunctionConfig())
-                    .SetUpdateFunctionConfiguration(UpdateFunctionConfig(numberofMappers, numIterations, dim))
+                    .Build());
+        }
+
+        protected IMRUJobDefinitionBuilder BuildJobDefinationBuilder(int numberofMappers, int chunkSize, int numIterations, int dim, int mapperMemory, int updateTaskMemory)
+        {
+            return new IMRUJobDefinitionBuilder()
+                    .SetMapFunctionConfiguration(BuildMapperFunctionConfig())
                     .SetMapInputCodecConfiguration(MapInputCodecConfiguration())
                     .SetUpdateFunctionCodecsConfiguration(UpdateFunctionCodecsConfiguration())
                     .SetReduceFunctionConfiguration(ReduceFunctionConfiguration())
@@ -58,14 +64,12 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
                     .SetJobName("BroadcastReduce")
                     .SetNumberOfMappers(numberofMappers)
                     .SetMapperMemory(mapperMemory)
-                    .SetUpdateTaskMemory(updateTaskMemory)
-                    .Build());
+                    .SetUpdateTaskMemory(updateTaskMemory);
         }
 
         /// <summary>
         /// Configuration for Partitioned Dataset
         /// </summary>
-        /// <param name="numberofMappers"></param>
         /// <returns></returns>
         protected static IConfiguration PartitionedDatasetConfiguration(int numberofMappers)
         {

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/PipelinedBroadcastReduce/PipelinedBroadcastAndReduce.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/PipelinedBroadcastReduce/PipelinedBroadcastAndReduce.cs
@@ -46,15 +46,15 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
         internal void Run(int numberofMappers, int chunkSize, int numIterations, int dim, int mapperMemory, int updateTaskMemory)
         {
             var results = _imruClient.Submit<int[], int[], int[], Stream>(
-                BuildJobDefinationBuilder(numberofMappers, chunkSize, numIterations, dim, mapperMemory, updateTaskMemory)
+                CreateJobDefinationBuilder(numberofMappers, chunkSize, numIterations, dim, mapperMemory, updateTaskMemory)
                     .SetMapFunctionConfiguration(BuildMapperFunctionConfig())
                     .Build());
         }
 
-        protected IMRUJobDefinitionBuilder BuildJobDefinationBuilder(int numberofMappers, int chunkSize, int numIterations, int dim, int mapperMemory, int updateTaskMemory)
+        protected IMRUJobDefinitionBuilder CreateJobDefinationBuilder(int numberofMappers, int chunkSize, int numIterations, int dim, int mapperMemory, int updateTaskMemory)
         {
             return new IMRUJobDefinitionBuilder()
-                    .SetMapFunctionConfiguration(BuildMapperFunctionConfig())
+                    .SetUpdateFunctionConfiguration(UpdateFunctionConfig(numberofMappers, numIterations, dim))
                     .SetMapInputCodecConfiguration(MapInputCodecConfiguration())
                     .SetUpdateFunctionCodecsConfiguration(UpdateFunctionCodecsConfiguration())
                     .SetReduceFunctionConfiguration(ReduceFunctionConfiguration())

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
@@ -66,7 +66,7 @@ namespace Org.Apache.REEF.IMRU.Examples
             int mapperMemory = 512;
             int updateTaskMemory = 512;
             int maxRetryNumberInRecovery = 2;
-            int totalAllowedFailureNumberInRecovery = 2;
+            int totalNumberOfForcedFailures = 2;
 
             if (args.Length > 0)
             {
@@ -100,7 +100,7 @@ namespace Org.Apache.REEF.IMRU.Examples
 
             if (args.Length > 6)
             {
-                totalAllowedFailureNumberInRecovery = Convert.ToInt32(args[6]);
+                totalNumberOfForcedFailures = Convert.ToInt32(args[6]);
             }
 
             IInjector injector;
@@ -120,7 +120,7 @@ namespace Org.Apache.REEF.IMRU.Examples
             if (faultTolerant)
             {
                 var broadcastReduceFtExample = injector.GetInstance<FaultTolerantPipelinedBroadcastAndReduce>();
-                broadcastReduceFtExample.Run(numNodes - 1, chunkSize, iterations, dims, mapperMemory, updateTaskMemory, maxRetryNumberInRecovery, totalAllowedFailureNumberInRecovery);
+                broadcastReduceFtExample.Run(numNodes - 1, chunkSize, iterations, dims, mapperMemory, updateTaskMemory, maxRetryNumberInRecovery, totalNumberOfForcedFailures);
             }
             else
             {
@@ -133,8 +133,8 @@ namespace Org.Apache.REEF.IMRU.Examples
         /// Run IMRU examples from command line
         /// </summary>
         /// Sample command line:  
-        /// .\Org.Apache.REEF.IMRU.Examples.exe true 500 8900 1000 broadcastandreduce 20000000 1000000 1024 1024 10 2
-        /// .\Org.Apache.REEF.IMRU.Examples.exe true 500 8900 1000 broadcastandreduceft 20000000 1000000 1024 1024 100 2
+        /// .\Org.Apache.REEF.IMRU.Examples.exe true 500 8900 1000 broadcastandreduce 20000000 1000000 1024 1024 10
+        /// .\Org.Apache.REEF.IMRU.Examples.exe true 500 8900 1000 broadcastandreduceft 20000000 1000000 1024 1024 100 5 2
         /// <param name="args"></param>
         private static void Main(string[] args)
         {

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
@@ -65,7 +65,8 @@ namespace Org.Apache.REEF.IMRU.Examples
             int iterations = 100;
             int mapperMemory = 512;
             int updateTaskMemory = 512;
-            int maxRetryNumberInRecovery = 2;         
+            int maxRetryNumberInRecovery = 2;
+            int totalAllowedFailureNumberInRecovery = 2;
 
             if (args.Length > 0)
             {
@@ -97,6 +98,11 @@ namespace Org.Apache.REEF.IMRU.Examples
                 maxRetryNumberInRecovery = Convert.ToInt32(args[5]);
             }
 
+            if (args.Length > 6)
+            {
+                totalAllowedFailureNumberInRecovery = Convert.ToInt32(args[6]);
+            }
+
             IInjector injector;
 
             if (!runOnYarn)
@@ -114,12 +120,12 @@ namespace Org.Apache.REEF.IMRU.Examples
             if (faultTolerant)
             {
                 var broadcastReduceFtExample = injector.GetInstance<FaultTolerantPipelinedBroadcastAndReduce>();
-                broadcastReduceFtExample.Run(numNodes - 1, chunkSize, iterations, dims, mapperMemory, updateTaskMemory, maxRetryNumberInRecovery);
+                broadcastReduceFtExample.Run(numNodes - 1, chunkSize, iterations, dims, mapperMemory, updateTaskMemory, maxRetryNumberInRecovery, totalAllowedFailureNumberInRecovery);
             }
             else
             {
                 var broadcastReduceExample = injector.GetInstance<PipelinedBroadcastAndReduce>();
-                broadcastReduceExample.Run(numNodes - 1, chunkSize, iterations, dims, mapperMemory, updateTaskMemory, maxRetryNumberInRecovery);
+                broadcastReduceExample.Run(numNodes - 1, chunkSize, iterations, dims, mapperMemory, updateTaskMemory);
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
@@ -61,7 +61,7 @@ namespace Org.Apache.REEF.Network.Group.Config
         /// We want it to return as soon as all nodes in the group are registered, So increasing retry count is better than increasing sleep time.
         /// Current default sleep time is 500ms. Default retry is 500. Total is 250000ms, that is 250s, little bit more than 4 min
         /// </remarks>
-        [NamedParameter("Retry times to wait for nodes to be registered", defaultValue: "500")]
+        [NamedParameter("Retry times to wait for nodes to be registered", defaultValue: "100")]
         internal sealed class RetryCountWaitingForRegistration : Name<int>
         {
         }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
@@ -61,7 +61,7 @@ namespace Org.Apache.REEF.Network.Group.Config
         /// We want it to return as soon as all nodes in the group are registered, So increasing retry count is better than increasing sleep time.
         /// Current default sleep time is 500ms. Default retry is 500. Total is 250000ms, that is 250s, little bit more than 4 min
         /// </remarks>
-        [NamedParameter("Retry times to wait for nodes to be registered", defaultValue: "100")]
+        [NamedParameter("Retry times to wait for nodes to be registered", defaultValue: "500")]
         internal sealed class RetryCountWaitingForRegistration : Name<int>
         {
         }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBroadcastReduceTest.cs
@@ -70,7 +70,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .Set(TcpPortConfigurationModule.PortRangeCount, "1000")
                 .Build();
 
-            string[] args = { "10", "2", "512", "512", "100", NumOfRetry.ToString() };
+            string[] args = { "10", "2", "512", "512", "100", NumOfRetry.ToString(), NumOfRetry.ToString() };
             Run.RunBroadcastReduceTest(tcpPortConfig, runOnYarn, NumNodes, faultTolerant, args, testFolder);
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
@@ -139,7 +139,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .BindSetEntry<TaskIdsToFail, string>(GenericType<TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-3-")
                 .BindIntNamedParam<FailureType>(FailureType.EvaluatorFailureDuringTaskExecution.ToString())
                 .BindNamedParameter(typeof(MaxRetryNumberInRecovery), NumberOfRetry.ToString())
-                .BindNamedParameter(typeof(FaultTolerantPipelinedBroadcastAndReduce.TotalNumberOfAllowedFailures), NumberOfRetry.ToString())
+                .BindNamedParameter(typeof(FaultTolerantPipelinedBroadcastAndReduce.TotalNumberOfForcedFailures), NumberOfRetry.ToString())
                 .Build();
 
             return Configurations.Merge(c1, c2, GetTcpConfiguration());

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
@@ -139,6 +139,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .BindSetEntry<TaskIdsToFail, string>(GenericType<TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-3-")
                 .BindIntNamedParam<FailureType>(FailureType.EvaluatorFailureDuringTaskExecution.ToString())
                 .BindNamedParameter(typeof(MaxRetryNumberInRecovery), NumberOfRetry.ToString())
+                .BindNamedParameter(typeof(FaultTolerantPipelinedBroadcastAndReduce.TotalNumberOfAllowedFailures), NumberOfRetry.ToString())
                 .Build();
 
             return Configurations.Merge(c1, c2, GetTcpConfiguration());

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnInit.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnInit.cs
@@ -81,7 +81,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .BindSetEntry<TaskIdsToFail, string>(GenericType<TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-3-")
                 .BindIntNamedParam<FailureType>(FailureType.EvaluatorFailureDuringTaskInitialization.ToString())
                 .BindNamedParameter(typeof(MaxRetryNumberInRecovery), NumberOfRetry.ToString())
-                .BindNamedParameter(typeof(FaultTolerantPipelinedBroadcastAndReduce.TotalNumberOfAllowedFailures), NumberOfRetry.ToString())
+                .BindNamedParameter(typeof(FaultTolerantPipelinedBroadcastAndReduce.TotalNumberOfForcedFailures), NumberOfRetry.ToString())
                 .Build();
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnInit.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnInit.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using Org.Apache.REEF.IMRU.API;
+using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
 using Org.Apache.REEF.IMRU.OnREEF.Parameters;
 using TaskIdsToFail = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.TaskIdsToFail;
 using FailureType = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.FailureType;
@@ -80,6 +81,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .BindSetEntry<TaskIdsToFail, string>(GenericType<TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-3-")
                 .BindIntNamedParam<FailureType>(FailureType.EvaluatorFailureDuringTaskInitialization.ToString())
                 .BindNamedParameter(typeof(MaxRetryNumberInRecovery), NumberOfRetry.ToString())
+                .BindNamedParameter(typeof(FaultTolerantPipelinedBroadcastAndReduce.TotalNumberOfAllowedFailures), NumberOfRetry.ToString())
                 .Build();
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasks.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasks.cs
@@ -61,7 +61,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
 
             // on each try each task should fail or complete
-            // there shoould be no failed evaluators
+            // there should be no failed evaluators
             // and on each try all tasks should start successfully
             Assert.Equal((NumberOfRetry + 1) * numTasks, completedTaskCount + failedTaskCount);
             Assert.Equal(0, failedEvaluatorCount);
@@ -85,7 +85,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .BindSetEntry<TaskIdsToFail, string>(GenericType<TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-3-")
                 .BindIntNamedParam<FailureType>(FailureType.TaskFailureDuringTaskExecution.ToString())
                 .BindNamedParameter(typeof(MaxRetryNumberInRecovery), NumberOfRetry.ToString())
-                .BindNamedParameter(typeof(FaultTolerantPipelinedBroadcastAndReduce.TotalNumberOfAllowedFailures), NumberOfRetry.ToString())
+                .BindNamedParameter(typeof(FaultTolerantPipelinedBroadcastAndReduce.TotalNumberOfForcedFailures), NumberOfRetry.ToString())
                 .Build();
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasks.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasks.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using Org.Apache.REEF.IMRU.API;
+using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
 using TaskIdsToFail = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.TaskIdsToFail;
 using FailureType = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.FailureType;
 using TestSenderMapFunction = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.TestSenderMapFunction;
@@ -84,6 +85,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .BindSetEntry<TaskIdsToFail, string>(GenericType<TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-3-")
                 .BindIntNamedParam<FailureType>(FailureType.TaskFailureDuringTaskExecution.ToString())
                 .BindNamedParameter(typeof(MaxRetryNumberInRecovery), NumberOfRetry.ToString())
+                .BindNamedParameter(typeof(FaultTolerantPipelinedBroadcastAndReduce.TotalNumberOfAllowedFailures), NumberOfRetry.ToString())
                 .Build();
         }
     }


### PR DESCRIPTION
…ting

* Refactor PipelinedBroadcastAndReduce in IMRU example so that it can be reused by fault tolerant
* Update FaultTolerantPipelinedBroadcastAndReduce to allow passing allowed failure number
* Update test cases

JIRA: [REEF-1556](https://issues.apache.org/jira/browse/REEF-1556)
This closes