### PR TITLE
[REEF-1572] Clean up class hierarchy for Map/UpdateTaskHost

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/MapTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/MapTaskHost.cs
@@ -17,7 +17,6 @@
 
 using System;
 using Org.Apache.REEF.Common.Tasks;
-using Org.Apache.REEF.Common.Tasks.Events;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.IMRU.OnREEF.MapInputWithControlMessage;
@@ -36,7 +35,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
     /// <typeparam name="TMapInput">Map input</typeparam>
     /// <typeparam name="TMapOutput">Map output</typeparam>
     [ThreadSafe]
-    internal sealed class MapTaskHost<TMapInput, TMapOutput> : TaskHostBase, ITask, IObserver<ICloseEvent>
+    internal sealed class MapTaskHost<TMapInput, TMapOutput> : TaskHostBase
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(MapTaskHost<TMapInput, TMapOutput>));
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/TaskHostBase.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/TaskHostBase.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.Net.Sockets;
 using System.Runtime.Remoting;
 using System.Threading;
+using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Common.Tasks.Events;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.Network.Group.Task;
@@ -28,7 +29,7 @@ using Org.Apache.REEF.Wake.Remote.Impl;
 
 namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
 {
-    internal abstract class TaskHostBase
+    internal abstract class TaskHostBase : ITask, IObserver<ICloseEvent>
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(TaskHostBase));
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
@@ -17,7 +17,6 @@
 
 using System;
 using Org.Apache.REEF.Common.Tasks;
-using Org.Apache.REEF.Common.Tasks.Events;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.IMRU.OnREEF.MapInputWithControlMessage;
@@ -37,7 +36,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
     /// <typeparam name="TMapOutput">Map output</typeparam>
     /// <typeparam name="TResult">Final result</typeparam>
     [ThreadSafe]
-    internal sealed class UpdateTaskHost<TMapInput, TMapOutput, TResult> : TaskHostBase, ITask, IObserver<ICloseEvent>
+    internal sealed class UpdateTaskHost<TMapInput, TMapOutput, TResult> : TaskHostBase
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(UpdateTaskHost<TMapInput, TMapOutput, TResult>));
 


### PR DESCRIPTION
This change moves inheritance from ITask and IObserver<ICloseEvent>
from Map/UpdateTaskHost to TaskHostBase.

JIRA:
  [REEF-1572](https://issues.apache.org/jira/browse/REEF-1572)

Pull request:
  This closes #