### PR TITLE
[REEF-1554] Fix .NET Core compatibility issues in REEF.Wake

### DIFF
--- a/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.csproj
@@ -51,6 +51,7 @@ under the License.
     <Compile Include="RemoteManagerTest.cs" />
     <Compile Include="StreamingRemoteManagerTest.cs" />
     <Compile Include="StreamingTransportTest.cs" />
+    <Compile Include="TimerStageTest.cs" />
     <Compile Include="TimeTest.cs" />
     <Compile Include="TcpConnectionRetryTest.cs" />
     <Compile Include="TransportTest.cs" />

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/TimerStageTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/TimerStageTest.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License
+
+using System;
+using System.Threading;
+using Xunit;
+using Org.Apache.REEF.Wake;
+using Org.Apache.REEF.Wake.Impl;
+using Org.Apache.REEF.Wake.Tests;
+
+namespace Org.Apache.REEF.Wake.Tests
+{
+    // Timer stage tests.
+    public class TimerStageTest
+    {
+        private static long _delay = 100;
+        private static long _period = 1000;
+        private static long _bigPeriod = long.MaxValue;
+
+        [Fact]
+        public void testValidTimerPeriod()
+        {
+            runTest(_delay, _period);
+        }
+
+        [Fact]
+        public void testInvalidTimerPeriod()
+        {
+            Assert.Throws<ArgumentException>(() => runTest(_delay, _bigPeriod));
+        }
+
+        [Fact]
+        public void testInvalidTimerDelay()
+        {
+            Assert.Throws<ArgumentException>(() => runTest(_bigPeriod, _period));
+        }
+
+        void runTest(long delay, long period)
+        {
+            TimerMonitor monitor = new TimerMonitor();
+            int expected = 10;
+
+            TestEventHandler handler = new TestEventHandler(monitor, expected);
+            IStage stage = new TimerStage(handler, delay, period);
+
+            monitor.Mwait();
+            Assert.Equal(expected, handler.getCount());
+        }
+
+        public class TestEventHandler : IEventHandler<PeriodicEvent>
+        {
+            private TimerMonitor _monitor;
+            private long _expected;
+            private long _count;
+
+            public TestEventHandler(TimerMonitor monitor, long expected)
+            {
+                _count = 0;
+                _monitor = monitor;
+                _expected = expected;
+            }
+
+            public void OnNext(PeriodicEvent e)
+            {
+                long count = Interlocked.Increment(ref _count);
+                if (Interlocked.Read(ref _count) == _expected)
+                {
+                    _monitor.Mnotify();
+                }
+            }
+
+            public long getCount()
+            {
+                return Interlocked.Read(ref _count);
+            }
+        }
+
+        public class TimerMonitor
+        {
+            private long finished;
+
+            public TimerMonitor()
+            {
+                finished = 0;
+            }
+
+            public void Mwait()
+            {
+                lock (this)
+                {
+                    while (Interlocked.Read(ref this.finished) < 1)
+                    {
+                        Monitor.Wait(this);
+                    }
+                    Interlocked.CompareExchange(ref finished, 0, 1);
+                }
+            }
+
+            public void Mnotify()
+            {
+                lock (this)
+                {
+                    Interlocked.CompareExchange(ref finished, 1, 0);
+                    Monitor.Pulse(this);
+                }
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Impl/TimerStage.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Impl/TimerStage.cs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System.Timers;
+using System;
+using System.Threading;
 
 namespace Org.Apache.REEF.Wake.Impl
 {
@@ -36,14 +37,17 @@ namespace Org.Apache.REEF.Wake.Impl
 
         /// <summary>Constructs a timer stage</summary>
         /// <param name="handler">an event handler</param>
-        /// <param name="initialDelay">an initial delay</param>
+        /// <param name="initialDelay">an initial delay</param>d
         /// <param name="period">a period in milli-seconds</param>
         public TimerStage(IEventHandler<PeriodicEvent> handler, long initialDelay, long period)
         {
+            // Core .NET only supports 32 bit timers.
+            validate("initialDelay", initialDelay);
+            validate("initialDelay", period);
+
             _handler = handler;
-            _timer = new Timer(period);
-            _timer.Elapsed += (sender, e) => OnTimedEvent(sender, e, _handler, _value);
-            _timer.Enabled = true;
+            _timer = new System.Threading.Timer(
+                (object state) => { OnTimedEvent(_handler, _value); }, this, (int)initialDelay, (int)period);
         }
 
         /// <summary>
@@ -51,12 +55,27 @@ namespace Org.Apache.REEF.Wake.Impl
         /// </summary>
         public void Dispose()
         {
-            _timer.Stop();
+            _timer.Dispose();
         }
 
-        private static void OnTimedEvent(object source, ElapsedEventArgs e, IEventHandler<PeriodicEvent> handler, PeriodicEvent value)
+        private static void OnTimedEvent(IEventHandler<PeriodicEvent> handler, PeriodicEvent value)
         {
             handler.OnNext(value);
+        }
+
+        /// <summary>
+        /// Validates the input is less than Int32.MaxInt. 
+        /// </summary>
+        /// <param name="name">Parameter name</param>
+        /// <param name="value">Parameter value</param>
+        /// <exception cref="ArgumentException">Input value excess Int32.Max</exception>
+        private void validate(string name, long value)
+        {
+            if (value > int.MaxValue)
+            {
+                throw new ArgumentException(string.Format(
+                    "Parameter: " + name + " {0} is larger supported value {0}", int.MaxValue));
+            }
         }
     }
 }


### PR DESCRIPTION
This change addressed the issue by
  * Replacing System.Timers.Timer in TimerStage class with System.Threading.Timer
  * Added timer period and initialDelay parameter verifiction since interface
    is 64 bit and .NET Core class only supports 32 bit.
  * Added unit tests to verify TimerStage behavior since there were no
    previous tests.

JIRA:
  [REEF-1554](https://issues.apache.org/jira/browse/REEF-1554)