### PR TITLE
[REEF-1451] Clean up IMRU Fault Tolerant scenario tests

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/PipelinedBroadcastReduce/FaultTolerantPipelinedBroadcastAndReduce.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/PipelinedBroadcastReduce/FaultTolerantPipelinedBroadcastAndReduce.cs
@@ -87,15 +87,18 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
         [NamedParameter(Documentation = "Type of failure to simulate")]
         internal class FailureType : Name<int>
         {
-            internal static readonly int EvaluatorFailureDuringTaskExecution = 0;
-            internal static readonly int TaskFailureDuringTaskExecution = 1;
-            internal static readonly int EvaluatorFailureDuringTaskInitialization = 2;
-            internal static readonly int TaskFailureDuringTaskInitialization = 3;
+            internal const int EvaluatorFailureDuringTaskExecution = 0;
+            internal const int TaskFailureDuringTaskExecution = 1;
+            internal const int EvaluatorFailureDuringTaskInitialization = 2;
+            internal const int TaskFailureDuringTaskInitialization = 3;
+            internal const int EvaluatorFailureDuringTaskDispose = 4;
+            internal const int TaskFailureDuringTaskDispose = 5;
 
             internal static bool IsEvaluatorFailure(int failureType)
             {
                 return failureType == EvaluatorFailureDuringTaskExecution ||
-                       failureType == EvaluatorFailureDuringTaskInitialization;
+                       failureType == EvaluatorFailureDuringTaskInitialization ||
+                       failureType == EvaluatorFailureDuringTaskDispose;
             }
         }
 
@@ -107,7 +110,7 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
         /// <summary>
         /// The function is to simulate Evaluator/Task failure for mapper evaluator
         /// </summary>
-        internal sealed class TestSenderMapFunction : IMapFunction<int[], int[]>
+        internal sealed class TestSenderMapFunction : IMapFunction<int[], int[]>, IDisposable
         {
             private int _iterations;
             private readonly string _taskId;
@@ -178,6 +181,15 @@ namespace Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce
                 }
 
                 return mapInput;
+            }
+
+            public void Dispose()
+            {
+                if (_failureType == FailureType.EvaluatorFailureDuringTaskDispose ||
+                    _failureType == FailureType.TaskFailureDuringTaskDispose)
+                {
+                    SimulateFailure(_iterations);
+                }
             }
 
             private void SimulateFailure(int onIteration)

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -71,6 +71,9 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         private static readonly Logger Logger =
             Logger.GetLogger(typeof(IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>));
 
+        internal const string DoneActionPrefix = "DoneAction:";
+        internal const string FailActionPrefix = "FailAction:";
+
         private readonly ConfigurationManager _configurationManager;
         private readonly int _totalMappers;
         private readonly IGroupCommDriver _groupCommDriver;
@@ -699,7 +702,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         private void DoneAction()
         {
             ShutDownAllEvaluators();
-            Logger.Log(Level.Info, "DoneAction done in retry {0}!!!", _numberOfRetries);
+            Logger.Log(Level.Info, "{0} done in retry {1}!!!", DoneActionPrefix, _numberOfRetries);
         }
 
         /// <summary>
@@ -709,8 +712,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         {
             ShutDownAllEvaluators();
             var msg = string.Format(CultureInfo.InvariantCulture,
-                "The system cannot be recovered after {0} retries. NumberofFailedMappers in the last try is {1}.",
-                _numberOfRetries, _evaluatorManager.NumberofFailedMappers());
+                "{0} The system cannot be recovered after {1} retries. NumberofFailedMappers in the last try is {2}.",
+                FailActionPrefix, _numberOfRetries, _evaluatorManager.NumberofFailedMappers());
             Exceptions.Throw(new ApplicationException(msg), Logger);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
