### PR TITLE
[REEF-1596] Add the ability to check status of the REEF job launched directly via REEFEnvironment Driver.

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientConnection.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientConnection.java
@@ -21,11 +21,8 @@ package org.apache.reef.runtime.common.driver.client;
 import com.google.protobuf.ByteString;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.proto.ReefServiceProtos;
-import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
 import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
-import org.apache.reef.runtime.common.utils.RemoteManager;
 import org.apache.reef.tang.annotations.Parameter;
-import org.apache.reef.wake.EventHandler;
 
 import javax.inject.Inject;
 import java.util.logging.Level;
@@ -39,22 +36,16 @@ public final class ClientConnection {
 
   private static final Logger LOG = Logger.getLogger(ClientConnection.class.getName());
 
-  private final EventHandler<ReefServiceProtos.JobStatusProto> jobStatusHandler;
+  private final JobStatusHandler jobStatusHandler;
   private final String jobIdentifier;
 
   @Inject
   public ClientConnection(
-      final RemoteManager remoteManager,
-      @Parameter(ClientRemoteIdentifier.class) final String clientRID,
-      @Parameter(JobIdentifier.class) final String jobIdentifier) {
+      @Parameter(JobIdentifier.class) final String jobIdentifier,
+      final JobStatusHandler jobStatusHandler) {
+
     this.jobIdentifier = jobIdentifier;
-    if (clientRID.equals(ClientRemoteIdentifier.NONE)) {
-      LOG.log(Level.FINE, "Instantiated 'ClientConnection' without an actual connection to the client.");
-      this.jobStatusHandler = new LoggingJobStatusHandler();
-    } else {
-      this.jobStatusHandler = remoteManager.getHandler(clientRID, ReefServiceProtos.JobStatusProto.class);
-      LOG.log(Level.FINE, "Instantiated 'ClientConnection'");
-    }
+    this.jobStatusHandler = jobStatusHandler;
   }
 
   /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/JobStatusHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/JobStatusHandler.java
@@ -20,38 +20,21 @@ package org.apache.reef.runtime.common.driver.client;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.proto.ReefServiceProtos;
-
-import javax.inject.Inject;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.apache.reef.tang.annotations.DefaultImplementation;
+import org.apache.reef.wake.EventHandler;
 
 /**
- * A handler for job status messages that just logs them.
+ * Generic interface for job status messages' handler.
+ * Receive JobStatusProto messages and keep the last message so it can be retrieved via getLastStatus() method.
  */
 @DriverSide
-public class LoggingJobStatusHandler implements JobStatusHandler {
-
-  private static final Logger LOG = Logger.getLogger(LoggingJobStatusHandler.class.getName());
-
-  private ReefServiceProtos.JobStatusProto lastStatus = null;
-
-  @Inject
-  LoggingJobStatusHandler() {
-  }
-
-  @Override
-  public void onNext(final ReefServiceProtos.JobStatusProto jobStatusProto) {
-    this.lastStatus = jobStatusProto;
-    LOG.log(Level.INFO, "In-process JobStatus:\n{0}", jobStatusProto);
-  }
+@DefaultImplementation(RemoteClientJobStatusHandler.class)
+public interface JobStatusHandler extends EventHandler<ReefServiceProtos.JobStatusProto> {
 
   /**
    * Return the last known status of the REEF job.
    * Can return null if the job has not been launched yet.
    * @return Last status of the REEF job.
    */
-  @Override
-  public ReefServiceProtos.JobStatusProto getLastStatus() {
-    return this.lastStatus;
-  }
+  ReefServiceProtos.JobStatusProto getLastStatus();
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.reef.runtime.local.driver;
 
 import org.apache.reef.runtime.common.driver.api.*;
+import org.apache.reef.runtime.common.driver.client.JobStatusHandler;
 import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
 import org.apache.reef.runtime.common.driver.parameters.DefinedRuntimes;
 import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
@@ -30,10 +31,7 @@ import org.apache.reef.runtime.local.LocalClasspathProvider;
 import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
 import org.apache.reef.runtime.local.client.parameters.RackNames;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
-import org.apache.reef.tang.formats.ConfigurationModule;
-import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
-import org.apache.reef.tang.formats.OptionalParameter;
-import org.apache.reef.tang.formats.RequiredParameter;
+import org.apache.reef.tang.formats.*;
 
 /**
  * ConfigurationModule for the Driver executed in the local resourcemanager. This is meant to eventually replace
@@ -68,6 +66,11 @@ public class LocalDriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<String> CLIENT_REMOTE_IDENTIFIER = new OptionalParameter<>();
 
   /**
+   * Interface to use for communications back to the client.
+   */
+  public static final OptionalImpl<JobStatusHandler> JOB_STATUS_HANDLER = new OptionalImpl<>();
+
+  /**
    * The identifier of the Job submitted.
    */
   public static final RequiredParameter<String> JOB_IDENTIFIER = new RequiredParameter<>();
@@ -78,6 +81,7 @@ public class LocalDriverConfiguration extends ConfigurationModuleBuilder {
       .bindImplementation(ResourceReleaseHandler.class, LocalResourceReleaseHandler.class)
       .bindImplementation(ResourceManagerStartHandler.class, LocalResourceManagerStartHandler.class)
       .bindImplementation(ResourceManagerStopHandler.class, LocalResourceManagerStopHandler.class)
+      .bindImplementation(JobStatusHandler.class, JOB_STATUS_HANDLER)
       .bindNamedParameter(ClientRemoteIdentifier.class, CLIENT_REMOTE_IDENTIFIER)
       .bindNamedParameter(ErrorHandlerRID.class, CLIENT_REMOTE_IDENTIFIER)
       .bindNamedParameter(JobIdentifier.class, JOB_IDENTIFIER)

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/FailClient.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/FailClient.java
@@ -22,6 +22,7 @@ import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.client.LauncherStatus;
+import org.apache.reef.proto.ReefServiceProtos;
 import org.apache.reef.runtime.common.REEFEnvironment;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Tang;
@@ -81,18 +82,18 @@ public final class FailClient {
    * @param failMsgClass A class that should fail during the test.
    * @param runtimeConfig REEF runtime configuration. Can be e.g. Local or YARN.
    * @param timeOut REEF application timeout - not used yet.
-   * @return launcher status - usually FAIL.
+   * @return Final job status. Final status for tests is usually something
+   * with state = FAILED and exception like SimulatedDriverFailure.
    * @throws InjectionException configuration error.
    */
-  public static LauncherStatus runInProcess(final Class<?> failMsgClass,
+  public static ReefServiceProtos.JobStatusProto runInProcess(final Class<?> failMsgClass,
       final Configuration runtimeConfig, final int timeOut) throws InjectionException {
 
     try (final REEFEnvironment reef =
              REEFEnvironment.fromConfiguration(runtimeConfig, buildDriverConfig(failMsgClass))) {
       reef.run();
+      return reef.getLastStatus();
     }
-
-    return LauncherStatus.FORCE_CLOSED; // TODO[REEF-1596]: Use the actual status, when implemented.
   }
 
   /**


### PR DESCRIPTION
This is work towards [REEF-1561](https://issues.apache.org/jira/browse/REEF-1561) *REEF as a library* project

This PR should follow after [REEF-1633](https://issues.apache.org/jira/browse/REEF-1633) `Configurations.toString()` merge (PR #1149)

Summary of changes:
   * Add `.getLastStatus()` method to `JobStatusHandler` interface
   * Implement `.getLastStatus()` method in all classes that derive from `JobStatusHandler`
   * Set the default value for `JobStatusHandler` injectable parameter
   * implement `REEFEnvironment.getLastStatus()` method
   * Use that method in unit tests
   * Minor cosmetic changes in the code, more javadocs

JIRA: [REEF-1596](https://issues.apache.org/jira/browse/REEF-1596)
