### PR TITLE
[REEF-1656] Implement proper logging of threads that are still running at the end of the REEF process

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFEnvironment.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFEnvironment.java
@@ -31,6 +31,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.util.EnvironmentUtils;
 import org.apache.reef.util.REEFVersion;
+import org.apache.reef.util.ThreadLogger;
 import org.apache.reef.wake.profiler.WakeProfiler;
 import org.apache.reef.wake.time.Clock;
 
@@ -52,6 +53,8 @@ public final class REEFEnvironment implements Runnable, AutoCloseable {
   private static final class ProfilingEnabled implements Name<Boolean> { }
 
   private static final Logger LOG = Logger.getLogger(REEFEnvironment.class.getName());
+
+  private static final String CLASS_NAME = REEFEnvironment.class.getCanonicalName();
 
   private static final Tang TANG = Tang.Factory.getTang();
 
@@ -131,7 +134,7 @@ public final class REEFEnvironment implements Runnable, AutoCloseable {
   @SuppressWarnings("checkstyle:illegalcatch") // Catch throwable to feed it to error handler
   public void close() {
 
-    LOG.log(Level.FINER, "Closing REEF Environment - start");
+    LOG.entering(CLASS_NAME, "close");
 
     try {
       this.clock.close();
@@ -150,7 +153,9 @@ public final class REEFEnvironment implements Runnable, AutoCloseable {
       }
     }
 
-    LOG.log(Level.FINER, "Closing REEF Environment - end");
+    ThreadLogger.logThreads(LOG, Level.FINEST, "Threads running after REEFEnvironment.close():");
+
+    LOG.exiting(CLASS_NAME, "close");
   }
 
   /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
@@ -185,15 +185,9 @@ public final class REEFLauncher {
 
     LOG.log(Level.INFO, "Exiting REEFLauncher.main()");
 
-    if (LOG.isLoggable(Level.FINEST)) {
-      LOG.log(Level.FINEST, ThreadLogger.getFormattedThreadList("Threads running after REEFLauncher.close():"));
-    }
-
     System.exit(0);
 
-    if (LOG.isLoggable(Level.FINEST)) {
-      LOG.log(Level.FINEST, ThreadLogger.getFormattedThreadList("Threads running after System.exit():"));
-    }
+    ThreadLogger.logThreads(LOG, Level.FINEST, "Threads running after System.exit():");
   }
 
   /**

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
@@ -212,7 +212,7 @@ public final class RuntimeClock implements Clock {
     synchronized (this.schedule) {
 
       if (this.isClosed) {
-        LOG.log(Level.FINEST, "Clock has already been closed");
+        LOG.exiting(CLASS_NAME, "close", "Clock has already been closed");
         return;
       }
 
@@ -266,24 +266,6 @@ public final class RuntimeClock implements Clock {
     for (final EventHandler<T> handler : handlers) {
       LOG.log(Level.FINEST, "Subscribe: event {0} handler {1}", new Object[] {eventClass.getName(), handler});
       this.handlers.subscribe(eventClass, handler);
-    }
-  }
-
-  /**
-   * Logs the currently running threads.
-   * @param level Log level used to write the entry.
-   * @param prefix put before the comma-separated list of threads
-   */
-  private static void logThreads(final Level level, final String prefix) {
-
-    if (LOG.isLoggable(level)) {
-
-      final StringBuilder sb = new StringBuilder(prefix);
-      for (final Thread t : Thread.getAllStackTraces().keySet()) {
-        sb.append(t.getName()).append(", ");
-      }
-
-      LOG.log(level, sb.toString());
     }
   }
 
@@ -382,8 +364,6 @@ public final class RuntimeClock implements Clock {
       this.handlers.onNext(new RuntimeStop(this.timer.getCurrent(), e));
 
     } finally {
-
-      logThreads(Level.FINE, "Threads running after exiting the clock main loop: ");
       LOG.log(Level.FINE, "Runtime clock exit");
     }
 


### PR DESCRIPTION

This work is towards clean shutdown of the driver for "REEF as a library" [REEF-1561](https://issues.apache.org/jira/browse/REEF-1561) project

Changes:
  * Make `DriverRuntimeRestartManager` implement `AutoCloseable` to shut down the timer thread;
  * Invoke `.close()` method in `DriverRuntimeStopHandler` on driver shutdown

JIRA: [REEF-1655](https://issues.apache.org/jira/browse/REEF-1655)