### PR TITLE
[REEF-1665] Better default value for Java runtime path

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/JavaLaunchCommandBuilder.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/JavaLaunchCommandBuilder.java
@@ -37,19 +37,22 @@ import java.util.regex.Pattern;
  * Build the launch command for Java REEF processes.
  */
 public final class JavaLaunchCommandBuilder implements LaunchCommandBuilder {
+
   private static final Logger LOG = Logger.getLogger(JavaLaunchCommandBuilder.class.getName());
 
-  private static final String DEFAULT_JAVA_PATH = System.getenv("JAVA_HOME") + "/bin/" + "java";
+  private static final String DEFAULT_JAVA_PATH = "{{JAVA_HOME}}/bin/java";
   private static final String[] DEFAULT_OPTIONS = {"-XX:PermSize=128m", "-XX:MaxPermSize=128m"};
+
+  private final Map<String, JVMOption> options = new HashMap<>();
+  private final List<String> commandPrefixList;
+  private final Class launcherClass;
+
   private String stderrPath = null;
   private String stdoutPath = null;
   private Optional<List<String>> evaluatorConfigurationPaths = Optional.empty();
   private String javaPath = null;
   private String classPath = null;
   private Boolean assertionsEnabled = null;
-  private final Map<String, JVMOption> options = new HashMap<>();
-  private final List<String> commandPrefixList;
-  private final Class launcherClass;
 
   /**
    * Constructor that populates default options, using the default Launcher

--- a/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/process/RunnableProcessExpandVariablesTest.java
+++ b/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/process/RunnableProcessExpandVariablesTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.local.process;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit tests for the RunnableProcess utility methods.
+ */
+public final class RunnableProcessExpandVariablesTest {
+
+  @Test
+  public void testExpandEnvironmentVariablesEmpty() {
+    final String res = RunnableProcess.expandEnvironmentVariables("");
+    Assert.assertEquals("", res);
+  }
+
+  @Test
+  public void testExpandEnvironmentVariablesNoVars() {
+    final String res = RunnableProcess.expandEnvironmentVariables("foo*bar");
+    Assert.assertEquals("foo*bar", res);
+  }
+
+  @Test
+  public void testExpandEnvironmentVariablesPartial1() {
+    final String res = RunnableProcess.expandEnvironmentVariables("foo{{bar");
+    Assert.assertEquals("foo{{bar", res);
+  }
+
+  @Test
+  public void testExpandEnvironmentVariablesPartial2() {
+    final String res = RunnableProcess.expandEnvironmentVariables("foo{{}}bar");
+    Assert.assertEquals("foo{{}}bar", res);
+  }
+
+  @Test
+  public void testExpandEnvironmentVariablesNonMatching() {
+    final String res = RunnableProcess.expandEnvironmentVariables("foo*{{SOME_RANDOM_VAR}}*bar");
+    Assert.assertEquals("foo**bar", res);
+  }
+
+  @Test
+  public void testExpandEnvironmentVariablesMatching() {
+    final String path = System.getenv("PATH");
+    final String res = RunnableProcess.expandEnvironmentVariables("foo*{{PATH}}*bar");
+    Assert.assertEquals("foo*" + path + "*bar", res);
+  }
+
+  @Test
+  public void testExpandEnvironmentVariablesMatchingMany() {
+    final String path = System.getenv("PATH");
+    final String res = RunnableProcess.expandEnvironmentVariables("foo*{{PATH}}{{PATH}}*bar");
+    Assert.assertEquals("foo*" + path + path + "*bar", res);
+  }
+
+  @Test
+  public void testExpandEnvironmentVariablesList() {
+    final String path = System.getenv("PATH");
+    final List<String> res = RunnableProcess.expandEnvironmentVariables(
+        Arrays.asList("foo*{{PATH}}", "{{PATH}}*bar", "", "etc"));
+    Assert.assertArrayEquals(new String[] {"foo*" + path, path + "*bar", "", "etc"}, res.toArray());
+  }
+}

--- a/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/process/package-info.java
+++ b/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/process/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Tests for the local runtime runnable process.
+ */
+package org.apache.reef.runtime.local.process;


### PR DESCRIPTION

Summary of changes:
  * Fix the default path to java binary use `{{JAVA_HOME}}` notation for all OS
  * Implement `{{...}}` variable expansion for REEF local runtime
  * Write unit tests for various cases of the variable expansion
  * Minor code refactoring for better readability

This fix allows to run `runtests.ps1 -Yarn ...` again.

JIRA: [REEF-1665](https://issues.apache.org/jira/browse/REEF-1665)
