### PR TITLE
[REEF-1660] Don't close streams in DFSEvaluatorLogOverwriteReaderWriter before flushing them

### DIFF
--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/restart/DFSEvaluatorLogOverwriteReaderWriter.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/restart/DFSEvaluatorLogOverwriteReaderWriter.java
@@ -82,7 +82,7 @@ public final class DFSEvaluatorLogOverwriteReaderWriter implements DFSEvaluatorL
           inputStream = newEntryInputStream;
         }
 
-        IOUtils.copyBytes(inputStream, outputStream, 4096, true);
+        IOUtils.copyBytes(inputStream, outputStream, 4096, false);
       } finally {
         outputStream.hsync();
         if (inputStream != null) {


### PR DESCRIPTION
This change removes closing streams in call to IOUtils.copyBytes.
This way outputStream is synced while it's still open, so sync operation doesn't fail.

JIRA:
  [REEF-1660](https://issues.apache.org/jira/browse/REEF-1660)

Pull request:
  This closes #