### PR TITLE
[REEF-1682] Update TCP Connection config values for IMRU example and …

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/OnREEFIMRURunTimeConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/OnREEFIMRURunTimeConfiguration.cs
@@ -59,7 +59,7 @@ namespace Org.Apache.REEF.IMRU.Examples
                    .Build();
             }
 
-            return Configurations.Merge(runtimeConfig, imruClientConfig, GetTcpConfiguration());
+            return Configurations.Merge(runtimeConfig, imruClientConfig, GetTcpConnectionConfiguration());
         }
 
         /// <summary>
@@ -74,14 +74,14 @@ namespace Org.Apache.REEF.IMRU.Examples
             var runtimeConfig = YARNClientConfiguration.ConfigurationModule
                 .Build();
 
-            return Configurations.Merge(runtimeConfig, imruClientConfig, GetTcpConfiguration());
+            return Configurations.Merge(runtimeConfig, imruClientConfig, GetTcpConnectionConfiguration());
         }
 
-        private static IConfiguration GetTcpConfiguration()
+        private static IConfiguration GetTcpConnectionConfiguration()
         {
             return TcpClientConfigurationModule.ConfigurationModule
-                .Set(TcpClientConfigurationModule.MaxConnectionRetry, "200")
-                .Set(TcpClientConfigurationModule.SleepTime, "1000")
+                .Set(TcpClientConfigurationModule.MaxConnectionRetry, "300")
+                .Set(TcpClientConfigurationModule.SleepTime, "2000")
                 .Build();
         }
     }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUCloseTaskTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUCloseTaskTest.cs
@@ -21,9 +21,7 @@ using System.Diagnostics;
 using Org.Apache.REEF.Driver.Evaluator;
 using Org.Apache.REEF.Driver.Task;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
-using Org.Apache.REEF.Network;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities;
@@ -115,36 +113,6 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .Set(REEF.Driver.DriverConfiguration.OnTaskRunning,
                     GenericType<TestHandlers>.Class)
                 .Set(REEF.Driver.DriverConfiguration.CustomTraceLevel, TraceLevel.Info.ToString())
-                .Build();
-        }
-
-        /// <summary>
-        /// Mapper function configuration. Add TcpConfiguration to the base configuration
-        /// </summary>
-        /// <returns></returns>
-        protected override IConfiguration BuildMapperFunctionConfig()
-        {
-            return Configurations.Merge(GetTcpConfiguration(), base.BuildMapperFunctionConfig());
-        }
-
-        /// <summary>
-        /// Update function configuration. Add TcpConfiguration to the base configuration.
-        /// </summary>
-        /// <returns></returns>
-        protected override IConfiguration BuildUpdateFunctionConfigModule()
-        {
-            return Configurations.Merge(GetTcpConfiguration(), base.BuildUpdateFunctionConfigModule());
-        }
-
-        /// <summary>
-        /// Override default setting for retry policy
-        /// </summary>
-        /// <returns></returns>
-        private IConfiguration GetTcpConfiguration()
-        {
-            return TcpClientConfigurationModule.ConfigurationModule
-                .Set(TcpClientConfigurationModule.MaxConnectionRetry, "5")
-                .Set(TcpClientConfigurationModule.SleepTime, "1000")
                 .Build();
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
@@ -21,7 +21,6 @@ using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.IMRU.OnREEF.IMRUTasks;
 using Org.Apache.REEF.IMRU.OnREEF.Parameters;
-using Org.Apache.REEF.Network;
 using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -184,7 +183,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .BindNamedParameter(typeof(PipelinedBroadcastAndReduceWithFaultTolerant.TotalNumberOfForcedFailures), NumberOfRetry.ToString())
                 .Build();
 
-            return Configurations.Merge(c1, c2, GetTcpConfiguration());
+            return Configurations.Merge(c1, c2);
         }
 
         /// <summary>
@@ -193,23 +192,9 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
         /// <returns></returns>
         protected override IConfiguration BuildUpdateFunctionConfigModule()
         {
-            var c = IMRUUpdateConfiguration<int[], int[], int[]>.ConfigurationModule
+            return IMRUUpdateConfiguration<int[], int[], int[]>.ConfigurationModule
                 .Set(IMRUUpdateConfiguration<int[], int[], int[]>.UpdateFunction,
                     GenericType<PipelinedBroadcastAndReduceWithFaultTolerant.BroadcastSenderReduceReceiverUpdateFunctionFT>.Class)
-                .Build();
-
-            return Configurations.Merge(c, GetTcpConfiguration());
-        }
-
-        /// <summary>
-        /// Override default setting for retry policy
-        /// </summary>
-        /// <returns></returns>
-        private IConfiguration GetTcpConfiguration()
-        {
-            return TcpClientConfigurationModule.ConfigurationModule
-                .Set(TcpClientConfigurationModule.MaxConnectionRetry, "200")
-                .Set(TcpClientConfigurationModule.SleepTime, "1000")
                 .Build();
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -28,6 +28,7 @@ using Microsoft.WindowsAzure.Storage.Blob;
 using Org.Apache.REEF.Client.API;
 using Org.Apache.REEF.Client.Local;
 using Org.Apache.REEF.Client.Yarn;
+using Org.Apache.REEF.Network;
 using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -380,20 +381,29 @@ namespace Org.Apache.REEF.Tests.Functional
             {
                 case Local:
                     var dir = Path.Combine(".", runtimeFolder);
-                    return LocalRuntimeClientConfiguration.ConfigurationModule
+                    var localClientConfig = LocalRuntimeClientConfiguration.ConfigurationModule
                         .Set(LocalRuntimeClientConfiguration.NumberOfEvaluators, numberOfEvaluator.ToString())
                         .Set(LocalRuntimeClientConfiguration.RuntimeFolder, dir)
                         .Build();
+                    return Configurations.Merge(localClientConfig, GetTcpConfiguration());
                 case YARN:
                     var yarnClientConfig = YARNClientConfiguration.ConfigurationModule.Build();
                     var tcpPortConfig = TcpPortConfigurationModule.ConfigurationModule
                        .Set(TcpPortConfigurationModule.PortRangeStart, PortRangeStart)
                        .Set(TcpPortConfigurationModule.PortRangeCount, PortRangeCount)
                        .Build();
-                    return Configurations.Merge(yarnClientConfig, tcpPortConfig);
+                    return Configurations.Merge(yarnClientConfig, tcpPortConfig, GetTcpConfiguration());
                 default:
                     throw new Exception("Unknown runtime: " + runOnYarn);
             }
+        }
+
+        private IConfiguration GetTcpConfiguration()
+        {
+            return TcpClientConfigurationModule.ConfigurationModule
+                .Set(TcpClientConfigurationModule.MaxConnectionRetry, "150")
+                .Set(TcpClientConfigurationModule.SleepTime, "1000")
+                .Build();
         }
     }
 }


### PR DESCRIPTION
…test

Recent stress testing for IMRU FT shows when there are hundreds of hundreds nodes with many failed and re-requested elevators, the default Tcp connection retry time is not long enough for evaluators to connect to driver, as driver might be very busy to handle a long event queue and each event handler is locked in IMRU driver.
We need to set proper configuration values for IMRU example which is used for running stress testing.

In some of the IMRU tests, this configuration data is set through task function config that is incorrect. It should be set through configuration provider to make it work.

This PR sets TCP Connection configuration values for IMRU example and make corrections in functional tests for this configuration setting.

JIRA: [REEF-1682](https://issues.apache.org/jira/browse/REEF-1682)
This closes  #