### PR TITLE
[REEF-1504] Collect garbage in the idle time of UpdateTaskHost.TaskBody

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
@@ -98,14 +98,14 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
                     _dataAndControlMessageSender.Send(message);
                 }
 
-                var input = _dataReceiver.Reduce(_cancellationSource);
-
                 if (_invokeGc)
                 {
                     Logger.Log(Level.Verbose, "Calling Garbage Collector");
                     GC.Collect();
                     GC.WaitForPendingFinalizers();
                 }
+
+                var input = _dataReceiver.Reduce(_cancellationSource);
 
                 try
                 {


### PR DESCRIPTION
This change moved garbage collection to before _dataReceiver.Reduce,
which corresponds to update task idle time.

JIRA:
  [REEF-1504](https://issues.apache.org/jira/browse/REEF-1504)

Pull request:
  This closes #