### PR TITLE
[REEF-1623] Remove double-logging exception in Logger.Log(Exception)

### DIFF
--- a/lang/cs/Org.Apache.REEF.Utilities/Logging/Logger.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Logging/Logger.cs
@@ -175,21 +175,22 @@ namespace Org.Apache.REEF.Utilities.Logging
         {
             string exceptionLog;
 
-            if (IsLoggable(level) && exception != null)
+            if (exception != null)
             {
                 exceptionLog = string.Format(
                     CultureInfo.InvariantCulture,
-                    "encountered error [{0}] with mesage [{1}] and stack trace [{2}]",
-                    exception,
-                    exception.Message,
-                    exception.StackTrace);
+                    "\r\nEncountered error [{0}]",
+                    exception);
             }
             else
             {
                 exceptionLog = string.Empty;
             }
-            
-            Log(level, msg + exceptionLog);
+
+            if (IsLoggable(level))
+            {
+                Log(level, msg + exceptionLog);
+            }
         }
 
         public IDisposable LogFunction(string function, params object[] args)

--- a/lang/cs/Org.Apache.REEF.Utilities/Logging/Logger.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Logging/Logger.cs
@@ -173,22 +173,22 @@ namespace Org.Apache.REEF.Utilities.Logging
 
         public void Log(Level level, string msg, Exception exception)
         {
-            string exceptionLog;
-
-            if (exception != null)
-            {
-                exceptionLog = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "\r\nEncountered error [{0}]",
-                    exception);
-            }
-            else
-            {
-                exceptionLog = string.Empty;
-            }
-
             if (IsLoggable(level))
             {
+                string exceptionLog;
+
+                if (exception != null)
+                {
+                    exceptionLog = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "\r\nEncountered error [{0}]",
+                        exception);
+                }
+                else
+                {
+                    exceptionLog = string.Empty;
+                }
+
                 Log(level, msg + exceptionLog);
             }
         }


### PR DESCRIPTION
This change
 * removes logging of exception.Message and exception.StackTrace
   which are logged as part of exception anyways.
 * cleans up logic of when message is logged.

JIRA:
  [REEF-1623](https://issues.apache.org/jira/browse/REEF-1623)

Pull request:
  This closes #