### PR TITLE
[REEF-1669]Removing YarnClient from YarnContainerManager

### DIFF
--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/YarnClasspathProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/YarnClasspathProvider.java
@@ -156,11 +156,11 @@ public final class YarnClasspathProvider implements RuntimeClasspathProvider {
     return this.classPathSuffix;
   }
 
-  private void logEnvVariable() {
+  private static void logEnvVariable() {
     if (LOG.isLoggable(CLASSPATH_LOG_LEVEL)) {
-      Map<String, String> map = System.getenv();
-      for (Map.Entry<String, String> entry : map.entrySet()) {
-        LOG.log(CLASSPATH_LOG_LEVEL, "Environment Variable: Key: " + entry.getKey() + "   Value: " + entry.getValue());
+      for (final Map.Entry<String, String> entry : System.getenv().entrySet()) {
+        LOG.log(CLASSPATH_LOG_LEVEL, "Environment variable: Key: {0}, Value: {1}.",
+            new Object[]{entry.getKey(), entry.getValue()});
       }
     }
   }

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/YarnClasspathProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/YarnClasspathProvider.java
@@ -27,6 +27,7 @@ import org.apache.reef.util.Optional;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -59,6 +60,7 @@ public final class YarnClasspathProvider implements RuntimeClasspathProvider {
       HADOOP_HDFS_HOME + "/lib/*",
       HADOOP_MAPRED_HOME + "/*",
       HADOOP_MAPRED_HOME + "/lib/*",
+      HADOOP_COMMON_HOME + "/etc/hadoop/client/*",
       HADOOP_HOME + "/etc/hadoop",
       HADOOP_HOME + "/share/hadoop/common/*",
       HADOOP_HOME + "/share/hadoop/common/lib/*",
@@ -74,6 +76,7 @@ public final class YarnClasspathProvider implements RuntimeClasspathProvider {
 
   @Inject
   YarnClasspathProvider(final YarnConfiguration yarnConfiguration) {
+    logEnvVariable();
     boolean needsLegacyClasspath = false;
     // will be set to true below whenever we encounter issues with the YARN Configuration
     final ClassPathBuilder builder = new ClassPathBuilder();
@@ -153,6 +156,14 @@ public final class YarnClasspathProvider implements RuntimeClasspathProvider {
     return this.classPathSuffix;
   }
 
+  private void logEnvVariable() {
+    if (LOG.isLoggable(CLASSPATH_LOG_LEVEL)) {
+      Map<String, String> map = System.getenv();
+      for (Map.Entry<String, String> entry : map.entrySet()) {
+        LOG.log(CLASSPATH_LOG_LEVEL, "Environment Variable: Key: " + entry.getKey() + "   Value: " + entry.getValue());
+      }
+    }
+  }
 
   private void logClasspath() {
     if (LOG.isLoggable(CLASSPATH_LOG_LEVEL)) {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/YarnClasspathProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/YarnClasspathProvider.java
@@ -61,7 +61,7 @@ public final class YarnClasspathProvider implements RuntimeClasspathProvider {
       HADOOP_MAPRED_HOME + "/*",
       HADOOP_MAPRED_HOME + "/lib/*",
       HADOOP_COMMON_HOME + "/etc/hadoop/client/*",
-      HADOOP_HOME + "/etc/hadoop",
+      HADOOP_HOME + "/etc/hadoop/*",
       HADOOP_HOME + "/share/hadoop/common/*",
       HADOOP_HOME + "/share/hadoop/common/lib/*",
       HADOOP_HOME + "/share/hadoop/yarn/*",

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.fs.*;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.yarn.api.records.*;
 import org.apache.hadoop.yarn.client.api.AMRMClient;
-import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
 import org.apache.hadoop.yarn.client.api.async.NMClientAsync;
 import org.apache.hadoop.yarn.client.api.async.impl.NMClientAsyncImpl;


### PR DESCRIPTION
Currently we have both YarnClient and resourceManager (AMRMClientAsync) in YarnContainerManager. We call init() and start() for both of them. But inside driver, we are not able to get correct YarnConfiguration for YarnClient, that makes yarnClient.getNodeReports() fail to connect to RM.

In YarnContainerManager, we already have onNodesUpdated() which gives the list of the NodeReports on the fly.  yarnClient.getNodeReports() was called at beginning and it only gives a static list. So looks like we don't need to call it anyway.

Based on RM folks, REEF should not use YarnClient at driver side. This PR is to remove YarnClient from YarnContainerManager. It also added some logs for environment variables with a lower log level or debug.

JIRA: [REEF-1669](https://issues.apache.org/jira/browse/REEF-1669)
This closes  #