### PR TITLE
[REEF-1637] Bugfix: When launched via REEFEnvironment, Driver does not receive heartbeats from Evaluators

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStartHandler.java
@@ -38,29 +38,33 @@ import java.util.logging.Logger;
  * This is bound to the start event of the clock and dispatches it to the appropriate application code.
  */
 public final class DriverStartHandler implements EventHandler<StartTime> {
+
   private static final Logger LOG = Logger.getLogger(DriverStartHandler.class.getName());
 
   private final Set<EventHandler<StartTime>> startHandlers;
   private final Set<EventHandler<DriverRestarted>> restartHandlers;
   private final Set<EventHandler<DriverRestarted>> serviceRestartHandlers;
+
   private final DriverRestartManager driverRestartManager;
 
   @Inject
-  DriverStartHandler(@Parameter(org.apache.reef.driver.parameters.DriverStartHandler.class)
-                     final Set<EventHandler<StartTime>> startHandlers,
-                     @Parameter(DriverRestartHandler.class)
-                     final Set<EventHandler<DriverRestarted>> restartHandlers,
-                     @Parameter(ServiceDriverRestartedHandlers.class)
-                     final Set<EventHandler<DriverRestarted>> serviceRestartHandlers,
-                     final DriverRestartManager driverRestartManager) {
+  private DriverStartHandler(
+      @Parameter(org.apache.reef.driver.parameters.DriverStartHandler.class)
+        final Set<EventHandler<StartTime>> startHandlers,
+      @Parameter(DriverRestartHandler.class)
+        final Set<EventHandler<DriverRestarted>> restartHandlers,
+      @Parameter(ServiceDriverRestartedHandlers.class)
+        final Set<EventHandler<DriverRestarted>> serviceRestartHandlers,
+      final DriverRestartManager driverRestartManager) {
+
     this.startHandlers = startHandlers;
     this.restartHandlers = restartHandlers;
     this.serviceRestartHandlers = serviceRestartHandlers;
     this.driverRestartManager = driverRestartManager;
-    LOG.log(Level.FINE, "Instantiated `DriverStartHandler with StartHandlers [{0}], RestartHandlers [{1}]," +
-            "and ServiceRestartHandlers [{2}].",
-        new String[] {this.startHandlers.toString(), this.restartHandlers.toString(),
-            this.serviceRestartHandlers.toString()});
+
+    LOG.log(Level.FINE,
+        "Instantiated DriverStartHandler: StartHandlers:{0} RestartHandlers:{1} ServiceRestartHandlers:{2}",
+        new Object[] {this.startHandlers, this.restartHandlers, this.serviceRestartHandlers});
   }
 
   @Override
@@ -73,19 +77,20 @@ public final class DriverStartHandler implements EventHandler<StartTime> {
   }
 
   private void onRestart(final StartTime startTime) {
-    if (this.restartHandlers.size() > 0) {
-      final List<EventHandler<DriverRestarted>> orderedRestartHandlers =
-          new ArrayList<>(this.serviceRestartHandlers.size() + this.restartHandlers.size());
 
-      orderedRestartHandlers.addAll(this.serviceRestartHandlers);
-      orderedRestartHandlers.addAll(this.restartHandlers);
-
-      // This can only be called after calling client restart handlers because REEF.NET
-      // JobDriver requires making this call to set up the InterOp handlers.
-      this.driverRestartManager.onRestart(startTime, orderedRestartHandlers);
-    } else {
-      throw new DriverFatalRuntimeException("Driver restart happened, but no ON_DRIVER_RESTART handler is bound.");
+    if (this.restartHandlers.isEmpty()) {
+      throw new DriverFatalRuntimeException("Driver restarted, but no ON_DRIVER_RESTART handler is bound.");
     }
+
+    final List<EventHandler<DriverRestarted>> orderedRestartHandlers =
+        new ArrayList<>(this.serviceRestartHandlers.size() + this.restartHandlers.size());
+
+    orderedRestartHandlers.addAll(this.serviceRestartHandlers);
+    orderedRestartHandlers.addAll(this.restartHandlers);
+
+    // This can only be called after calling client restart handlers because REEF.NET
+    // JobDriver requires making this call to set up the InterOp handlers.
+    this.driverRestartManager.onRestart(startTime, orderedRestartHandlers);
   }
 
   private void onStart(final StartTime startTime) {

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFEnvironment.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFEnvironment.java
@@ -22,11 +22,14 @@ import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.proto.ReefServiceProtos;
 import org.apache.reef.runtime.common.REEFEnvironment;
 import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
+import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.runtime.local.driver.LocalDriverConfiguration;
 import org.apache.reef.runtime.local.driver.RuntimeIdentifier;
 import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.util.EnvironmentUtils;
+import org.apache.reef.wake.remote.RemoteConfiguration;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -39,20 +42,26 @@ public final class HelloREEFEnvironment {
   private static final Logger LOG = Logger.getLogger(HelloREEFEnvironment.class.getName());
 
   private static final Configuration DRIVER_CONFIG = DriverConfiguration.CONF
+      .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF_Env")
       .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(HelloDriver.class))
-      .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF")
       .set(DriverConfiguration.ON_DRIVER_STARTED, HelloDriver.StartHandler.class)
       .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, HelloDriver.EvaluatorAllocatedHandler.class)
       .build();
 
   private static final Configuration LOCAL_DRIVER_MODULE = LocalDriverConfiguration.CONF
-      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 2)
-      .set(LocalDriverConfiguration.ROOT_FOLDER, ".")
-      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
+      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
       .set(LocalDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, ClientRemoteIdentifier.NONE)
       .set(LocalDriverConfiguration.JOB_IDENTIFIER, "LOCAL_ENV_DRIVER_TEST")
-      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
+      .set(LocalDriverConfiguration.ROOT_FOLDER, "./REEF_LOCAL_RUNTIME")
+      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 2)
+      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
       .build();
+
+  private static final Configuration ENVIRONMENT_CONFIG =
+      Tang.Factory.getTang().newConfigurationBuilder()
+          .bindNamedParameter(RemoteConfiguration.ManagerName.class, "REEF_ENVIRONMENT")
+          .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
+          .build();
 
   /**
    * Start Hello REEF job with Driver and Client sharing the same process.
@@ -62,7 +71,8 @@ public final class HelloREEFEnvironment {
    */
   public static void main(final String[] args) throws InjectionException {
 
-    try (final REEFEnvironment reef = REEFEnvironment.fromConfiguration(LOCAL_DRIVER_MODULE, DRIVER_CONFIG)) {
+    try (final REEFEnvironment reef = REEFEnvironment.fromConfiguration(
+        LOCAL_DRIVER_MODULE, DRIVER_CONFIG, ENVIRONMENT_CONFIG)) {
       reef.run();
       final ReefServiceProtos.JobStatusProto status = reef.getLastStatus();
       LOG.log(Level.INFO, "REEF job completed: {0}", status);

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/driver/REEFEnvironmentDriverTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/driver/REEFEnvironmentDriverTest.java
@@ -37,18 +37,18 @@ import org.junit.Test;
 public final class REEFEnvironmentDriverTest {
 
   private static final Configuration DRIVER_CONFIG = DriverConfiguration.CONF
-      .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(DriverTestStartHandler.class))
       .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_REEFEnvironmentDriverTest")
+      .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(DriverTestStartHandler.class))
       .set(DriverConfiguration.ON_DRIVER_STARTED, DriverTestStartHandler.class)
       .build();
 
   private static final Configuration LOCAL_DRIVER_MODULE = LocalDriverConfiguration.CONF
-      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 1)
-      .set(LocalDriverConfiguration.ROOT_FOLDER, ".")
-      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
+      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
       .set(LocalDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, ClientRemoteIdentifier.NONE)
       .set(LocalDriverConfiguration.JOB_IDENTIFIER, "LOCAL_ENV_DRIVER_TEST")
-      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
+      .set(LocalDriverConfiguration.ROOT_FOLDER, "./REEF_LOCAL_RUNTIME")
+      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 1)
+      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
       .build();
 
   @Test

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/REEFEnvironmentFailDriverTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/REEFEnvironmentFailDriverTest.java
@@ -51,12 +51,12 @@ import org.junit.Test;
 public class REEFEnvironmentFailDriverTest {
 
   private static final Configuration LOCAL_DRIVER_MODULE = LocalDriverConfiguration.CONF
-      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 1)
-      .set(LocalDriverConfiguration.ROOT_FOLDER, ".")
-      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
+      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
       .set(LocalDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, ClientRemoteIdentifier.NONE)
       .set(LocalDriverConfiguration.JOB_IDENTIFIER, "LOCAL_ENV_FAIL_DRIVER_TEST")
-      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
+      .set(LocalDriverConfiguration.ROOT_FOLDER, "./REEF_LOCAL_RUNTIME")
+      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 1)
+      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
       .build();
 
   private static void failOn(final Class<?> clazz) throws BindException, InjectionException {
@@ -88,49 +88,47 @@ public class REEFEnvironmentFailDriverTest {
     failOn(AllocatedEvaluator.class);
   }
 
-  // TODO[REEF-1637] This and subsequent tests: enable when the bug is fixed.
-  // (i.e. in-process Driver can receive heartbeats from Evaluators).
-  // @Test
+  @Test
   public void testFailDriverActiveContext() throws BindException, InjectionException {
     failOn(ActiveContext.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverRunningTask() throws BindException, InjectionException {
     failOn(RunningTask.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverTaskMessage() throws BindException, InjectionException {
     failOn(TaskMessage.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverSuspendedTask() throws BindException, InjectionException {
     failOn(SuspendedTask.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverCompletedTask() throws BindException, InjectionException {
     failOn(CompletedTask.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverCompletedEvaluator() throws BindException, InjectionException {
     failOn(CompletedEvaluator.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverAlarm() throws BindException, InjectionException {
     failOn(Alarm.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverStop() throws BindException, InjectionException {
     failOn(StopTime.class);
   }
 
-  // @Test
+  @Test
   public void testDriverCompleted() throws BindException, InjectionException {
 
     // REEFEnvironmentFailDriverTest can be replaced with any other class never used in FailDriver

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultErrorHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultErrorHandler.java
@@ -21,18 +21,23 @@ package org.apache.reef.wake.remote;
 import org.apache.reef.wake.EventHandler;
 
 import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The default RemoteConfiguration.ErrorHandler.
  */
 final class DefaultErrorHandler implements EventHandler<Throwable> {
 
+  private static final Logger LOG = Logger.getLogger(DefaultErrorHandler.class.getName());
+
   @Inject
-  DefaultErrorHandler() {
+  private DefaultErrorHandler() {
   }
 
   @Override
   public void onNext(final Throwable value) {
+    LOG.log(Level.SEVERE, "No error handler in RemoteManager", value);
     throw new RuntimeException("No error handler bound for RemoteManager.", value);
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManager.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManager.java
@@ -18,7 +18,6 @@
  */
 package org.apache.reef.wake.remote;
 
-
 import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.Stage;
@@ -29,9 +28,6 @@ import org.apache.reef.wake.remote.impl.DefaultRemoteManagerImplementation;
  */
 @DefaultImplementation(DefaultRemoteManagerImplementation.class)
 public interface RemoteManager extends Stage {
-  /**
-   * Constructor that takes a Codec<T>
-   */
 
   /**
    * Returns an event handler that can be used to send messages of type T to the

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEvent.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEvent.java
@@ -29,7 +29,9 @@ public class RemoteEvent<T> {
 
   private final T event;
   private final long seq;
+
   //private static final AtomicLong curSeq = new AtomicLong(0);
+
   private SocketAddress localAddr;
   private SocketAddress remoteAddr;
 
@@ -108,17 +110,8 @@ public class RemoteEvent<T> {
    * @return a string representation of this object
    */
   public String toString() {
-    final StringBuilder builder = new StringBuilder();
-    builder.append("RemoteEvent");
-    builder.append(" localAddr=");
-    builder.append(localAddr);
-    builder.append(" remoteAddr=");
-    builder.append(remoteAddr);
-    builder.append(" seq=");
-    builder.append(seq);
-    builder.append(" event=");
-    builder.append(event);
-    return builder.toString();
+    return String.format(
+        "RemoteEvent localAddr=%s remoteAddr=%s seq=%d event=%s:%s",
+        this.localAddr, this.remoteAddr, this.seq, this.event.getClass().getCanonicalName(), this.event);
   }
-
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/TransportEvent.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/TransportEvent.java
@@ -22,11 +22,11 @@ import org.apache.reef.wake.remote.transport.Link;
 
 import java.net.SocketAddress;
 
-
 /**
  * Event sent from a remote node.
  */
 public class TransportEvent {
+
   private final byte[] data;
   private final SocketAddress localAddr;
   private final SocketAddress remoteAddr;
@@ -63,6 +63,13 @@ public class TransportEvent {
       localAddr = null;
       remoteAddr = null;
     }
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "TransportEvent: {local: %s remote: %s size: %d bytes}",
+        this.localAddr, this.remoteAddr, this.data.length);
   }
 
   /**
@@ -102,5 +109,4 @@ public class TransportEvent {
   public SocketAddress getRemoteAddress() {
     return remoteAddr;
   }
-
 }


### PR DESCRIPTION
Summary of changes:
   * Improve logging in the `RemoteManager` and around
   * Implement `.toString()` methods for some remote messages
   * Log unhandled exceptions in `DefaultErrorHandler`
   * Pass proper `REEFMessageCodec` to all unit tests and examples
   * Multiple code readability improvements
   * Enable commented-out unit tests from [REEF-1615](https://issues.apache.org/jira/browse/REEF-1615)

JIRA: [REEF-1637](https://issues.apache.org/jira/browse/REEF-1637)