### PR TITLE
[REEF-1657] Better thread names in REEF and Wake + logging improvements in shutdown phase

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFErrorHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFErrorHandler.java
@@ -39,6 +39,7 @@ import java.util.logging.Logger;
 public final class REEFErrorHandler implements EventHandler<Throwable>, AutoCloseable {
 
   private static final Logger LOG = Logger.getLogger(REEFErrorHandler.class.getName());
+  private static final String CLASS_NAME = REEFErrorHandler.class.getCanonicalName();
 
   // This class is used as the ErrorHandler in the RemoteManager. Hence, we need an InjectionFuture here.
   private final InjectionFuture<RemoteManager> remoteManager;
@@ -47,10 +48,12 @@ public final class REEFErrorHandler implements EventHandler<Throwable>, AutoClos
   private final ExceptionCodec exceptionCodec;
 
   @Inject
-  REEFErrorHandler(final InjectionFuture<RemoteManager> remoteManager,
-                   @Parameter(ErrorHandlerRID.class) final String errorHandlerRID,
-                   @Parameter(LaunchID.class) final String launchID,
-                   final ExceptionCodec exceptionCodec) {
+  REEFErrorHandler(
+      @Parameter(ErrorHandlerRID.class) final String errorHandlerRID,
+      @Parameter(LaunchID.class) final String launchID,
+      final InjectionFuture<RemoteManager> remoteManager,
+      final ExceptionCodec exceptionCodec) {
+
     this.errorHandlerRID = errorHandlerRID;
     this.remoteManager = remoteManager;
     this.launchID = launchID;
@@ -91,19 +94,22 @@ public final class REEFErrorHandler implements EventHandler<Throwable>, AutoClos
 
   @SuppressWarnings("checkstyle:illegalcatch")
   public void close() {
+
+    LOG.entering(CLASS_NAME, "close");
+
     try {
       this.remoteManager.get().close();
     } catch (final Throwable ex) {
       LOG.log(Level.SEVERE, "Unable to close the remote manager", ex);
     }
+
+    LOG.exiting(CLASS_NAME, "close");
   }
 
   @Override
   public String toString() {
-    return "REEFErrorHandler{" +
-        "remoteManager=" + remoteManager +
-        ", launchID='" + launchID + '\'' +
-        ", errorHandlerRID='" + errorHandlerRID + '\'' +
-        '}';
+    return String.format(
+        "REEFErrorHandler: { remoteManager:{%s}, launchID:%s, errorHandlerRID:%s }",
+        this.remoteManager.get(), this.launchID, this.errorHandlerRID);
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
@@ -32,6 +32,7 @@ import java.util.logging.Logger;
 public class RemoteManager {
 
   private static final Logger LOG = Logger.getLogger(RemoteManager.class.getName());
+  private static final String CLASS_NAME = RemoteManager.class.getCanonicalName();
 
   private final org.apache.reef.wake.remote.RemoteManager raw;
   private final RemoteIdentifierFactory factory;
@@ -41,7 +42,7 @@ public class RemoteManager {
                        final RemoteIdentifierFactory factory) {
     this.raw = raw;
     this.factory = factory;
-    LOG.log(Level.FINE, "Instantiated 'RemoteManager' with remoteId: {0}", this.getMyIdentifier());
+    LOG.log(Level.FINE, "Instantiated RemoteManager wrapper: {0}", this.raw);
   }
 
   public final org.apache.reef.wake.remote.RemoteManager raw() {
@@ -49,7 +50,9 @@ public class RemoteManager {
   }
 
   public void close() throws Exception {
+    LOG.entering(CLASS_NAME, "close");
     this.raw.close();
+    LOG.exiting(CLASS_NAME, "close");
   }
 
   public <T> EventHandler<T> getHandler(
@@ -71,5 +74,9 @@ public class RemoteManager {
   public String getMyIdentifier() {
     return this.raw.getMyIdentifier().toString();
   }
-}
 
+  @Override
+  public String toString() {
+    return "RemoteManager wrap: " + this.raw;
+  }
+}

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ProcessContainer.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ProcessContainer.java
@@ -55,6 +55,7 @@ public final class ProcessContainer implements Container {
   private final File globalFolder;
   private final RunnableProcessObserver processObserver;
   private final ThreadGroup threadGroup;
+
   private Thread theThread;
   private RunnableProcess process;
 
@@ -134,13 +135,16 @@ public final class ProcessContainer implements Container {
 
   @Override
   public void run(final List<String> commandLine) {
-    this.process = new RunnableProcess(commandLine,
+
+    this.process = new RunnableProcess(
+        commandLine,
         this.containedID,
         this.folder,
         this.processObserver,
         this.fileNames.getEvaluatorStdoutFileName(),
         this.fileNames.getEvaluatorStderrFileName());
-    this.theThread = new Thread(this.threadGroup, this.process, this.containedID);
+
+    this.theThread = new Thread(this.threadGroup, this.process, "ProcessContainer:" + this.containedID);
     this.theThread.start();
   }
 
@@ -189,12 +193,8 @@ public final class ProcessContainer implements Container {
 
   @Override
   public String toString() {
-    return "ProcessContainer{" +
-        "containedID='" + containedID + '\'' +
-        ", nodeID='" + nodeID + '\'' +
-        ", errorHandlerRID='" + errorHandlerRID + '\'' +
-        ", folder=" + folder + '\'' +
-        ", rack=" + rackName +
-        '}';
+    return String.format(
+        "ProcessContainer{containedID=%s, nodeID=%s, errorHandlerRID=%s, folder=%s, rack=%s}",
+        this.containedID, this.nodeID, this.errorHandlerRID, this.folder, this.rackName);
   }
 }


### PR DESCRIPTION
This work is towards cleaner shutdown of REEF application required for "REEF as a library" [REEF-1561](https://issues.apache.org/jira/browse/REEF-1561) project

There are no functionality changes in this PR.

Summary of changes:
- More descriptive names for threads created in Wake `OrderedRemoteReceiverStage` and `DefaultThreadFactory`
- Better thread names in REEF `ProcessContainer` and `EvaluatorMessageDispatcher`
- Better logging in `REEFErrorHandler` and in many `.close()` methods in REEF
- Minor refactoring in shutdown code; no functionality changes

JIRA: [REEF-1657](https://issues.apache.org/jira/browse/REEF-1657)
