### PR TITLE
[REEF-1570] In-line AvroUtils & remove Avro dependency from O.A.R.Utilities

### DIFF
--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/codecs/AvroUtils.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/codecs/AvroUtils.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.IO;
+using Microsoft.Hadoop.Avro;
+using Org.Apache.REEF.Utilities.Attributes;
+
+/// <summary>
+/// This copy of AvroUtils should belong to O.A.R.Utilities
+/// As per the discussion on https://issues.apache.org/jira/browse/REEF-1570
+/// we are in-lining this here temporarily
+/// </summary>
+namespace Org.Apache.REEF.Examples.MachineLearning.KMeans.codecs
+{
+    [Private, TemporaryFix]
+    public static class AvroUtils
+    {
+        /// <summary>
+        /// Convert an object to byte array using Avro serialization
+        /// </summary>
+        /// <param name="obj">The object to serialize</param>
+        /// <returns>The serialized object in a byte array</returns>
+        public static byte[] AvroSerialize<T>(T obj)
+        {
+            IAvroSerializer<T> serializer = AvroSerializer.Create<T>();
+            using (MemoryStream stream = new MemoryStream())
+            {
+                serializer.Serialize(stream, obj);
+                return stream.GetBuffer();
+            }
+        }
+
+        /// <summary>
+        /// Converts a byte array to an object using Avro deserialization.
+        /// </summary>
+        /// <param name="data">The byte array to deserialize</param>
+        /// <returns>The deserialized object</returns>
+        public static T AvroDeserialize<T>(byte[] data)
+        {
+            IAvroSerializer<T> deserializer = AvroSerializer.Create<T>();
+            using (MemoryStream stream = new MemoryStream(data))
+            {
+                return deserializer.Deserialize(stream);
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/codecs/CentroidsCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/codecs/CentroidsCodec.cs
@@ -17,7 +17,6 @@
 
 using Org.Apache.REEF.Examples.MachineLearning.KMeans.Contracts;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Wake.Remote;
 
 namespace Org.Apache.REEF.Examples.MachineLearning.KMeans.codecs

--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/codecs/DataVectorCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/codecs/DataVectorCodec.cs
@@ -17,7 +17,6 @@
 
 using Org.Apache.REEF.Examples.MachineLearning.KMeans.Contracts;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Wake.Remote;
 
 namespace Org.Apache.REEF.Examples.MachineLearning.KMeans.codecs

--- a/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.csproj
+++ b/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.csproj
@@ -30,12 +30,12 @@ under the License.
   </PropertyGroup>
   <Import Project="$(SolutionDir)\build.props" />
   <ItemGroup>
-    <Reference Include="Microsoft.Hadoop.Avro, Version=1.5.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Hadoop.Avro.1.5.6\lib\net45\Microsoft.Hadoop.Avro.dll</HintPath>
+    <Reference Include="Microsoft.Hadoop.Avro">
+      <HintPath>$(PackagesDir)\Microsoft.Hadoop.Avro.$(AvroVersion)\lib\net45\Microsoft.Hadoop.Avro.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(PackagesDir)\Newtonsoft.Json.$(NewtonsoftJsonVersion)\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.csproj
+++ b/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.csproj
@@ -30,6 +30,14 @@ under the License.
   </PropertyGroup>
   <Import Project="$(SolutionDir)\build.props" />
   <ItemGroup>
+    <Reference Include="Microsoft.Hadoop.Avro, Version=1.5.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Hadoop.Avro.1.5.6\lib\net45\Microsoft.Hadoop.Avro.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -38,6 +46,7 @@ under the License.
     <Compile Include="DriverRestart\HelloRestartDriver.cs" />
     <Compile Include="DriverRestart\HelloRestartTask.cs" />
     <Compile Include="MachineLearning\KMeans\Centroids.cs" />
+    <Compile Include="MachineLearning\KMeans\codecs\AvroUtils.cs" />
     <Compile Include="MachineLearning\KMeans\codecs\CentroidsCodec.cs" />
     <Compile Include="MachineLearning\KMeans\codecs\DataVectorCodec.cs" />
     <Compile Include="MachineLearning\KMeans\codecs\ProcessedResultsCodec.cs" />
@@ -89,6 +98,9 @@ under the License.
       <Project>{cdfb3464-4041-42b1-9271-83af24cd5008}</Project>
       <Name>Org.Apache.REEF.Wake</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/lang/cs/Org.Apache.REEF.Examples/packages.config
+++ b/lang/cs/Org.Apache.REEF.Examples/packages.config
@@ -19,6 +19,6 @@ under the License.
 -->
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Examples/packages.config
+++ b/lang/cs/Org.Apache.REEF.Examples/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -18,5 +18,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
+  <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Network/Naming/Codec/NamingLookupRequestCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/Codec/NamingLookupRequestCodec.cs
@@ -17,7 +17,7 @@
 
 using Org.Apache.REEF.Network.Naming.Contracts;
 using Org.Apache.REEF.Network.Naming.Events;
-using Org.Apache.REEF.Utilities;
+using Org.Apache.REEF.Network.Utilities;
 using Org.Apache.REEF.Wake.Remote;
 
 namespace Org.Apache.REEF.Network.Naming.Codec

--- a/lang/cs/Org.Apache.REEF.Network/Naming/Codec/NamingLookupResponseCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/Codec/NamingLookupResponseCodec.cs
@@ -20,8 +20,8 @@ using System.Linq;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Network.Naming.Contracts;
 using Org.Apache.REEF.Network.Naming.Events;
-using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Wake.Remote;
+using Org.Apache.REEF.Network.Utilities;
 
 namespace Org.Apache.REEF.Network.Naming.Codec
 {

--- a/lang/cs/Org.Apache.REEF.Network/Naming/Codec/NamingRegisterRequestCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/Codec/NamingRegisterRequestCodec.cs
@@ -18,7 +18,7 @@
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Network.Naming.Contracts;
 using Org.Apache.REEF.Network.Naming.Events;
-using Org.Apache.REEF.Utilities;
+using Org.Apache.REEF.Network.Utilities;
 using Org.Apache.REEF.Wake.Remote;
 
 namespace Org.Apache.REEF.Network.Naming.Codec

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -158,10 +158,12 @@ under the License.
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TcpClientConfigurationModule.cs" />
     <Compile Include="TcpClientConfigurationProvider.cs" />
+    <Compile Include="Utilities\AvroUtils.cs" />
     <Compile Include="Utilities\BlockingCollectionExtensions.cs" />
     <Compile Include="Utilities\Utils.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Org.Apache.REEF.Network.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -163,7 +163,6 @@ under the License.
     <Compile Include="Utilities\Utils.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="Org.Apache.REEF.Network.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Network/Utilities/AvroUtils.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Utilities/AvroUtils.cs
@@ -19,9 +19,14 @@ using System.IO;
 using Microsoft.Hadoop.Avro;
 using Org.Apache.REEF.Utilities.Attributes;
 
-namespace Org.Apache.REEF.Utilities
+/// <summary>
+/// This copy of AvroUtils should belong to O.A.R.Utilities
+/// As per the discussion on https://issues.apache.org/jira/browse/REEF-1570
+/// we are in-lining this here temporarily
+/// </summary>
+namespace Org.Apache.REEF.Network.Utilities
 {
-    [Private]
+    [Private, TemporaryFix]
     public static class AvroUtils
     {
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Utilities/Attributes/TemporaryFixAttribute.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Attributes/TemporaryFixAttribute.cs
@@ -15,25 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using Org.Apache.REEF.Network.Naming.Contracts;
-using Org.Apache.REEF.Network.Naming.Events;
-using Org.Apache.REEF.Network.Utilities;
-using Org.Apache.REEF.Wake.Remote;
+using System;
 
-namespace Org.Apache.REEF.Network.Naming.Codec
+namespace Org.Apache.REEF.Utilities.Attributes
 {
-    internal sealed class NamingUnregisterRequestCodec : ICodec<NamingUnregisterRequest>
+    /// <summary>
+    /// Attribute target is a temporary fix and will
+    /// be refactored suitably without a deprecation phase.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All)]
+    public sealed class TemporaryFixAttribute : Attribute
     {
-        public byte[] Encode(NamingUnregisterRequest obj)
-        {
-            AvroNamingUnRegisterRequest request = new AvroNamingUnRegisterRequest { id = obj.Identifier };
-            return AvroUtils.AvroSerialize(request);
-        }
-
-        public NamingUnregisterRequest Decode(byte[] data)
-        {
-            AvroNamingUnRegisterRequest request = AvroUtils.AvroDeserialize<AvroNamingUnRegisterRequest>(data);
-            return new NamingUnregisterRequest(request.id);
-        }
+        // Intentionally empty.
     }
 }

--- a/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.Reef.Utilities.csproj
+++ b/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.Reef.Utilities.csproj
@@ -30,9 +30,6 @@ under the License.
   </PropertyGroup>
   <Import Project="$(SolutionDir)\build.props" />
   <ItemGroup>
-    <Reference Include="Microsoft.Hadoop.Avro">
-      <HintPath>$(PackagesDir)\Microsoft.Hadoop.Avro.$(AvroVersion)\lib\net45\Microsoft.Hadoop.Avro.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
@@ -46,12 +43,12 @@ under the License.
     <Compile Include="Attributes\EvaluatorSideAttribute.cs" />
     <Compile Include="Attributes\InteropAttribute.cs" />
     <Compile Include="Attributes\NotThreadSafeAttribute.cs" />
+    <Compile Include="Attributes\TemporaryFixAttribute.cs" />
     <Compile Include="Attributes\PrivateAttribute.cs" />
     <Compile Include="Attributes\TaskSideAttribute.cs" />
     <Compile Include="Attributes\TestingAttribute.cs" />
     <Compile Include="Attributes\ThreadSafeAttribute.cs" />
     <Compile Include="Attributes\UnstableAttribute.cs" />
-    <Compile Include="AvroUtils.cs" />
     <Compile Include="ByteUtilities.cs" />
     <Compile Include="Collections\PriorityQueue.cs" />
     <Compile Include="Collections\ReadOnlySet.cs" />

--- a/lang/cs/Org.Apache.REEF.Utilities/packages.config
+++ b/lang/cs/Org.Apache.REEF.Utilities/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -18,7 +18,6 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION

    This moves AvroUtils from O.A.R.Utilities and in-lines its usage into O.A.R.Naming.Utilities
    and O.A.R.Examples.MachineLearning.KMeans.codecs. Also, the Avro dependency from
    O.A.R.Utilities is removed while an Avro dependency has been added to O.A.R.Examples.
    The current usages have been tagged with a TemporaryFixAttribute so that we can fix it
    appropriately when we are ready to do so.

JIRA:
    [REEF-1570](https://issues.apache.org/jira/browse/REEF-1570)

Pull Request:
    Closes #