### PR TITLE
[REEF-1619] Add Evaluator.exe to the libs folder of the Evaluator NuGet

### DIFF
--- a/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.nuspec
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.nuspec
@@ -38,6 +38,8 @@ under the License.
     </dependencies>
   </metadata>
   <files>
+    <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Evaluator\Org.Apache.REEF.Evaluator.exe" target="lib\net45" />
+    <!-- TODO[REEF-1620]: Remove the below -->
     <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Evaluator\Org.Apache.REEF.Evaluator.exe" target="tools" />
     <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Evaluator\NugetExeFix.txt" target="lib\net45" />
   </files>


### PR DESCRIPTION
This adds Evaluator.exe to the libs folder of the NuGet. That way, it will be
added as a reference upon installation.

JIRA:
  [REEF-1619](https://issues.apache.org/jira/browse/REEF-1619)