### PR TITLE
[REEF-1565] Make Context accessible from task

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Properties/AssemblyInfo.cs
@@ -73,6 +73,13 @@ using System.Runtime.InteropServices;
  "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
  "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
 
+// Common and IMRU share APIs that should not be exposed to the user
+[assembly: InternalsVisibleTo("Org.Apache.REEF.IMRU, publickey=" +
+ "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
+ "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
+ "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
+ "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
+
 // Allow the tests access to `internal` APIs
 [assembly: InternalsVisibleTo("Org.Apache.REEF.Common.Tests, publickey=" +
  "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
@@ -482,7 +482,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// </summary>
         /// <param name="taskId"></param>
         /// <returns></returns>
-        internal TaskState GetTaskState(string taskId)
+        internal StateMachine.TaskState GetTaskState(string taskId)
         {
             var taskInfo = GetTaskInfo(taskId);
             return taskInfo.TaskState.CurrentState;
@@ -494,7 +494,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// </summary>
         /// <param name="taskState"></param>
         /// <returns></returns>
-        internal bool AreAllTasksInState(TaskState taskState)
+        internal bool AreAllTasksInState(StateMachine.TaskState taskState)
         {
             return _tasks.All(t => t.Value.TaskState.CurrentState == taskState);
         }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using Org.Apache.REEF.Common.Runtime.Evaluator.Context;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Common.Tasks.Events;
 using Org.Apache.REEF.IMRU.API;
@@ -45,6 +46,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         private readonly IBroadcastSender<MapInputWithControlMessage<TMapInput>> _dataAndControlMessageSender;
         private readonly IUpdateFunction<TMapInput, TMapOutput, TResult> _updateTask;
         private readonly IIMRUResultHandler<TResult> _resultHandler;
+        private readonly ContextRuntime _contextRuntime;
 
         /// <summary>
         /// </summary>
@@ -54,8 +56,10 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         /// <param name="taskCloseCoordinator">Task close Coordinator</param>
         /// <param name="invokeGc">Whether to call Garbage Collector after each iteration or not</param>
         /// <param name="taskId">task id</param>
+        /// <param name="contextRuntime">Reference of ContextRuntime id</param>
         [Inject]
         private UpdateTaskHost(
+            ContextRuntime contextRuntime,
             IUpdateFunction<TMapInput, TMapOutput, TResult> updateTask,
             IGroupCommClient groupCommunicationsClient,
             IIMRUResultHandler<TResult> resultHandler,
@@ -66,6 +70,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         {
             Logger.Log(Level.Info, "Entering constructor of UpdateTaskHost for task id {0}", taskId);
             _updateTask = updateTask;
+            _contextRuntime = contextRuntime;
             _dataAndControlMessageSender =
                 _communicationGroupClient.GetBroadcastSender<MapInputWithControlMessage<TMapInput>>(IMRUConstants.BroadcastOperatorName);
             _dataReceiver = _communicationGroupClient.GetReduceReceiver<TMapOutput>(IMRUConstants.ReduceOperatorName);


### PR DESCRIPTION
For fault tolerant, states should be saved at context level so that when the task is resubmitted, update task host would be able to restore the state from the context.

Currently, we start task from context. But inside task we are not able to access context. As ContextRuntime could have multiple instances, it is not created by injection.

This Jira is to make Task able to inject context where the task is running on. This is the first step for the state management.

JIRA: [REEF-1565](https://issues.apache.org/jira/browse/REEF-1565)
This closes