### PR TITLE
[REEF-1685] Complete the Job properly if update/master task is comple…

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
@@ -177,6 +177,25 @@ namespace Org.Apache.REEF.IMRU.Tests
         }
 
         /// <summary>
+        /// Tests RecordCompletedRunningTask
+        /// </summary>
+        [Fact]
+        public void TestCompletingRunningTasks()
+        {
+            var taskManager = TaskManagerWithTasksRunning();
+            Assert.True(taskManager.AreAllTasksInState(TaskState.TaskRunning));
+
+            taskManager.RecordCompletedRunningTask(CreateMockCompletedTask(MapperTaskIdPrefix + 1));
+            Assert.False(taskManager.IsMasterTaskCompleted());
+
+            taskManager.RecordCompletedRunningTask(CreateMockCompletedTask(MasterTaskId));
+            Assert.True(taskManager.IsMasterTaskCompleted());
+
+            taskManager.RecordCompletedRunningTask(CreateMockCompletedTask(MapperTaskIdPrefix + 2));
+            Assert.True(taskManager.AreAllTasksInState(TaskState.TaskCompleted));
+        }
+
+        /// <summary>
         /// Tests closing running tasks
         /// </summary>
         [Fact]

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
@@ -180,18 +180,18 @@ namespace Org.Apache.REEF.IMRU.Tests
         /// Tests RecordCompletedRunningTask
         /// </summary>
         [Fact]
-        public void TestCompletingRunningTasks()
+        public void TestIsMaterCompelted()
         {
             var taskManager = TaskManagerWithTasksRunning();
             Assert.True(taskManager.AreAllTasksInState(TaskState.TaskRunning));
 
-            taskManager.RecordCompletedRunningTask(CreateMockCompletedTask(MapperTaskIdPrefix + 1));
+            taskManager.RecordCompletedTask(CreateMockCompletedTask(MapperTaskIdPrefix + 1));
             Assert.False(taskManager.IsMasterTaskCompleted());
 
-            taskManager.RecordCompletedRunningTask(CreateMockCompletedTask(MasterTaskId));
+            taskManager.RecordCompletedTask(CreateMockCompletedTask(MasterTaskId));
             Assert.True(taskManager.IsMasterTaskCompleted());
 
-            taskManager.RecordCompletedRunningTask(CreateMockCompletedTask(MapperTaskIdPrefix + 2));
+            taskManager.RecordCompletedTask(CreateMockCompletedTask(MapperTaskIdPrefix + 2));
             Assert.True(taskManager.AreAllTasksInState(TaskState.TaskCompleted));
         }
 

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
@@ -186,10 +186,10 @@ namespace Org.Apache.REEF.IMRU.Tests
             Assert.True(taskManager.AreAllTasksInState(TaskState.TaskRunning));
 
             taskManager.RecordCompletedTask(CreateMockCompletedTask(MapperTaskIdPrefix + 1));
-            Assert.False(taskManager.IsMasterTaskCompleted());
+            Assert.False(taskManager.IsMasterTaskCompletedRunnig());
 
             taskManager.RecordCompletedTask(CreateMockCompletedTask(MasterTaskId));
-            Assert.True(taskManager.IsMasterTaskCompleted());
+            Assert.True(taskManager.IsMasterTaskCompletedRunnig());
 
             taskManager.RecordCompletedTask(CreateMockCompletedTask(MapperTaskIdPrefix + 2));
             Assert.True(taskManager.AreAllTasksInState(TaskState.TaskCompleted));

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
@@ -180,16 +180,16 @@ namespace Org.Apache.REEF.IMRU.Tests
         /// Tests RecordCompletedRunningTask
         /// </summary>
         [Fact]
