### PR TITLE
[REEF-1567] Update Newtonsoft Json.NET to version 9.0.1

### DIFF
--- a/lang/cs/App.config
+++ b/lang/cs/App.config
@@ -25,7 +25,7 @@ under the License.
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/lang/cs/Org.Apache.REEF.Client.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/packages.config
@@ -18,7 +18,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
@@ -47,7 +47,7 @@ namespace Org.Apache.REEF.Client.Common
         @"    <assemblyBinding xmlns=""urn:schemas-microsoft-com:asm.v1"">" +
         @"      <dependentAssembly>" +
         @"        <assemblyIdentity name=""Newtonsoft.Json"" publicKeyToken=""30ad4fe6b2a6aeed"" culture=""neutral"" />" +
-        @"        <bindingRedirect oldVersion=""0.0.0.0-8.0.0.0"" newVersion=""8.0.0.0"" />" +
+        @"        <bindingRedirect oldVersion=""0.0.0.0-9.0.0.0"" newVersion=""9.0.0.0"" />" +
         @"      </dependentAssembly>" +
         @"      <probing privatePath=""local;global""/>" +
         @"    </assemblyBinding>" +

--- a/lang/cs/Org.Apache.REEF.Client/packages.config
+++ b/lang/cs/Org.Apache.REEF.Client/packages.config
@@ -18,7 +18,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net45" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Common/packages.config
+++ b/lang/cs/Org.Apache.REEF.Common/packages.config
@@ -19,7 +19,7 @@ under the License.
 -->
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Driver/packages.config
+++ b/lang/cs/Org.Apache.REEF.Driver/packages.config
@@ -19,7 +19,7 @@ under the License.
 -->
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.IO/packages.config
+++ b/lang/cs/Org.Apache.REEF.IO/packages.config
@@ -22,7 +22,7 @@ under the License.
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="6.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Network/packages.config
+++ b/lang/cs/Org.Apache.REEF.Network/packages.config
@@ -19,7 +19,7 @@ under the License.
 -->
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/packages.config
@@ -19,7 +19,7 @@ under the License.
 -->
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Tang/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tang/packages.config
@@ -19,7 +19,7 @@ under the License.
 -->
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tests/packages.config
@@ -22,7 +22,7 @@ under the License.
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.Reef.Utilities.nuspec
+++ b/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.Reef.Utilities.nuspec
@@ -30,7 +30,7 @@ under the License.
     <tags>Reef/Wake/Tang common utilities</tags>
     <dependencies>
       <dependency id="Microsoft.Hadoop.Avro" version="1.5.6" />
-      <dependency id="Newtonsoft.Json" version="8.0.3" />
+      <dependency id="Newtonsoft.Json" version="9.0.1" />
     </dependencies>
   </metadata>
   <files>

--- a/lang/cs/Org.Apache.REEF.Utilities/packages.config
+++ b/lang/cs/Org.Apache.REEF.Utilities/packages.config
@@ -19,6 +19,6 @@ under the License.
 -->
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -68,7 +68,7 @@ under the License.
   <!-- Package versions -->
   <PropertyGroup>
     <AvroVersion>1.5.6</AvroVersion>
-    <NewtonsoftJsonVersion>8.0.3</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <ProtobufVersion>2.0.0.668</ProtobufVersion>
     <RxVersion>2.2.5</RxVersion>
     <StyleCopVersion>4.7.49.1</StyleCopVersion>


### PR DESCRIPTION
This addressed the issue by
- Changing references to Newtonsoft.Json 8.0.0.0 to 9.0.0.0
- Changing references to Newtonsoft.Json 8.0.3 to 9.0.1

JIRA:
 [REEF-1567](https://issues.apache.org/jira/browse/REEF-1567)
