### PR TITLE
[REEF-1464] Fix TestTaskCloseOnLocalRuntime failures in AppVeyor

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -398,7 +398,7 @@ namespace Org.Apache.REEF.Tests.Functional
             }
         }
 
-        private IConfiguration GetTcpConnectionConfiguration()
+        protected virtual IConfiguration GetTcpConnectionConfiguration()
         {
             return TcpClientConfigurationModule.ConfigurationModule
                 .Set(TcpClientConfigurationModule.MaxConnectionRetry, "150")


### PR DESCRIPTION
Test failures are caused by delayed task cancellation,
which happens if task is trying to establish TCP connection with
an already cancelled task.

This change decreases time spent by task trying to establish
connection before failing (for this test only).

JIRA:
  [REEF-1464](https://issues.apache.org/jira/browse/REEF-1464)

Pull request:
  This closes #