### PR TITLE
[REEF-1679]Evaluator shouldn't go to recovery mode if there is no rec…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -199,6 +199,7 @@ under the License.
     <Compile Include="Runtime\Evaluator\HeartBeatManager.cs" />
     <Compile Include="Runtime\Evaluator\IHeartBeatManager.cs" />
     <Compile Include="Runtime\Evaluator\Parameters\EvaluatorHeartbeatPeriodInMs.cs" />
+    <Compile Include="Runtime\Evaluator\Parameters\HeartbeatMaxRetryForNonRecoveryMode.cs" />
     <Compile Include="Runtime\Evaluator\Parameters\HeartbeatMaxRetry.cs" />
     <Compile Include="Runtime\Evaluator\PIDStoreHandler.cs" />
     <Compile Include="Runtime\Evaluator\ReefMessageProtoObserver.cs" />

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorSettings.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/EvaluatorSettings.cs
@@ -35,6 +35,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
         private readonly string _evaluatorId;
         private readonly int _heartBeatPeriodInMs;
         private readonly int _maxHeartbeatRetries;
+        private readonly int _maxHeartbeatRetriesForNonrecoveryMode;
         private readonly IClock _clock;
         private readonly IRemoteManager<REEFMessage> _remoteManager;
 
@@ -45,6 +46,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
         /// <param name="evaluatorId"></param>
         /// <param name="heartbeatPeriodInMs"></param>
         /// <param name="maxHeartbeatRetries"></param>
+        /// <param name="maxHeartbeatRetriesForNonRecoveryMode">Max retry number for non HA mode</param>
         /// <param name="clock"></param>
         /// <param name="remoteManagerFactory"></param>
         /// <param name="reefMessageCodec"></param>
@@ -54,10 +56,11 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
             [Parameter(typeof(EvaluatorIdentifier))] string evaluatorId,
             [Parameter(typeof(EvaluatorHeartbeatPeriodInMs))] int heartbeatPeriodInMs,
             [Parameter(typeof(HeartbeatMaxRetry))] int maxHeartbeatRetries,
+            [Parameter(typeof(HeartbeatMaxRetryForNonRecoveryMode))] int maxHeartbeatRetriesForNonRecoveryMode,
             IClock clock,
             IRemoteManagerFactory remoteManagerFactory,
             REEFMessageCodec reefMessageCodec) :
