### PR TITLE
[REEF-1681] Allow REEF Driver to run in unmanaged AM mode

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverIsUnmanaged.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverIsUnmanaged.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * If true, run Driver in unmanaged mode.
+ * (i.e. co-located with the client and not managed by the RM).
+ * This setting is false by default.
+ */
+@NamedParameter(doc = "Run driver in unmanaged mode", default_value = "false")
+public final class DriverIsUnmanaged implements Name<Boolean> {
+  private DriverIsUnmanaged() {
+  }
+}


### PR DESCRIPTION
  * Introduce `DriverIsUnmanaged` config parameter
  * Set `ApplicationSubmissionContext.setUnmanagedAM()` when submitting application request to YARN
  * Minor refactoring for readability and better logging
  * Additional javadoc comments

JIRA: [REEF-1681](https://issues.apache.org/jira/browse/REEF-1681)