-        public void TestIsMaterCompelted()
+        public void TestIsMasterCompleted()
         {
             var taskManager = TaskManagerWithTasksRunning();
             Assert.True(taskManager.AreAllTasksInState(TaskState.TaskRunning));
 
             taskManager.RecordCompletedTask(CreateMockCompletedTask(MapperTaskIdPrefix + 1));
-            Assert.False(taskManager.IsMasterTaskCompletedRunnig());
+            Assert.False(taskManager.IsMasterTaskCompletedRunning());
 
             taskManager.RecordCompletedTask(CreateMockCompletedTask(MasterTaskId));
-            Assert.True(taskManager.IsMasterTaskCompletedRunnig());
+            Assert.True(taskManager.IsMasterTaskCompletedRunning());
 
             taskManager.RecordCompletedTask(CreateMockCompletedTask(MapperTaskIdPrefix + 2));
             Assert.True(taskManager.AreAllTasksInState(TaskState.TaskCompleted));

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -434,7 +434,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         ///     Then record completed running and updates task state from TaskRunning to TaskCompleted
         ///     If all tasks are completed, sets system state to TasksCompleted and then go to Done action
         /// Case TasksCompleted:
-        ///     Record, log and then ignore the event        /// Case ShuttingDown
+        ///     Record, log and then ignore the event        
+        /// Case ShuttingDown
         ///     Record completed running and updates task state to TaskCompleted
         ///     Try to recover
         /// Other cases - not expected 
@@ -467,7 +468,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                         _taskManager.RecordCompletedTask(completedTask);
                         break;
 
-                   default:
+                    default:
                         UnexpectedState(completedTask.Id, "ICompletedTask");
                         break;
                 }
@@ -478,6 +479,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         #region IFailedEvaluator
         /// <summary>
         /// IFailedEvaluator handler. It specifies what to do when an evaluator fails.
+        /// Case WaitingForEvaluator
         ///     This happens in the middle of submitting contexts. We just need to remove the failed evaluator 
         ///     from EvaluatorManager and remove associated active context, if any, from ActiveContextManager
         ///     then checks if the system is recoverable. If yes, request another Evaluator 
@@ -491,7 +493,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         ///     Try to recover in case it is the last failure received
         /// Case TasksCompleted:
         ///     Record, log and then ignore the failure. 
-        /// Case WaitingForEvaluator
         /// Case ShuttingDown
         ///     This happens when we have received either FailedEvaluator or FailedTask, some tasks are running some are in closing.
         ///     Removes Evaluator and associated context from EvaluatorManager and ActiveContextManager
@@ -604,18 +605,15 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                 {
                     switch (_systemState.CurrentState)
                     {
-                        case SystemState.SubmittingTasks:
-                        case SystemState.TasksRunning:
-                            var msg = string.Format("Context with Id: {0} failed with Evaluator id: {1}", failedContext.Id, failedContext.EvaluatorId);
-                            throw new Exception(msg);
-
                         case SystemState.TasksCompleted:
                             Logger.Log(Level.Info, "The Job has been completed. So ignoring the Context {0} failure.", failedContext.Id);
                             break;
-
                         case SystemState.ShuttingDown:
                         case SystemState.Fail:
                             break;
+                        default:
+                            var msg = string.Format(CultureInfo.InvariantCulture, "Context with Id: {0} failed with Evaluator id: {1}", failedContext.Id, failedContext.EvaluatorId);
+                            throw new NotImplementedException(msg);
                     }
                 }
             }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
@@ -89,6 +89,11 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         private int _numberOfAppErrors = 0;
 
         /// <summary>
+        /// Indicate if master task is completed running properly
+        /// </summary>
+        private bool _masterTaskCompleted = false;
+
+        /// <summary>
         /// Creates a TaskManager with specified total number of tasks and master task id.
         /// Throws IMRUSystemException if numTasks is smaller than or equals to 0 or masterTaskId is null.
         /// </summary>
@@ -300,6 +305,30 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         private void UpdateState(string taskId, TaskStateEvent taskEvent)
         {
             GetTaskInfo(taskId).TaskState.MoveNext(taskEvent);
+        }
+
+        /// <summary>
+        /// This method is called when a running task is completed.
+        /// If it is master task, set _masterTaskCompleted to true
+        /// then calls RecordCompletedTask to remove the task from runningTasks and change task state.
+        /// </summary>
+        /// <param name="completedTask"></param>
+        internal void RecordCompletedRunningTask(ICompletedTask completedTask)
+        {
+            if (completedTask.Id.Equals(_masterTaskId))
+            {
+                _masterTaskCompleted = true;
+            }
+            RecordCompletedTask(completedTask);
+        }
+
+        /// <summary>
+        /// Returns true if master task is completed from running
+        /// </summary>
+        /// <returns></returns>
+        internal bool IsMasterTaskCompleted()
+        {
+            return _masterTaskCompleted;
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
@@ -91,7 +91,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <summary>
         /// Indicate if master task is completed running properly
         /// </summary>
-        private bool _masterTaskCompleted = false;
+        private bool _masterTaskCompletedRunning = false;
 
         /// <summary>
         /// Creates a TaskManager with specified total number of tasks and master task id.
@@ -221,7 +221,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             {
                 if (GetTaskInfo(completedTask.Id).TaskState.CurrentState.Equals(TaskState.TaskRunning))
                 {
-                    _masterTaskCompleted = true;
+                    _masterTaskCompletedRunning = true;
                 }
             }
             _runningTasks.Remove(completedTask.Id);
@@ -319,9 +319,9 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Returns true if master task is completed from running
         /// </summary>
         /// <returns></returns>
-        internal bool IsMasterTaskCompleted()
+        internal bool IsMasterTaskCompletedRunnig()
         {
-            return _masterTaskCompleted;
+            return _masterTaskCompletedRunning;
         }
 
         /// <summary>
@@ -335,15 +335,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         }
 
         /// <summary>
