### PR TITLE
[REEF-1642] Make sure there is only one instance of Evaluators class per REEFEnvironment/Driver

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
@@ -20,9 +20,12 @@ package org.apache.reef.runtime.common.driver.evaluator;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.driver.parameters.DriverIdentifier;
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceAllocationEvent;
+import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.util.Optional;
 import org.apache.reef.tang.util.MonotonicSet;
+import org.apache.reef.util.SingletonAsserter;
 
 import javax.inject.Inject;
 import java.util.*;
@@ -50,12 +53,11 @@ public final class Evaluators implements AutoCloseable {
   private final MonotonicSet<String> closedEvaluatorIds = new MonotonicSet<>();
 
   @Inject
-  Evaluators() {
-    LOG.log(Level.FINE, "Instantiated 'Evaluators'");
-    // TODO[REEF-1642] Assert singleton per REEFEnvironment
+  private Evaluators(@Parameter(DriverIdentifier.class) final String driverId) {
+    LOG.log(Level.FINE, "Instantiated 'Evaluators' for driver {0}", driverId);
     // There can be several instances of the class for multiple REEFEnvironments.
     // It is still a singleton when REEF Driver owns the entire JVM.
-    // assert SingletonAsserter.assertSingleton(Evaluators.class);
+    assert SingletonAsserter.assertSingleton(driverId, Evaluators.class);
   }
 
   /**

--- a/lang/java/reef-common/src/test/java/org/apache/reef/util/SingletonAsserterTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/util/SingletonAsserterTest.java
@@ -21,17 +21,46 @@ package org.apache.reef.util;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.List;
-
 /**
  * Test for SingletonAsserter.
  */
 public final class SingletonAsserterTest {
 
+  private static final class GlobalA { }
+  private static final class GlobalB { }
+
   @Test
-  public void testSingletonAsserter() {
-    Assert.assertTrue(SingletonAsserter.assertSingleton(SingletonAsserterTest.class));
-    Assert.assertTrue(SingletonAsserter.assertSingleton(List.class));
-    Assert.assertFalse(SingletonAsserter.assertSingleton(List.class));
+  public void testSingletonAsserterGlobal() {
+    Assert.assertTrue(SingletonAsserter.assertSingleton(GlobalA.class));
+    Assert.assertTrue(SingletonAsserter.assertSingleton(GlobalB.class));
+    Assert.assertFalse(SingletonAsserter.assertSingleton(GlobalA.class));
+  }
+
+  private static final class LocalA { }
+  private static final class LocalB { }
+
+  @Test
+  public void testSingletonAsserterScoped() {
+    Assert.assertTrue(SingletonAsserter.assertSingleton("A", LocalA.class));
+    Assert.assertTrue(SingletonAsserter.assertSingleton("A", LocalB.class));
+    Assert.assertTrue(SingletonAsserter.assertSingleton("B", LocalA.class));
+    Assert.assertFalse(SingletonAsserter.assertSingleton("A", LocalA.class));
+  }
+
+  private static final class Mixed1 { }
+
+  @Test
+  public void testSingletonAsserterMixed1() {
+    Assert.assertTrue(SingletonAsserter.assertSingleton("A", Mixed1.class));
+    Assert.assertTrue(SingletonAsserter.assertSingleton("B", Mixed1.class));
+    Assert.assertFalse(SingletonAsserter.assertSingleton(Mixed1.class));
+  }
+
+  private static final class Mixed2 { }
+
+  @Test
+  public void testSingletonAsserterMixed2() {
+    Assert.assertTrue(SingletonAsserter.assertSingleton(Mixed2.class));
+    Assert.assertFalse(SingletonAsserter.assertSingleton("A", Mixed2.class));
   }
 }


### PR DESCRIPTION
Summary of changes:
   * Improve `SingletonAsserter` to support both global and scoped singletons
   * Add unit tests for new functionality of `SingletonAsserter`
   * Use scoped `SingletonAsserter` in the `Evaluators` class
    
This is work towards [REEF-1561](https://issues.apache.org/jira/browse/REEF-1561) *"REEF as a library"* effort.

JIRA: [REEF-1542](https://issues.apache.org/jira/browse/REEF-1642)
