### PR TITLE
[REEF-1482] IMRU driver does not exit even if all the task exit normally

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/DriverIdleManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/DriverIdleManager.java
@@ -77,6 +77,8 @@ public final class DriverIdleManager {
       isIdle &= idleMessage.isIdle();
     }
 
+    LOG.log(IDLE_REASONS_LEVEL, "onPotentiallyIdle: isIdle: " + isIdle);
+
     if (isIdle) {
       LOG.log(Level.INFO, "All components indicated idle. Initiating Driver shutdown.");
       driverStatusManagerImpl.onComplete();


### PR DESCRIPTION
Currently, even when all the tasks are completed and all the evaluators are completed, sometimes driver still doen't shut down and hungs there forever. This happens intermittently. When there are many nodes like 500 in Yarn cluster, the issue can happen in every 2 or 3 runs.

The investigation shows there is a potential dead lock in ResourceManagerStatus. This PR is to resolve this issue.

With the fixes, I have tested 10 times with 500 nodes in cluster, there is no repro any more.

JIRA: [REEF-1482](https://issues.apache.org/jira/browse/REEF-1482)
This closes  #
