### PR TITLE
[REEF-1562] Remove inheritance from ReefRuntimeException

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tang/Exceptions/BindException.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Exceptions/BindException.cs
@@ -19,7 +19,7 @@ using System;
 
 namespace Org.Apache.REEF.Tang.Exceptions
 {
-    public class BindException : ReefRuntimeException
+    public class BindException : Exception
     {
         internal BindException(string message)
             : base(message)

--- a/lang/cs/Org.Apache.REEF.Tang/Exceptions/ClassHierarchyException.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Exceptions/ClassHierarchyException.cs
@@ -19,7 +19,7 @@ using System;
 
 namespace Org.Apache.REEF.Tang.Exceptions
 {
-    public sealed class ClassHierarchyException : ReefRuntimeException
+    public sealed class ClassHierarchyException : Exception
     {
         internal ClassHierarchyException(string msg) : base(msg)
         {           


### PR DESCRIPTION
This change converts ClassHierarchyException and BindException
to inherit directly from Exception.

JIRA:
  [REEF-1562](https://issues.apache.org/jira/browse/REEF-1562)

Pull request:
  This closes #