### PR TITLE
[REEF-1676] Make REEF compile in VS 2017 RC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ atlassian-ide-plugin.xml
 *.VC.opendb
 *.VC.db
 *.vcxproj.user
+.vs
 #
 # ----------------------------------------------------------------------
 # OS Files

--- a/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj
+++ b/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj
@@ -58,6 +58,10 @@ under the License.
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '14.0'">
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
+  <!-- Visual Studio 2017 (15.0) -->
+  <PropertyGroup Condition="'$(VisualStudioVersion)' == '15.0'">
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
   <!--
     End of: Switch the PlatformToolset based on the Visual Studio Version
   -->


### PR DESCRIPTION
This change:

  * adds `.vs` to the `.gitignore` list as VS 2017 stores its per-use settings in that folder.
  * adds a new condition for Visual Studio 2017 tools to the Bridge C++ project file.

JIRA:
  [REEF-1676](https://issues.apache.org/jira/browse/REEF-1676)