### PR TITLE
[REEF-1617] Mark the RxTimerStage class as obsolete

### DIFF
--- a/lang/cs/Org.Apache.REEF.Wake/RX/Impl/RxTimerStage.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/RX/Impl/RxTimerStage.cs
@@ -22,6 +22,7 @@ using Org.Apache.REEF.Wake.Impl;
 namespace Org.Apache.REEF.Wake.RX.Impl
 {
     /// <summary>Timer stage that provides events to the observer periodically</summary>
+    [Obsolete("TODO[JIRA REEF-1617] This class will be removed")]
     public sealed class RxTimerStage : IStage, IStaticObservable
     {
         private readonly Timer _timer;


### PR DESCRIPTION
    This change marks the RxTimerStage C# class as being obsolete
    since it is not used on the C# side and does not exist on the
    java side.

JIRA:
    [REEF-1617](https://issues.apache.org/jira/browse/REEF-1617)