### PR TITLE
[REEF-1637] Bugfix: When launched via REEFEnvironment, Driver does not receive heartbeats from Evaluators

### DIFF
--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFEnvironment.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFEnvironment.java
@@ -22,11 +22,14 @@ import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.proto.ReefServiceProtos;
 import org.apache.reef.runtime.common.REEFEnvironment;
 import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
+import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.runtime.local.driver.LocalDriverConfiguration;
 import org.apache.reef.runtime.local.driver.RuntimeIdentifier;
 import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.util.EnvironmentUtils;
+import org.apache.reef.wake.remote.RemoteConfiguration;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -39,20 +42,26 @@ public final class HelloREEFEnvironment {
   private static final Logger LOG = Logger.getLogger(HelloREEFEnvironment.class.getName());
 
   private static final Configuration DRIVER_CONFIG = DriverConfiguration.CONF
+      .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF_Env")
       .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(HelloDriver.class))
-      .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF")
       .set(DriverConfiguration.ON_DRIVER_STARTED, HelloDriver.StartHandler.class)
       .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, HelloDriver.EvaluatorAllocatedHandler.class)
       .build();
 
   private static final Configuration LOCAL_DRIVER_MODULE = LocalDriverConfiguration.CONF
-      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 2)
-      .set(LocalDriverConfiguration.ROOT_FOLDER, ".")
-      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
+      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
       .set(LocalDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, ClientRemoteIdentifier.NONE)
       .set(LocalDriverConfiguration.JOB_IDENTIFIER, "LOCAL_ENV_DRIVER_TEST")
-      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
+      .set(LocalDriverConfiguration.ROOT_FOLDER, "./REEF_LOCAL_RUNTIME")
+      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 2)
+      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
       .build();
+
+  private static final Configuration ENVIRONMENT_CONFIG =
+      Tang.Factory.getTang().newConfigurationBuilder()
+          .bindNamedParameter(RemoteConfiguration.ManagerName.class, "REEF_ENVIRONMENT")
+          .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
+          .build();
 
   /**
    * Start Hello REEF job with Driver and Client sharing the same process.
@@ -62,7 +71,8 @@ public final class HelloREEFEnvironment {
    */
   public static void main(final String[] args) throws InjectionException {
 
-    try (final REEFEnvironment reef = REEFEnvironment.fromConfiguration(LOCAL_DRIVER_MODULE, DRIVER_CONFIG)) {
+    try (final REEFEnvironment reef = REEFEnvironment.fromConfiguration(
+        LOCAL_DRIVER_MODULE, DRIVER_CONFIG, ENVIRONMENT_CONFIG)) {
       reef.run();
       final ReefServiceProtos.JobStatusProto status = reef.getLastStatus();
       LOG.log(Level.INFO, "REEF job completed: {0}", status);

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/driver/REEFEnvironmentDriverTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/driver/REEFEnvironmentDriverTest.java
@@ -37,18 +37,18 @@ import org.junit.Test;
 public final class REEFEnvironmentDriverTest {
 
   private static final Configuration DRIVER_CONFIG = DriverConfiguration.CONF
-      .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(DriverTestStartHandler.class))
       .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_REEFEnvironmentDriverTest")
+      .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(DriverTestStartHandler.class))
       .set(DriverConfiguration.ON_DRIVER_STARTED, DriverTestStartHandler.class)
       .build();
 
   private static final Configuration LOCAL_DRIVER_MODULE = LocalDriverConfiguration.CONF
-      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 1)
-      .set(LocalDriverConfiguration.ROOT_FOLDER, ".")
-      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
+      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
       .set(LocalDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, ClientRemoteIdentifier.NONE)
       .set(LocalDriverConfiguration.JOB_IDENTIFIER, "LOCAL_ENV_DRIVER_TEST")
-      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
+      .set(LocalDriverConfiguration.ROOT_FOLDER, "./REEF_LOCAL_RUNTIME")
+      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 1)
+      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
       .build();
 
   @Test

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/REEFEnvironmentFailDriverTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/REEFEnvironmentFailDriverTest.java
@@ -51,12 +51,12 @@ import org.junit.Test;
 public class REEFEnvironmentFailDriverTest {
 
   private static final Configuration LOCAL_DRIVER_MODULE = LocalDriverConfiguration.CONF
-      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 1)
-      .set(LocalDriverConfiguration.ROOT_FOLDER, ".")
-      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
+      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
       .set(LocalDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, ClientRemoteIdentifier.NONE)
       .set(LocalDriverConfiguration.JOB_IDENTIFIER, "LOCAL_ENV_FAIL_DRIVER_TEST")
-      .set(LocalDriverConfiguration.RUNTIME_NAMES, RuntimeIdentifier.RUNTIME_NAME)
+      .set(LocalDriverConfiguration.ROOT_FOLDER, "./REEF_LOCAL_RUNTIME")
+      .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, 1)
+      .set(LocalDriverConfiguration.JVM_HEAP_SLACK, 0.0)
       .build();
 
   private static void failOn(final Class<?> clazz) throws BindException, InjectionException {
@@ -88,49 +88,47 @@ public class REEFEnvironmentFailDriverTest {
     failOn(AllocatedEvaluator.class);
   }
 
-  // TODO[REEF-1637] This and subsequent tests: enable when the bug is fixed.
-  // (i.e. in-process Driver can receive heartbeats from Evaluators).
-  // @Test
+  @Test
   public void testFailDriverActiveContext() throws BindException, InjectionException {
     failOn(ActiveContext.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverRunningTask() throws BindException, InjectionException {
     failOn(RunningTask.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverTaskMessage() throws BindException, InjectionException {
     failOn(TaskMessage.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverSuspendedTask() throws BindException, InjectionException {
     failOn(SuspendedTask.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverCompletedTask() throws BindException, InjectionException {
     failOn(CompletedTask.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverCompletedEvaluator() throws BindException, InjectionException {
     failOn(CompletedEvaluator.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverAlarm() throws BindException, InjectionException {
     failOn(Alarm.class);
   }
 
-  // @Test
+  @Test
   public void testFailDriverStop() throws BindException, InjectionException {
     failOn(StopTime.class);
   }
 
-  // @Test
+  @Test
   public void testDriverCompleted() throws BindException, InjectionException {
 
     // REEFEnvironmentFailDriverTest can be replaced with any other class never used in FailDriver


### PR DESCRIPTION
Summary of changes:
  * Pass proper `REEFMessageCodec` and RM name to all unit tests and examples
  * Enable commented-out unit tests from [REEF-1615](https://issues.apache.org/jira/browse/REEF-1615)
  * Multiple code readability improvements

JIRA: [REEF-1637](https://issues.apache.org/jira/browse/REEF-1637)