### PR TITLE
Reef 1646 ConfigurationBuilder: adding argument exception if one of initialization configs is null.

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/ConfigurationBuilderImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/Configuration/ConfigurationBuilderImpl.cs
@@ -59,6 +59,11 @@ namespace Org.Apache.REEF.Tang.Implementations.Configuration
             this.ClassHierarchy = TangFactory.GetTang().GetDefaultClassHierarchy(assemblies, parsers);
             foreach (IConfiguration tc in confs) 
             {
+                if (tc == null)
+                {
+                    throw new ArgumentNullException("One of specified configurations is null");
+                } 
+                
                 AddConfiguration((ConfigurationImpl)tc);
             }
         }


### PR DESCRIPTION
Reef 1646
Optional Configuraiton is supported by setting EMPTY config in job definition.
For better error handling, adding argument exception if one of initialization configs is null.