-            this(applicationId, evaluatorId, heartbeatPeriodInMs, maxHeartbeatRetries, 
+            this(applicationId, evaluatorId, heartbeatPeriodInMs, maxHeartbeatRetries, maxHeartbeatRetriesForNonRecoveryMode,
             clock, remoteManagerFactory, reefMessageCodec, null)
         {
         }
@@ -68,6 +71,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
             [Parameter(typeof(EvaluatorIdentifier))] string evaluatorId,
             [Parameter(typeof(EvaluatorHeartbeatPeriodInMs))] int heartbeatPeriodInMs,
             [Parameter(typeof(HeartbeatMaxRetry))] int maxHeartbeatRetries,
+            [Parameter(typeof(HeartbeatMaxRetryForNonRecoveryMode))] int maxHeartbeatRetriesForNonRecoveryMode,
             IClock clock,
             IRemoteManagerFactory remoteManagerFactory,
             REEFMessageCodec reefMessageCodec,
@@ -77,6 +81,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
             _evaluatorId = evaluatorId;
             _heartBeatPeriodInMs = heartbeatPeriodInMs;
             _maxHeartbeatRetries = maxHeartbeatRetries;
+            _maxHeartbeatRetriesForNonrecoveryMode = maxHeartbeatRetriesForNonRecoveryMode;
             _clock = clock;
 
             _remoteManager = remoteManagerFactory.GetInstance(reefMessageCodec);
@@ -130,6 +135,17 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
             get
             {
                 return _maxHeartbeatRetries;
+            }
+        }
+
+        /// <summary>
+        /// Return MaxHeartbeatRetriesForNonrecoveryMode from NamedParameter
+        /// </summary>
+        public int MaxHeartbeatRetriesForNonRecoveryMode
+        {
+            get
+            {
+                return _maxHeartbeatRetriesForNonrecoveryMode;
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/HeartBeatManager.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/HeartBeatManager.cs
@@ -29,7 +29,6 @@ using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Tang.Implementations.InjectionPlan;
-using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Utilities.Attributes;
 using Org.Apache.REEF.Utilities.Logging;
@@ -155,7 +154,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                 try
                 {
                     _observer.OnNext(payload);
-                    _heartbeatFailures = 0; // reset failure counts if we are having intermidtten (not continuous) failures
+                    _heartbeatFailures = 0; // reset failure counts if we are having intermittent (not continuous) failures
                 }
                 catch (Exception e)
                 {
@@ -173,8 +172,12 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                     {
                         if (_heartbeatFailures >= _maxHeartbeatRetriesForNonRecoveryMode)
                         {
-                            LOGGER.Log(Level.Error, "Have encountered {0} heartbeat failures. There is no IDriverConnection implemented for HA.", _heartbeatFailures);
-                            throw;
+                            var msg =
+                                string.Format(CultureInfo.InvariantCulture,
+                                    "Have encountered {0} heartbeat failures. Limit of heartbeat sending failures exceeded. Driver reconnect logic is not implemented, failing evaluator.",
+                                    _heartbeatFailures);
+                            LOGGER.Log(Level.Error, msg);
+                            throw new ReefRuntimeException(msg, e);
                         }
                     }
                     else
@@ -184,7 +187,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                             LOGGER.Log(Level.Warning,
                                 "Heartbeat communications to driver reached max of {0} failures. Driver is considered dead/unreachable",
                                 _heartbeatFailures);
-                            LOGGER.Log(Level.Info, "=========== Entering RECOVERY mode. ===========");
+                            LOGGER.Log(Level.Info, "Entering RECOVERY mode!!!");
                             ContextManager.HandleDriverConnectionMessage(
                                 new DriverConnectionMessageImpl(DriverConnectionState.Disconnected));
 
@@ -301,27 +304,29 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                     if (_evaluatorSettings.OperationState == EvaluatorOperationState.RECOVERY)
                     {
                         var driverConnection = _driverConnection.Get();
-
-                        if (driverConnection is MissingDriverConnection)
-                        {
-                            var msg = "Reaching EvaluatorOperation RECOVERY mode, however, there is no IDriverConnection implemented for HA.";
-                            LOGGER.Log(Level.Error, msg);
-                            throw new NotImplementedException(msg);
-                        }
                         try
                         {
                             var driverInformation = driverConnection.GetDriverInformation();
                             if (driverInformation == null)
                             {
-                                LOGGER.Log(Level.Verbose, "In RECOVERY mode, cannot retrieve driver information, will try again later.");
+                                LOGGER.Log(Level.Verbose,
+                                    "In RECOVERY mode, cannot retrieve driver information, will try again later.");
                             }
                             else
                             {
-                                LOGGER.Log(
-                                    Level.Info,
-                                    string.Format(CultureInfo.InvariantCulture, "Detect driver restarted at {0} and is running on endpoint {1} with services {2}. Now trying to re-establish connection", driverInformation.DriverStartTime, driverInformation.DriverRemoteIdentifier, driverInformation.NameServerId));
+                                var msg = string.Format(CultureInfo.InvariantCulture,
+                                        "Detect driver restarted at {0} and is running on endpoint {1} with services {2}. Now trying to re-establish connection",
+                                        driverInformation.DriverStartTime,
+                                        driverInformation.DriverRemoteIdentifier,
+                                        driverInformation.NameServerId);
+                                LOGGER.Log(Level.Info, msg);
                                 Recover(driverInformation);
                             }
+                        }
+                        catch (NotImplementedException)
+                        {
+                            LOGGER.Log(Level.Error, "Reaching EvaluatorOperation RECOVERY mode, however, there is no IDriverConnection implemented for HA.");
+                            throw;
                         }
                         catch (Exception e)
                         {
@@ -352,8 +357,8 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
 
         private static long CurrentTimeMilliSeconds()
         {
-            // this is an implmenation to get current time milli second counted from Jan 1st, 1970
-            // it is chose as such to be compatible with java implmentation
+            // this is an implementation to get current time million second counted from Jan 1st, 1970
+            // it is chose as such to be compatible with Java implementation
             DateTime jan1St1970 = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             return (long)(DateTime.UtcNow - jan1St1970).TotalMilliseconds;
         }
@@ -390,7 +395,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
                     {
                         if (firstHeartbeatInQueue)
                         {
-                            // first heartbeat is specially construted to include the recovery flag
+                            // first heartbeat is specially constructed to include the recovery flag
                             EvaluatorHeartbeatProto recoveryHeartbeat = ConstructRecoveryHeartBeat(_queuedHeartbeats.Dequeue());
                             LOGGER.Log(Level.Info, "Recovery heartbeat to be sent:" + recoveryHeartbeat);
                             _observer.OnNext(new REEFMessage(recoveryHeartbeat));
@@ -417,7 +422,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator
             _evaluatorSettings.OperationState = EvaluatorOperationState.OPERATIONAL;
             ContextManager.HandleDriverConnectionMessage(new DriverConnectionMessageImpl(DriverConnectionState.Reconnected));
 
-            LOGGER.Log(Level.Info, "=========== Exiting RECOVERY mode. ===========");
+            LOGGER.Log(Level.Info, "Exiting RECOVERY mode!!!");
         }
 
         private EvaluatorHeartbeatProto ConstructRecoveryHeartBeat(EvaluatorHeartbeatProto heartbeat)

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Parameters/HeartbeatMaxRetry.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Parameters/HeartbeatMaxRetry.cs
@@ -19,7 +19,7 @@ using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.Common.Runtime.Evaluator.Parameters
 {
-    [NamedParameter(Documentation = "Heartbeat Max Retry", ShortName = "HeartbeatMaxRetry", DefaultValue = "3")]
+    [NamedParameter(Documentation = "Heartbeat Max Retry", ShortName = "HeartbeatMaxRetry", DefaultValue = "10")]
     internal sealed class HeartbeatMaxRetry : Name<int>
     {
     }

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Parameters/HeartbeatMaxRetry.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Parameters/HeartbeatMaxRetry.cs
@@ -19,7 +19,7 @@ using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.Common.Runtime.Evaluator.Parameters
 {
-    [NamedParameter(Documentation = "Heartbeat Max Retry", ShortName = "HeartbeatMaxRetry", DefaultValue = "10")]
+    [NamedParameter(Documentation = "Max number of retries for sending heartbeat to driver before evaluator enters recovery mode to reconnect with driver.", ShortName = "HeartbeatMaxRetry", DefaultValue = "10")]
     internal sealed class HeartbeatMaxRetry : Name<int>
     {
     }

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Parameters/HeartbeatMaxRetryForNonRecoveryMode.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Parameters/HeartbeatMaxRetryForNonRecoveryMode.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.Common.Runtime.Evaluator.Parameters
+{
+    [NamedParameter(Documentation = "Heartbeat Max Retry for Non recovery", ShortName = "HeartbeatMaxRetryForNonRecovery", DefaultValue = "60")]
+    internal sealed class HeartbeatMaxRetryForNonRecoveryMode : Name<int>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Parameters/HeartbeatMaxRetryForNonRecoveryMode.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Parameters/HeartbeatMaxRetryForNonRecoveryMode.cs
@@ -19,7 +19,7 @@ using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.Common.Runtime.Evaluator.Parameters
 {
-    [NamedParameter(Documentation = "Heartbeat Max Retry for Non recovery", ShortName = "HeartbeatMaxRetryForNonRecovery", DefaultValue = "60")]
+    [NamedParameter(Documentation = "Max number of retries for sending heartbeat to driver if driver reconnection logic is not implemented.", ShortName = "HeartbeatMaxRetryForNonRecovery", DefaultValue = "60")]
     internal sealed class HeartbeatMaxRetryForNonRecoveryMode : Name<int>
     {
     }


### PR DESCRIPTION
…onnect logic provided

If there is no IDriverConnection bound, instead of throw exception after a few quick retries, we will increase the retry number and finally exit the evaluator if it reaches the max retry.
If there is a IDriverConnection implemented, we would also increase the max retry number as network glitch could happen for more than a few seconds.

JIRA: [REEF-1679](https://issues.apache.org/jira/browse/REEF-1679)
This closes  #