### PR TITLE
[REEF-1683] Use default MaxRetryNumberInRecovery properly

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
@@ -65,7 +65,7 @@ namespace Org.Apache.REEF.IMRU.Examples
             int iterations = 100;
             int mapperMemory = 512;
             int updateTaskMemory = 512;
-            int maxRetryNumberInRecovery = 2;
+            int maxRetryNumberInRecovery = 10;
             int totalNumberOfForcedFailures = 2;
 
             if (args.Length > 0)

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
@@ -72,7 +72,7 @@ namespace Org.Apache.REEF.IMRU.API
             _updateTaskMemory = 512;
             _coresPerMapper = 1;
             _updateTaskCores = 1;
-            _maxRetryNumberInRecovery = 0;
+            _maxRetryNumberInRecovery = 10;
             _invokeGC = true;
             _perMapConfigGeneratorConfig = new HashSet<IConfiguration>();
             _jobCancellationConfiguration = EmptyConfiguration;

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -131,8 +131,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// </summary>
         private readonly List<IDisposable> _disposableResources = new List<IDisposable>();
 
-        private const int DefaultMaxNumberOfRetryInRecovery = 3; 
-
         [Inject]
         private IMRUDriver(IPartitionedInputDataSet dataSet,
             [Parameter(typeof(PerMapConfigGeneratorSet))] ISet<IPerMapperConfigGenerator> perMapperConfigs,
@@ -155,7 +153,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             _perMapperConfigs = perMapperConfigs;
             _totalMappers = dataSet.Count;
             _invokeGC = invokeGC;
-            _maxRetryNumberForFaultTolerant = maxRetryNumberInRecovery > 0 ? maxRetryNumberInRecovery : DefaultMaxNumberOfRetryInRecovery;
+            _maxRetryNumberForFaultTolerant = maxRetryNumberInRecovery;
 
             _contextManager = new ActiveContextManager(_totalMappers + 1);
             _contextManager.Subscribe(this);

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/MaxRetryNumberInRecovery.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/MaxRetryNumberInRecovery.cs
@@ -22,7 +22,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Parameters
     /// <summary>
     /// Max retry number for the system recovery
     /// </summary>
-    [NamedParameter("Maximum retry number in fault tolerant recovery.", "maxRetryInRecovery", "3")]
+    [NamedParameter("Maximum retry number in fault tolerant recovery.", "maxRetryInRecovery", "10")]
     public sealed class MaxRetryNumberInRecovery : Name<int>
     {
     }


### PR DESCRIPTION
Currently in IMRUJobDefinitionBuilder, the default _maxRetryNumberInRecovery is set to 0. In REEFIMRUClient and some test code, we bind the value in  IMRUJobDefinition to the named parameter MaxRetryNumberInRecovery. If the user doesn't set this value in IMRUJobDefinitionBuilder when creating IMRUJobDefinition, the default value 0 is bound to the NamedParameter, which override the named parameter MaxRetryNumberInRecovery's own default value.

In IMRUDriver, to avoid this override, we set another default value and replace the value passed in if it 0. That caused some confusion.

This PR makes the change in REEFIMRUClient, if user doesn't pass any value for max retry number, don't bind it to the named parameter.

It also removed the default value for in MaxRetryNumberInRecovery IMRUDriver. Let it use the value either bind by the client or default on the named parameter.

Update the default value to a higher number for our stress testing really need a big number. For functional tests, we already set a proper values in the test code.

JIRA: [REEF-1683](https://issues.apache.org/jira/browse/REEF-1683)
This closes  #