### PR TITLE
[REEF-1518] Allow map and update functions in IMRU be disposable

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/MapTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/MapTaskHost.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using System.Threading;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
@@ -112,6 +113,19 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         protected override string TaskHostName
         {
             get { return "MapTaskHost"; }
+        }
+
+        public override void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                _groupCommunicationsClient.Dispose();
+                var disposableTask = _mapTask as IDisposable;
+                if (disposableTask != null)
+                {
+                    disposableTask.Dispose();
+                }
+            }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/TaskHostBase.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/TaskHostBase.cs
@@ -36,12 +36,12 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         /// <summary>
         /// Shows if the object has been disposed.
         /// </summary>
-        private int _disposed;
+        protected int _disposed;
 
         /// <summary>
         /// Group Communication client for the task
         /// </summary>
-        private readonly IGroupCommClient _groupCommunicationsClient;
+        protected readonly IGroupCommClient _groupCommunicationsClient;
 
         /// <summary>
         /// Task close Coordinator to handle the work when receiving task close event
@@ -157,7 +157,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         /// <summary>
         /// Dispose function. Dispose IGroupCommunicationsClient.
         /// </summary>
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (Interlocked.Exchange(ref _disposed, 1) == 0)
             {

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using System.Threading;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
@@ -152,6 +153,19 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         protected override string TaskHostName
         {
             get { return "UpdateTaskHost"; }
+        }
+
+        public override void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                _groupCommunicationsClient.Dispose();
+                var disposableTask = _updateTask as IDisposable;
+                if (disposableTask != null)
+                {
+                    disposableTask.Dispose();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This change adds disposing of map/update functions (if they are disposable)
to Map/UpdateTaskHost Dispose.

JIRA:
  [REEF-1518](https://issues.apache.org/jira/browse/REEF-1518)

Pull request:
  This closes #