### PR TITLE
[REEF-1571] Switch to appveyor DownloadFile command

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -29,7 +29,7 @@ if (!(Test-Path $tools))
 Push-Location $tools
 
 $mavenVer = "3.3.3"
-Start-FileDownload "https://archive.apache.org/dist/maven/maven-3/$mavenVer/binaries/apache-maven-$mavenVer-bin.zip" "maven.zip"
+appveyor DownloadFile "https://archive.apache.org/dist/maven/maven-3/$mavenVer/binaries/apache-maven-$mavenVer-bin.zip" -FileName "maven.zip"
 
 # extract
 Invoke-Expression "7z.exe x maven.zip" | Out-Null
@@ -49,7 +49,7 @@ if (!(Test-Path $protocPath))
 }
 Push-Location $protocPath
 
-Start-FileDownload "https://github.com/google/protobuf/releases/download/v$protocVer/protoc-$protocVer-win32.zip" "protoc.zip"
+appveyor DownloadFile "https://github.com/google/protobuf/releases/download/v$protocVer/protoc-$protocVer-win32.zip" -FileName "protoc.zip"
 
 # extract
 Invoke-Expression "7z.exe x protoc.zip" | Out-Null


### PR DESCRIPTION
This change switches from Start-FileDownload cmdlet
to appveyor DownloadFile command in our AppVeyor install
dependencies script.

JIRA:
  [REEF-1571](https://issues.apache.org/jira/browse/REEF-1571)

Pull request:
  This closes #