-        /// Checks if all the tasks are completed.
-        /// </summary>
-        /// <returns></returns>
-        internal bool AreAllTasksCompleted()
-        {
-            return AreAllTasksInState(StateMachine.TaskState.TaskCompleted) && _tasks.Count == _totalExpectedTasks && _runningTasks.Count == 0;
-        }
-
-        /// <summary>
         /// Either master is completed or all the tasks are completed.
         /// In fact AreAllTasksCompleted contains IsmasterCOmpleted
         /// Put it in a separate method so that We can update the logic for job done when needed
@@ -351,7 +342,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <returns></returns>
         internal bool IsJobDone()
         {
-            return IsMasterTaskCompleted() || AreAllTasksCompleted();
+            return IsMasterTaskCompletedRunnig();
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
@@ -317,10 +317,10 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         }
 
         /// <summary>
-        /// Returns true if master task is completed from running
+        /// Returns true if master task has completed and produced result
         /// </summary>
         /// <returns></returns>
-        internal bool IsMasterTaskCompletedRunnig()
+        internal bool IsMasterTaskCompletedRunning()
         {
             return _masterTaskCompletedRunning;
         }
@@ -342,7 +342,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <returns></returns>
         internal bool IsJobDone()
         {
-            return IsMasterTaskCompletedRunnig();
+            return IsMasterTaskCompletedRunning();
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
@@ -209,7 +209,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
 
         /// <summary>
         /// This method is called when receiving ICompletedTask event during task running or system shutting down.
-        /// If it is master task and if the master task was running, mark _masterTaskCompleted true
+        /// If it is master task and if the master task was running, mark _masterTaskCompletedRunning true. That indicates 
+        /// master task has successfully completed, which means the system has got the result from master task. 
         /// Removes the task from running tasks if it was running
         /// Changes the task state from RunningTask to CompletedTask if the task was running
         /// Change the task stat from TaskWaitingForClose to TaskClosedByDriver if the task was in TaskWaitingForClose state
@@ -335,9 +336,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         }
 
         /// <summary>
-        /// Either master is completed or all the tasks are completed.
-        /// In fact AreAllTasksCompleted contains IsmasterCOmpleted
-        /// Put it in a separate method so that We can update the logic for job done when needed
+        /// When master task is completed, that means the system has got the result expected 
+        /// regardless of other mapper tasks returned or not. 
         /// </summary>
         /// <returns></returns>
         internal bool IsJobDone()

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBroadcastReduceTest.cs
@@ -51,7 +51,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var runningTaskCount = GetMessageCount(lines, "Received IRunningTask");
             var failedEvaluatorCount = GetMessageCount(lines, "Received IFailedEvaluator");
             var failedTaskCount = GetMessageCount(lines, "Received IFailedTask");
-            Assert.Equal((NumOfRetry + 1) * NumNodes, completedTaskCount + failedEvaluatorCount + failedTaskCount);
+            Assert.True((NumOfRetry + 1) * NumNodes >= completedTaskCount + failedEvaluatorCount + failedTaskCount);
+            Assert.True(NumOfRetry * NumNodes < completedTaskCount + failedEvaluatorCount + failedTaskCount);
             Assert.Equal((NumOfRetry + 1) * NumNodes, runningTaskCount);
             CleanUp(testFolder);
         }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
@@ -67,8 +67,10 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
 
             // on each try each task should fail or complete or disappear with failed evaluator
             // and on each try all tasks should start successfully
-            Assert.Equal((NumberOfRetry + 1) * numTasks, completedTaskCount + failedEvaluatorCount + failedTaskCount);
+            Assert.True((NumberOfRetry + 1) * numTasks >= completedTaskCount + failedEvaluatorCount + failedTaskCount);
+            Assert.True(NumberOfRetry * numTasks < completedTaskCount + failedEvaluatorCount + failedTaskCount);
             Assert.Equal((NumberOfRetry + 1) * numTasks, runningTaskCount);
