### PR TITLE
[REEF-1650] Warn about unclean evaluator shutdown only if evaluator is not closing yet

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
@@ -70,8 +70,8 @@ public final class Evaluators implements AutoCloseable {
       evaluatorsCopy = new ArrayList<>(this.evaluators.values());
     }
     for (final EvaluatorManager evaluatorManager : evaluatorsCopy) {
-      LOG.log(Level.WARNING, "Unclean shutdown of evaluator {0}", evaluatorManager.getId());
       if (!evaluatorManager.isClosedOrClosing()) {
+        LOG.log(Level.WARNING, "Unclean shutdown of evaluator {0}", evaluatorManager.getId());
         evaluatorManager.close();
       }
     }


### PR DESCRIPTION
JIRA:
  [REEF-1650](https://issues.apache.org/jira/browse/REEF-1650)

Pull request:
  This closes #