@@ -36,10 +36,12 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
     public class TestFailMapperEvaluators : IMRUBrodcastReduceTestBase
     {
         protected const int NumberOfRetry = 3;
+        protected const string DoneActionMessage = "DoneAction";
+        protected const string FailActionMessage = "The system cannot be recovered after";
 
         /// <summary>
-        /// This test is to fail one evaluator and then try to resubmit. In the last retry, 
-        /// there will be no failed evaluator and all tasks will be successfully completed. 
+        /// This test fails two evaluators during task execution stage on each retry except last. 
+        /// Job is retried until success. 
         /// </summary>
         [Fact]
         public virtual void TestFailedMapperOnLocalRuntime()
@@ -65,11 +67,14 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var runningTaskCount = GetMessageCount(lines, RunningTaskMessage);
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
+            var jobSuccess = GetMessageCount(lines, DoneActionMessage);
 
             // on each try each task should fail or complete or disappear with failed evaluator
             // and on each try all tasks should start successfully
             Assert.Equal((NumberOfRetry + 1) * numTasks, completedTaskCount + failedEvaluatorCount + failedTaskCount);
             Assert.Equal((NumberOfRetry + 1) * numTasks, runningTaskCount);
+            // eventually job succeeds
+            Assert.True(jobSuccess > 0);
             CleanUp(testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
@@ -36,8 +36,6 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
     public class TestFailMapperEvaluators : IMRUBrodcastReduceTestBase
     {
         protected const int NumberOfRetry = 3;
-        protected const string DoneActionMessage = "DoneAction";
-        protected const string FailActionMessage = "The system cannot be recovered after";
 
         /// <summary>
         /// This test fails two evaluators during task execution stage on each retry except last. 
@@ -67,14 +65,14 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var runningTaskCount = GetMessageCount(lines, RunningTaskMessage);
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
-            var jobSuccess = GetMessageCount(lines, DoneActionMessage);
+            var jobSuccess = GetMessageCount(lines, IMRUDriver<int[], int[], int[], int[]>.DoneActionPrefix);
 
             // on each try each task should fail or complete or disappear with failed evaluator
             // and on each try all tasks should start successfully
             Assert.Equal((NumberOfRetry + 1) * numTasks, completedTaskCount + failedEvaluatorCount + failedTaskCount);
             Assert.Equal((NumberOfRetry + 1) * numTasks, runningTaskCount);
             // eventually job succeeds
-            Assert.True(jobSuccess > 0);
+            Assert.Equal(1, jobSuccess);
             CleanUp(testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnDispose.cs
@@ -29,11 +29,11 @@ using Xunit;
 namespace Org.Apache.REEF.Tests.Functional.IMRU
 {
     [Collection("FunctionalTests")]
-    public sealed class TestFailMapperEvaluatorsOnInit : TestFailMapperEvaluators
+    public sealed class TestFailMapperEvaluatorsOnDispose : TestFailMapperEvaluators
     {
         /// <summary>
-        /// This test fails two evaluators during task initialize stage on each retry except last. 
-        /// Job is retried until success.
+        /// This test fails two evaluators during task dispose stage. 
+        /// The failures are ignored, because tasks are already completed successfully.
         /// </summary>
         [Fact]
         public override void TestFailedMapperOnLocalRuntime()
@@ -60,12 +60,11 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
             var jobSuccess = GetMessageCount(lines, DoneActionMessage);
 
-            // In each retry, there are 2 failed evaluators.
-            // There will be no failed task.
-            // Rest of the tasks should be canceled and send completed task event to the driver. 
-            Assert.Equal(NumberOfRetry * 2, failedEvaluatorCount);
+            // In first retry, all tasks are completed and then there are 2 failed evaluators. 
+            // No failed tasks.
+            Assert.Equal(2, failedEvaluatorCount);
             Assert.Equal(0, failedTaskCount);
-            Assert.Equal(((NumberOfRetry + 1) * numTasks) - (NumberOfRetry * 2), completedTaskCount);
+            Assert.Equal(numTasks, completedTaskCount);
 
             // eventually job succeeds
             Assert.Equal(1, jobSuccess);
@@ -82,7 +81,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             return TangFactory.GetTang().NewConfigurationBuilder(c)
                 .BindSetEntry<TaskIdsToFail, string>(GenericType<TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-2-")
                 .BindSetEntry<TaskIdsToFail, string>(GenericType<TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-3-")
-                .BindIntNamedParam<FailureType>(FailureType.EvaluatorFailureDuringTaskInitialization.ToString())
+                .BindIntNamedParam<FailureType>(FailureType.EvaluatorFailureDuringTaskDispose.ToString())
                 .BindNamedParameter(typeof(MaxRetryNumberInRecovery), NumberOfRetry.ToString())
                 .BindNamedParameter(typeof(FaultTolerantPipelinedBroadcastAndReduce.TotalNumberOfForcedFailures), NumberOfRetry.ToString())
                 .Build();

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnDispose.cs
@@ -17,6 +17,7 @@
 
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
+using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.IMRU.OnREEF.Parameters;
 using TaskIdsToFail = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.TaskIdsToFail;
 using FailureType = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.FailureType;
@@ -58,7 +59,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var completedTaskCount = GetMessageCount(lines, "Received ICompletedTask");
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
-            var jobSuccess = GetMessageCount(lines, DoneActionMessage);
+            var jobSuccess = GetMessageCount(lines, IMRUDriver<int[], int[], int[], int[]>.DoneActionPrefix);
 
             // In first retry, all tasks are completed and then there are 2 failed evaluators. 
             // No failed tasks.

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnInit.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnInit.cs
@@ -17,6 +17,7 @@
 
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
+using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.IMRU.OnREEF.Parameters;
 using TaskIdsToFail = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.TaskIdsToFail;
 using FailureType = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.FailureType;
@@ -58,7 +59,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var completedTaskCount = GetMessageCount(lines, "Received ICompletedTask");
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
-            var jobSuccess = GetMessageCount(lines, DoneActionMessage);
+            var jobSuccess = GetMessageCount(lines, IMRUDriver<int[], int[], int[], int[]>.DoneActionPrefix);
 
             // In each retry, there are 2 failed evaluators.
             // There will be no failed task.

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasks.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasks.cs
@@ -17,6 +17,7 @@
 
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
+using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using TaskIdsToFail = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.TaskIdsToFail;
 using FailureType = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.FailureType;
 using TestSenderMapFunction = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.TestSenderMapFunction;
@@ -59,7 +60,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var runningTaskCount = GetMessageCount(lines, RunningTaskMessage);
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
-            var jobFailure = GetMessageCount(lines, FailActionMessage);
+            var jobFailure = GetMessageCount(lines, IMRUDriver<int[], int[], int[], int[]>.FailActionPrefix);
 
             // each task should fail or complete
             // there should be no failed evaluators

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasks.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasks.cs
@@ -29,11 +29,11 @@ using Xunit;
 namespace Org.Apache.REEF.Tests.Functional.IMRU
 {
     [Collection("FunctionalTests")]
-    public class TestFailMapperTasks : TestFailMapperEvaluators
+    public sealed class TestFailMapperTasks : TestFailMapperEvaluators
     {
         /// <summary>
-        /// This test is to throw exceptions in two tasks. In the first try, there is task app failure,
-        /// and no retries will be done. 
+        /// This test throws exception in two tasks during task execution stage. 
+        /// This is classified as task app failure, so no retries are done, and job fails.
         /// </summary>
         [Fact]
         public override void TestFailedMapperOnLocalRuntime()
@@ -59,6 +59,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var runningTaskCount = GetMessageCount(lines, RunningTaskMessage);
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
+            var jobFailure = GetMessageCount(lines, FailActionMessage);
 
             // each task should fail or complete
             // there should be no failed evaluators
@@ -67,6 +68,9 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             Assert.Equal(numTasks, completedTaskCount + failedTaskCount);
             Assert.Equal(0, failedEvaluatorCount);
             Assert.Equal(numTasks, runningTaskCount);
+            
+            // job fails
+            Assert.True(jobFailure > 0);
             CleanUp(testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnDispose.cs
@@ -17,6 +17,7 @@
 
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
+using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.IMRU.OnREEF.Parameters;
 using TaskIdsToFail = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.TaskIdsToFail;
 using FailureType = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.FailureType;
@@ -58,7 +59,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var completedTaskCount = GetMessageCount(lines, "Received ICompletedTask");
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
-            var jobSuccess = GetMessageCount(lines, DoneActionMessage);
+            var jobSuccess = GetMessageCount(lines, IMRUDriver<int[], int[], int[], int[]>.DoneActionPrefix);
 
             // No failed evaluators or tasks.
             Assert.Equal(0, failedEvaluatorCount);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnDispose.cs
@@ -29,11 +29,11 @@ using Xunit;
 namespace Org.Apache.REEF.Tests.Functional.IMRU
 {
     [Collection("FunctionalTests")]
-    public sealed class TestFailMapperEvaluatorsOnInit : TestFailMapperEvaluators
+    public sealed class TestFailMapperTasksOnDispose : TestFailMapperEvaluators
     {
         /// <summary>
-        /// This test fails two evaluators during task initialize stage on each retry except last. 
-        /// Job is retried until success.
+        /// This test fails two tasks during task dispose stage. 
+        /// The failures are ignored on core REEF layer, so no failed task events are received.
         /// </summary>
         [Fact]
         public override void TestFailedMapperOnLocalRuntime()
@@ -60,12 +60,10 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
             var jobSuccess = GetMessageCount(lines, DoneActionMessage);
 
-            // In each retry, there are 2 failed evaluators.
-            // There will be no failed task.
-            // Rest of the tasks should be canceled and send completed task event to the driver. 
-            Assert.Equal(NumberOfRetry * 2, failedEvaluatorCount);
+            // No failed evaluators or tasks.
+            Assert.Equal(0, failedEvaluatorCount);
             Assert.Equal(0, failedTaskCount);
-            Assert.Equal(((NumberOfRetry + 1) * numTasks) - (NumberOfRetry * 2), completedTaskCount);
+            Assert.Equal(numTasks, completedTaskCount);
 
             // eventually job succeeds
             Assert.Equal(1, jobSuccess);
@@ -82,7 +80,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             return TangFactory.GetTang().NewConfigurationBuilder(c)
                 .BindSetEntry<TaskIdsToFail, string>(GenericType<TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-2-")
                 .BindSetEntry<TaskIdsToFail, string>(GenericType<TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-3-")
-                .BindIntNamedParam<FailureType>(FailureType.EvaluatorFailureDuringTaskInitialization.ToString())
+                .BindIntNamedParam<FailureType>(FailureType.TaskFailureDuringTaskDispose.ToString())
                 .BindNamedParameter(typeof(MaxRetryNumberInRecovery), NumberOfRetry.ToString())
                 .BindNamedParameter(typeof(FaultTolerantPipelinedBroadcastAndReduce.TotalNumberOfForcedFailures), NumberOfRetry.ToString())
                 .Build();

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnInit.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnInit.cs
@@ -17,6 +17,7 @@
 
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
+using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using TaskIdsToFail = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.TaskIdsToFail;
 using FailureType = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.FailureType;
 using TestSenderMapFunction = Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce.FaultTolerantPipelinedBroadcastAndReduce.TestSenderMapFunction;
@@ -58,7 +59,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var completedTaskCount = GetMessageCount(lines, "Received ICompletedTask");
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
-            var jobSuccess = GetMessageCount(lines, DoneActionMessage);
+            var jobSuccess = GetMessageCount(lines, IMRUDriver<int[], int[], int[], int[]>.DoneActionPrefix);
 
             // In each retry, there are 2 failed tasks.
             // Rest of the tasks should be canceled and send completed task event to the driver. 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailUpdateEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailUpdateEvaluator.cs
@@ -65,7 +65,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var runningTaskCount = GetMessageCount(lines, RunningTaskMessage);
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
-            var jobFailure = GetMessageCount(lines, FailActionMessage);
+            var jobFailure = GetMessageCount(lines, IMRUDriver<int[], int[], int[], int[]>.FailActionPrefix);
 
             // there should be one try with each task either completing or disappearing with failed evaluator
             // no task failures

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailUpdateEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailUpdateEvaluator.cs
@@ -36,6 +36,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
     public class TestFailUpdateEvaluator : IMRUBrodcastReduceTestBase
     {
         private const int NumberOfRetry = 3;
+        protected const string FailActionMessage = "The system cannot be recovered after";
 
         /// <summary>
         /// This test is to fail update evaluator and then try to resubmit. We don't recover from update evaluator failure. 
@@ -64,6 +65,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var runningTaskCount = GetMessageCount(lines, RunningTaskMessage);
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
+            var jobFailure = GetMessageCount(lines, FailActionMessage);
 
             // there should be one try with each task either completing or disappearing with failed evaluator
             // no task failures
@@ -71,6 +73,9 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             Assert.Equal(numTasks, completedTaskCount + failedEvaluatorCount);
             Assert.Equal(0, failedTaskCount);
             Assert.Equal(numTasks, runningTaskCount);
+            
+            // job fails
+            Assert.True(jobFailure > 0);
             CleanUp(testFolder);
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -124,7 +124,10 @@ under the License.
     <Compile Include="Functional\IMRU\IMRUBrodcastReduceTestBase.cs" />
     <Compile Include="Functional\IMRU\IMRUCloseTaskTest.cs" />
     <Compile Include="Functional\IMRU\IMRUMapperCountTest.cs" />
+    <Compile Include="Functional\IMRU\TestFailMapperTasksOnDispose.cs" />
+    <Compile Include="Functional\IMRU\TestFailMapperEvaluatorsOnDispose.cs" />
     <Compile Include="Functional\IMRU\TestFailMapperEvaluatorsOnInit.cs" />
+    <Compile Include="Functional\IMRU\TestFailMapperTasksOnInit.cs" />
     <Compile Include="Functional\IMRU\TestFailUpdateEvaluator.cs" />
     <Compile Include="Functional\IMRU\TestFailMapperTasks.cs" />
     <Compile Include="Functional\IMRU\TestFailMapperEvaluators.cs" />


### PR DESCRIPTION
This change:
 * extends failures simulated with FailureType to include dispose.
 * adds tests for failure of mapper task on init and on dispose
   and failure of mapper evaluator on dispose.
 * cleans up checks and comments in other IMRU FT scenario tests.

JIRA:
  [REEF-1451](https://issues.apache.org/jira/browse/REEF-1451)

Pull request:
  This closes #

Good AppVeyor build: https://ci.appveyor.com/project/tcNickolas/reef/build/278-REEF-1451