### PR TITLE
[REEF-1677] Count evaluators failed during WaitingForEvaluator phase …

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -528,7 +528,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                                 _serviceAndContextConfigurationProvider.RemoveEvaluatorIdFromPartitionIdProvider(
                                     failedEvaluator.Id);
                                 Logger.Log(Level.Info, "Requesting mapper Evaluators.");
-                                _evaluatorManager.RemoveFailedEvaluator(failedEvaluator.Id);
                                 _evaluatorManager.RequestMapEvaluators(1);
                             }
                             else


### PR DESCRIPTION
…towards MaximumNumberOfEvaluatorFailures limit

Previously evaluators which failed during WaitingForEvaluator phase
were not counted. This caused long wait times for IMRU jobs which had
a lot of failures and should have failed sooner.

JIRA:
  [REEF-1677](https://issues.apache.org/jira/browse/REEF-1677)

Pull request:
  This closes #