### PR TITLE
[REEF-1658] Gracefully shut down all threads at the end of the REEF job

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorIdlenessThreadPool.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorIdlenessThreadPool.java
@@ -26,8 +26,10 @@ import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.wake.impl.DefaultThreadFactory;
 
 import javax.inject.Inject;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -36,22 +38,25 @@ import java.util.logging.Logger;
  * of an {@link EvaluatorManager} in order to trigger Evaluator idleness checks.
  */
 @Private
-public final class EvaluatorIdlenessThreadPool {
+public final class EvaluatorIdlenessThreadPool implements AutoCloseable {
+
   private static final Logger LOG = Logger.getLogger(EvaluatorIdlenessThreadPool.class.getName());
 
   private final ExecutorService executor;
   private final long waitInMillis;
 
   @Inject
-  private EvaluatorIdlenessThreadPool(@Parameter(EvaluatorIdlenessThreadPoolSize.class) final int numThreads,
-                                      @Parameter(EvaluatorIdlenessWaitInMilliseconds.class) final long waitInMillis) {
+  private EvaluatorIdlenessThreadPool(
+      @Parameter(EvaluatorIdlenessThreadPoolSize.class) final int numThreads,
+      @Parameter(EvaluatorIdlenessWaitInMilliseconds.class) final long waitInMillis) {
 
     Validate.isTrue(waitInMillis >= 0, "EvaluatorIdlenessWaitInMilliseconds must be configured to be >= 0");
     Validate.isTrue(numThreads > 0, "EvaluatorIdlenessThreadPoolSize must be configured to be > 0");
 
     this.waitInMillis = waitInMillis;
+
     this.executor = Executors.newFixedThreadPool(
-        numThreads, new DefaultThreadFactory(EvaluatorIdlenessThreadPool.class.getName()));
+        numThreads, new DefaultThreadFactory(this.getClass().getSimpleName()));
   }
 
   /**
@@ -60,12 +65,25 @@ public final class EvaluatorIdlenessThreadPool {
    * @param manager the {@link EvaluatorManager}
    */
   void runCheckAsync(final EvaluatorManager manager) {
-    executor.submit(new Runnable() {
+
+    final String evaluatorId = manager.getId();
+    LOG.log(Level.FINEST, "Idle check for Evaluator: {0}", manager);
+
+    this.executor.submit(new Runnable() {
       @Override
       public void run() {
+
+        LOG.log(Level.FINEST, "Idle check for Evaluator {0} - begin", evaluatorId);
+
         while (!manager.isClosed()) {
           try {
+
+            LOG.log(Level.FINEST,
+                "Waiting for Evaluator {0} to close: Sleep for {1} ms",
+                new Object[] {evaluatorId, waitInMillis});
+
             Thread.sleep(waitInMillis);
+
           } catch (final InterruptedException e) {
             LOG.log(Level.SEVERE, "Thread interrupted while waiting for Evaluator to finish.");
             throw new RuntimeException(e);
@@ -73,8 +91,34 @@ public final class EvaluatorIdlenessThreadPool {
         }
 
         manager.checkIdlenessSource();
-        LOG.log(Level.FINE, "Evaluator " + manager.getId() + " has finished.");
+
+        LOG.log(Level.FINEST, "Idle check for Evaluator {0} - end", evaluatorId);
       }
     });
+  }
+
+  /**
+   * Shutdown the thread pool of idleness checkers.
+   */
+  @Override
+  public void close() {
+
+    LOG.log(Level.FINE, "EvaluatorIdlenessThreadPool shutdown: begin");
+
+    this.executor.shutdown();
+
+    boolean isTerminated = false;
+    try {
+      isTerminated = this.executor.awaitTermination(this.waitInMillis, TimeUnit.MILLISECONDS);
+    } catch (final InterruptedException ex) {
+      LOG.log(Level.WARNING, "EvaluatorIdlenessThreadPool shutdown: Interrupted", ex);
+    }
+
+    if (isTerminated) {
+      LOG.log(Level.FINE, "EvaluatorIdlenessThreadPool shutdown: Terminated successfully");
+    } else {
+      final List<Runnable> pendingJobs = this.executor.shutdownNow();
+      LOG.log(Level.SEVERE, "EvaluatorIdlenessThreadPool shutdown: {0} jobs pending", pendingJobs.size());
+    }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorIdlenessThreadPool.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorIdlenessThreadPool.java
@@ -70,6 +70,7 @@ public final class EvaluatorIdlenessThreadPool implements AutoCloseable {
     LOG.log(Level.FINEST, "Idle check for Evaluator: {0}", manager);
 
     this.executor.submit(new Runnable() {
+
       @Override
       public void run() {
 
@@ -93,6 +94,11 @@ public final class EvaluatorIdlenessThreadPool implements AutoCloseable {
         manager.checkIdlenessSource();
 
         LOG.log(Level.FINEST, "Idle check for Evaluator {0} - end", evaluatorId);
+      }
+
+      @Override
+      public String toString() {
+        return "CheckIdle: " + evaluatorId;
       }
     });
   }
@@ -118,7 +124,8 @@ public final class EvaluatorIdlenessThreadPool implements AutoCloseable {
       LOG.log(Level.FINE, "EvaluatorIdlenessThreadPool shutdown: Terminated successfully");
     } else {
       final List<Runnable> pendingJobs = this.executor.shutdownNow();
-      LOG.log(Level.SEVERE, "EvaluatorIdlenessThreadPool shutdown: {0} jobs pending", pendingJobs.size());
+      LOG.log(Level.SEVERE, "EvaluatorIdlenessThreadPool shutdown: {0} jobs after timeout", pendingJobs.size());
+      LOG.log(Level.FINE, "EvaluatorIdlenessThreadPool shutdown: pending jobs: {0}", pendingJobs);
     }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -219,6 +219,8 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
   @Override
   public void close() {
 
+    LOG.log(Level.FINER, "Closing: {0}", this.toString());
+
     synchronized (this.evaluatorDescriptor) {
 
       if (this.stateManager.isAvailable()) {
@@ -275,6 +277,15 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
     }
 
     this.idlenessThreadPool.runCheckAsync(this);
+
+    LOG.log(Level.FINER, "Closed EvaluatorManager {0}", this.evaluatorId);
+  }
+
+  /**
+   * Close message dispatcher for the evaluator.
+   */
+  public void shutdown() {
+    this.messageDispatcher.close();
   }
 
   /**
@@ -357,7 +368,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
         LOG.log(Level.SEVERE, "Exception while handling FailedEvaluator", e);
       } finally {
         this.stateManager.setFailed();
-        close();
+        this.close();
       }
     }
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -219,7 +219,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
   @Override
   public void close() {
 
-    LOG.log(Level.FINER, "Closing: {0}", this.toString());
+    LOG.log(Level.FINER, "Close EvaluatorManager {0} - begin", this.evaluatorId);
 
     synchronized (this.evaluatorDescriptor) {
 
@@ -278,7 +278,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
 
     this.idlenessThreadPool.runCheckAsync(this);
 
-    LOG.log(Level.FINER, "Closed EvaluatorManager {0}", this.evaluatorId);
+    LOG.log(Level.FINER, "Close EvaluatorManager {0} - end", this.evaluatorId);
   }
 
   /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
@@ -286,7 +286,7 @@ public final class EvaluatorMessageDispatcher implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     LOG.log(Level.FINER, "Closing message dispatcher for {0}", this.evaluatorIdentifier);
     // This effectively closes all dispatchers as they share the same stage.
     this.serviceDispatcher.close();

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/DispatchingEStage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/DispatchingEStage.java
@@ -119,11 +119,9 @@ public final class DispatchingEStage implements AutoCloseable {
 
   /**
    * Close the internal thread pool.
-   *
-   * @throws Exception forwarded from EStage.close() call.
    */
   @Override
-  public void close() throws Exception {
+  public void close() {
     this.stage.close();
   }
 


### PR DESCRIPTION

This work is part of "REEF as a library" project [REEF-1561](https://issues.apache.org/jira/browse/REEF-1561)

After this update, REEF Driver should be able to close *without* explicit `System.exit(0)` invocation at the end. We will keep that call until we test all corner cases more thoroughly to make sure we always clean up the resources on REEF job exit.

Summary of changes:
  * Close the `EvaluatorIdlenessThreadPool` in `DriverRuntimeStopHandler`
  * Make `EvaluatorIdlenessThreadPool` `AutoCloseable` to close the local thread pool
  * Implement `EvaluatorManager.shutdown()` method and call it when removing evaluator from `Evaluators`
  * Make sure `.close()` methods never throw in `DispatchingEStage` and `EvaluatorMessageDispatcher`
  * Give better thread names in `EvaluatorIdlenessThreadPool`
  * Improve logging and error handling in `.close()` methods in all path of the driver shutdown

JIRA: [REEF-1658](https://issues.apache.org/jira/browse/REEF-1658)