+
             // eventually job succeeds
             Assert.Equal(1, jobSuccess);
             CleanUp(testFolder);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnInit.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnInit.cs
@@ -64,7 +64,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             // Rest of the tasks should be canceled and send completed task event to the driver. 
             Assert.Equal(NumberOfRetry * 2, failedEvaluatorCount);
             Assert.Equal(0, failedTaskCount);
-            Assert.True(((NumberOfRetry + 1) * numTasks) - failedEvaluatorCount > completedTaskCount);
+            Assert.True(((NumberOfRetry + 1) * numTasks) - failedEvaluatorCount >= completedTaskCount);
             Assert.True((NumberOfRetry * numTasks) - failedEvaluatorCount < completedTaskCount);
 
             // eventually job succeeds

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnInit.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsOnInit.cs
@@ -64,7 +64,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             // Rest of the tasks should be canceled and send completed task event to the driver. 
             Assert.Equal(NumberOfRetry * 2, failedEvaluatorCount);
             Assert.Equal(0, failedTaskCount);
-            Assert.Equal(((NumberOfRetry + 1) * numTasks) - (NumberOfRetry * 2), completedTaskCount);
+            Assert.True(((NumberOfRetry + 1) * numTasks) - failedEvaluatorCount > completedTaskCount);
+            Assert.True((NumberOfRetry * numTasks) - failedEvaluatorCount < completedTaskCount);
 
             // eventually job succeeds
             Assert.Equal(1, jobSuccess);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnDispose.cs
@@ -63,7 +63,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             Assert.Equal(0, failedEvaluatorCount);
             Assert.Equal(0, failedTaskCount);
             Assert.True(numTasks >= completedTaskCount);
-            Assert.True(completedTaskCount > 1);
+            Assert.True(completedTaskCount >= 1);
 
             // eventually job succeeds
             Assert.Equal(1, jobSuccess);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnDispose.cs
@@ -62,7 +62,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             // No failed evaluators or tasks.
             Assert.Equal(0, failedEvaluatorCount);
             Assert.Equal(0, failedTaskCount);
-            Assert.Equal(numTasks, completedTaskCount);
+            Assert.True(numTasks >= completedTaskCount);
+            Assert.True(completedTaskCount > 1);
 
             // eventually job succeeds
             Assert.Equal(1, jobSuccess);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnInit.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnInit.cs
@@ -63,8 +63,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             // Rest of the tasks should be canceled and send completed task event to the driver. 
             Assert.Equal(0, failedEvaluatorCount);
             Assert.Equal(NumberOfRetry * 2, failedTaskCount);
-            Assert.True(((NumberOfRetry + 1) * numTasks) - failedEvaluatorCount > completedTaskCount);
-            Assert.True((NumberOfRetry * numTasks) - failedEvaluatorCount < completedTaskCount);
+            Assert.True(((NumberOfRetry + 1) * numTasks) - failedTaskCount >= completedTaskCount);
+            Assert.True((NumberOfRetry * numTasks) - failedTaskCount < completedTaskCount);
 
             // eventually job succeeds
             Assert.Equal(1, jobSuccess);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnInit.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperTasksOnInit.cs
@@ -63,7 +63,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             // Rest of the tasks should be canceled and send completed task event to the driver. 
             Assert.Equal(0, failedEvaluatorCount);
             Assert.Equal(NumberOfRetry * 2, failedTaskCount);
-            Assert.Equal(((NumberOfRetry + 1) * numTasks) - (NumberOfRetry * 2), completedTaskCount);
+            Assert.True(((NumberOfRetry + 1) * numTasks) - failedEvaluatorCount > completedTaskCount);
+            Assert.True((NumberOfRetry * numTasks) - failedEvaluatorCount < completedTaskCount);
 
             // eventually job succeeds
             Assert.Equal(1, jobSuccess);


### PR DESCRIPTION
…ted from running state

In stress testing, we have seen such scenario in which master/update task is completed running, and most of the other tasks are also completed, but then there was a failed Evaluator event received by driver. This would result in system moving to shut down state and starting recovery that is not necessary.
When the driver receives ICompletedTask from master task which has running state, that means we have completed the calculation and result has been written to the output. After that, if the driver ever receives FailedEvalutor/FailedTask, they should be ignored and driver should execute DoneAction to dispose all the contexts and shut down the system.

JIRA: [REEF-1685](https://issues.apache.org/jira/browse/REEF-1685)
This closes  #