### PR TITLE
[REEF-1558] Mark Exceptions class Obsolete

### DIFF
--- a/lang/cs/Org.Apache.REEF.Utilities/Diagnostics/Exceptions.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Diagnostics/Exceptions.cs
@@ -24,6 +24,7 @@ using Org.Apache.REEF.Utilities.Attributes;
 namespace Org.Apache.REEF.Utilities.Diagnostics
 {
     [Private]
+    [Obsolete("TODO[JIRA REEF-1467] This class will be removed")]
     public static class Exceptions
     {
         #region methods


### PR DESCRIPTION
This change marks Exceptions class Obsolete to declare the intention
to remove it and to discourage new usage.

JIRA:
  [REEF-1558](https://issues.apache.org/jira/browse/REEF-1558)

Pull request:
  This closes #