### PR TITLE
[REEF-1655] Close the driver restart manager on driver shutdown

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStopHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStopHandler.java
@@ -21,6 +21,7 @@ package org.apache.reef.runtime.common.driver;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.parameters.ResourceManagerPreserveEvaluators;
+import org.apache.reef.driver.restart.DriverRestartManager;
 import org.apache.reef.exception.DriverFatalRuntimeException;
 import org.apache.reef.runtime.common.driver.api.ResourceManagerStopHandler;
 import org.apache.reef.runtime.common.driver.evaluator.Evaluators;
@@ -44,6 +45,7 @@ final class DriverRuntimeStopHandler implements EventHandler<RuntimeStop> {
 
   private static final Logger LOG = Logger.getLogger(DriverRuntimeStopHandler.class.getName());
 
+  private final DriverRestartManager driverRestartManager;
   private final DriverStatusManager driverStatusManager;
   private final ResourceManagerStopHandler resourceManagerStopHandler;
   private final RemoteManager remoteManager;
@@ -51,13 +53,15 @@ final class DriverRuntimeStopHandler implements EventHandler<RuntimeStop> {
   private final boolean preserveEvaluatorsAcrossRestarts;
 
   @Inject
-  DriverRuntimeStopHandler(
+  private DriverRuntimeStopHandler(
+      @Parameter(ResourceManagerPreserveEvaluators.class) final boolean preserveEvaluatorsAcrossRestarts,
+      final DriverRestartManager driverRestartManager,
       final DriverStatusManager driverStatusManager,
       final ResourceManagerStopHandler resourceManagerStopHandler,
       final RemoteManager remoteManager,
-      final Evaluators evaluators,
-      @Parameter(ResourceManagerPreserveEvaluators.class) final boolean preserveEvaluatorsAcrossRestarts) {
+      final Evaluators evaluators) {
 
+    this.driverRestartManager = driverRestartManager;
     this.driverStatusManager = driverStatusManager;
     this.resourceManagerStopHandler = resourceManagerStopHandler;
     this.remoteManager = remoteManager;
@@ -93,5 +97,7 @@ final class DriverRuntimeStopHandler implements EventHandler<RuntimeStop> {
       LOG.log(Level.WARNING, "Error when closing the RemoteManager", e);
       throw new RuntimeException("Unable to close the RemoteManager.", e);
     }
+
+    this.driverRestartManager.close();
   }
 }


### PR DESCRIPTION
This work is towards clean shutdown of the driver for "REEF as a library" [REEF-1561](https://issues.apache.org/jira/browse/REEF-1561) project

Changes:
- Make `DriverRuntimeRestartManager` implement `AutoCloseable` to shut down the timer thread;
- Invoke `.close()` method in `DriverRuntimeStopHandler` on driver shutdown

JIRA: [REEF-1655](https://issues.apache.org/jira/browse/REEF-1655)
