### PR TITLE
[REEF-1618] Add stack trace to exceptions handled in TaskHostBase

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/TaskHostBase.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/TaskHostBase.cs
@@ -206,11 +206,10 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         private void HandleException(Exception originalException, Exception targetException)
         {
             Logger.Log(Level.Error,
-                "Received Exception {0} in {1} with message: {2}. The cancellation token is: {3}.",
-                originalException.GetType(),
+                "Received exception in {0} with cancellation token {1}: [{2}]",
                 TaskHostName,
-                originalException.Message,
-                _cancellationSource.IsCancellationRequested);
+                _cancellationSource.IsCancellationRequested,
+                originalException);
             if (!_cancellationSource.IsCancellationRequested)
             {
                 Logger.Log(Level.Error,


### PR DESCRIPTION
This change adds full exception info to log printed in
TaskHostBase.HandleException.

JIRA:
  [REEF-1618](https://issues.apache.org/jira/browse/REEF-1618)

Pull request:
  This closes #