### PR TITLE
[REEF-1511] Timeout for Task shutdown during IMRU recovery

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
@@ -246,12 +246,12 @@ namespace Org.Apache.REEF.IMRU.Tests
 
             taskManager.CloseAllRunningTasks(TaskManager.CloseTaskByDriver);
             Thread.Sleep(100);
-            var tasks = taskManager.TasksWaitingForClose(50);
+            var tasks = taskManager.TasksTimeoutInState(TaskState.TaskWaitingForClose, 50);
             Assert.Equal(tasks.Count, 3);
 
             foreach (var t in tasks)
             {
-                taskManager.RecordTaskFailWhenTaskHasNoResponseInWaitingForClose(t.Key);
+                taskManager.RecordKillClosingTask(t.Key);
             }
             Assert.True(taskManager.AreAllTasksInState(TaskState.TaskClosedByDriver));
         }

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using System.Threading;
 using NSubstitute;
 using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Evaluator;
@@ -177,6 +178,22 @@ namespace Org.Apache.REEF.IMRU.Tests
         }
 
         /// <summary>
+        /// Tests AverageClosingTime
+        /// </summary>
+        [Fact]
+        public void TestTasksClosingTime()
+        {
+            var taskManager = TaskManagerWithTasksRunning();
+            taskManager.CloseAllRunningTasks(TaskManager.CloseTaskByDriver);
+            Thread.Sleep(100);
+            taskManager.RecordCompletedTask(CreateMockCompletedTask(MapperTaskIdPrefix + 1));
+            taskManager.RecordCompletedTask(CreateMockCompletedTask(MapperTaskIdPrefix + 2));
+            taskManager.RecordCompletedTask(CreateMockCompletedTask(MasterTaskId));
+
+            Assert.True(taskManager.AverageClosingTime() > 0);
+        }
+
+        /// <summary>
         /// Tests RecordCompletedRunningTask
         /// </summary>
         [Fact]
@@ -211,6 +228,32 @@ namespace Org.Apache.REEF.IMRU.Tests
 
             taskManager.CloseAllRunningTasks(TaskManager.CloseTaskByDriver);
             Assert.True(taskManager.AreAllTasksInState(TaskState.TaskWaitingForClose));
+        }
+
+        /// <summary>
+        /// Tests closing running tasks
+        /// </summary>
+        [Fact]
+        public void TestTasksWaitingForClose()
+        {
+            var taskManager = TaskManagerWithTasksSubmitted();
+
+            taskManager.RecordRunningTask(CreateMockRunningTask(MasterTaskId));
+            taskManager.RecordRunningTask(CreateMockRunningTask(MapperTaskIdPrefix + 1));
+
+            var runningTask2 = CreateMockRunningTask(MapperTaskIdPrefix + 2);
+            taskManager.RecordRunningTaskDuringSystemFailure(runningTask2, TaskManager.CloseTaskByDriver);
+
+            taskManager.CloseAllRunningTasks(TaskManager.CloseTaskByDriver);
+            Thread.Sleep(100);
+            var tasks = taskManager.TasksWaitingForClose(50);
+            Assert.Equal(tasks.Count, 3);
+
+            foreach (var t in tasks)
+            {
+                taskManager.RecordTaskFailWhenTaskHasNoResponseInWaitingForClose(t.Key);
+            }
+            Assert.True(taskManager.AreAllTasksInState(TaskState.TaskClosedByDriver));
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskInfo.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskInfo.cs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
 using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.IMRU.OnREEF.Driver.StateMachine;
 using Org.Apache.REEF.Tang.Interface;
@@ -38,6 +39,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             _taskState = taskState;
             _taskConfiguration = config;
             _activeContext = context;
+            TimeStateUpdated = DateTime.Now;
         }
 
         internal TaskStateMachine TaskState
@@ -54,5 +56,10 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         {
             get { return _activeContext; }
         }
+
+        /// <summary>
+        /// time that the task state is updated
+        /// </summary>
+        internal DateTime TimeStateUpdated { get; set; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
@@ -96,7 +96,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <summary>
         /// Total number of the tasks that is closed by driver and then completed.
         /// </summary>
-        private int _totalNumberOfClosingTask;
+        private int _totalNumberOfClosedTasksByDriver;
 
         /// <summary>
         /// Indicate if master task is completed running properly
@@ -134,9 +134,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         ///   trying to add extra tasks
         ///   No Master Task is added in the collection
         /// </summary>
-        /// <param name="taskId"></param>
-        /// <param name="taskConfiguration"></param>
-        /// <param name="activeContext"></param>
         internal void AddTask(string taskId, IConfiguration taskConfiguration, IActiveContext activeContext)
         {
             if (taskId == null)
@@ -187,7 +184,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Adds the IRunningTask to the running tasks collection and update the task state to TaskRunning.
         /// Throws IMRUSystemException if running tasks already contains this task or tasks collection doesn't contain this task.
         /// </summary>
-        /// <param name="runningTask"></param>
         internal void RecordRunningTask(IRunningTask runningTask)
         {
             if (_runningTasks.ContainsKey(runningTask.Id))
@@ -225,7 +221,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Changes the task state from RunningTask to CompletedTask if the task was running
         /// Change the task stat from TaskWaitingForClose to TaskClosedByDriver if the task was in TaskWaitingForClose state
         /// </summary>
-        /// <param name="completedTask"></param>
         internal void RecordCompletedTask(ICompletedTask completedTask)
         {
             if (completedTask.Id.Equals(_masterTaskId))
@@ -244,7 +239,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Removes the task from running tasks if the task was running
         /// Updates the task state to fail based on the error message in the failed task
         /// </summary>
-        /// <param name="failedTask"></param>
         internal void RecordFailedTaskDuringRunningOrSubmissionState(IFailedTask failedTask)
         {
             //// Remove the task from running tasks if it exists there
@@ -258,7 +252,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Task could fail by communication error or any other application or system error during this time, as long as it is not 
         /// TaskFailedByEvaluatorFailure, update the task state based on the error received. 
         /// </summary>
-        /// <param name="failedTask"></param>
         internal void RecordFailedTaskDuringSystemShuttingDownState(IFailedTask failedTask)
         {
             Logger.Log(Level.Info, "RecordFailedTaskDuringSystemShuttingDownState, exceptionType: {0}", GetTaskErrorEventByExceptionType(failedTask).ToString());
@@ -279,7 +272,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Removes the task from RunningTasks if the task associated with the FailedEvaluator is present and running. 
         /// Sets the task state to TaskFailedByEvaluatorFailure 
         /// </summary>
-        /// <param name="failedEvaluator"></param>
         internal void RecordTaskFailWhenReceivingFailedEvaluator(IFailedEvaluator failedEvaluator)
         {
             if (failedEvaluator.FailedTask.IsPresent())
@@ -315,20 +307,25 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Waiting for close task has no response in given time
         /// Driver will kill the evaluator and move the task to TaskFailedByEvaluatorFailure state
         /// </summary>
-        /// <param name="taskId"></param>
-        internal void RecordTaskFailWhenTaskHasNoResponseInWaitingForClose(string taskId)
+        internal void RecordKillClosingTask(string taskId)
         {
-            if (!GetTaskInfo(taskId).TaskState.CurrentState.Equals(TaskState.TaskWaitingForClose))
+            var taskInfo = GetTaskInfo(taskId);
+            if (!taskInfo.TaskState.CurrentState.Equals(TaskState.TaskWaitingForClose))
             {
                 var msg = string.Format(CultureInfo.InvariantCulture,
-                           "The task [{0}] is not in TaskWaitingForClose state.",
-                           taskId);
+                           "The task [{0}] is in [{1}] state, expecting it is in TaskWaitingForClose state.",
+                           taskId, taskInfo.TaskState.CurrentState);
                 Logger.Log(Level.Error, msg);
                 throw new IMRUSystemException(msg);
             }
             UpdateState(taskId, TaskStateEvent.FailedTaskEvaluatorError);
         }
 
+        /// <summary>
+        /// Find the task that is associated with the given evaluator
+        /// </summary>
+        /// <param name="evaluatorId"></param>
+        /// <returns></returns>
         private string FindTaskAssociatedWithTheEvalutor(string evaluatorId)
         {
             return _tasks.Where(e => e.Value.ActiveContext.EvaluatorId.Equals(evaluatorId)).Select(e => e.Key).FirstOrDefault();
@@ -337,12 +334,10 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <summary>
         /// Updates task state for a given taskId based on the task event
         /// </summary>
-        /// <param name="taskId"></param>
-        /// <param name="taskEvent"></param>
         private void UpdateState(string taskId, TaskStateEvent taskEvent)
         {
             var taskInfo = GetTaskInfo(taskId);
-            RecordingTime(taskInfo, taskEvent);
+            RecordingTime(taskId, taskInfo, taskEvent);
             taskInfo.TaskState.MoveNext(taskEvent);
             taskInfo.TimeStateUpdated = DateTime.Now;
         }
@@ -352,16 +347,14 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// The method can be extended to record the time for other task states
         /// The log level should be changed to verb once we complete the testing
         /// </summary>
-        /// <param name="taskInfo"></param>
-        /// <param name="taskEvent"></param>
-        private void RecordingTime(TaskInfo taskInfo, TaskStateEvent taskEvent)
+        private void RecordingTime(string taskId, TaskInfo taskInfo, TaskStateEvent taskEvent)
         {
             if (taskInfo.TaskState.CurrentState.Equals(TaskState.TaskWaitingForClose) && taskEvent.Equals(TaskStateEvent.CompletedTask))
             {
                 var timeSpan = DateTime.Now - taskInfo.TimeStateUpdated;
-                _totalNumberOfClosingTask++;
-                Logger.Log(Level.Info, "RecordClosingTime. _taskClosingTimeSpan: {0}, _totalNumberOfClosingTask: {1}.", timeSpan.Milliseconds, _totalNumberOfClosingTask);
+                _totalNumberOfClosedTasksByDriver++;
                 _totalTaskClosingTimeSpan = _totalTaskClosingTimeSpan.Add(timeSpan);
+                Logger.Log(Level.Info, "RecordClosingTime for task id {0}, closing time: {1}, average closing time: {2}.", taskId, timeSpan.Milliseconds, _totalTaskClosingTimeSpan.Milliseconds/_totalNumberOfClosedTasksByDriver);
             }
         }
 
@@ -371,9 +364,9 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <returns></returns>
         internal int AverageClosingTime()
         {
-            if (_totalNumberOfClosingTask != 0)
+            if (_totalNumberOfClosedTasksByDriver != 0)
             {
-                return _totalTaskClosingTimeSpan.Milliseconds/_totalNumberOfClosingTask;
+                return _totalTaskClosingTimeSpan.Milliseconds/_totalNumberOfClosedTasksByDriver;
             }
             return 0;
         }
@@ -381,7 +374,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <summary>
         /// Returns true if master task has completed and produced result
         /// </summary>
-        /// <returns></returns>
         internal bool IsMasterTaskCompletedRunning()
         {
             return _masterTaskCompletedRunning;
@@ -390,7 +382,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <summary>
         /// Checks if all the tasks are running.
         /// </summary>
-        /// <returns></returns>
         internal bool AreAllTasksRunning()
         {
             return AreAllTasksInState(StateMachine.TaskState.TaskRunning) &&
@@ -401,7 +392,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// When master task is completed, that means the system has got the result expected 
         /// regardless of other mapper tasks returned or not. 
         /// </summary>
-        /// <returns></returns>
         internal bool IsJobDone()
         {
             return IsMasterTaskCompletedRunning();
@@ -410,22 +400,16 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <summary>
         /// Finds all the tasks that are waiting for close and waiting time is timeout
         /// </summary>
-        /// <param name="timeoutMilliseconds"></param>
-        /// <returns></returns>
-        internal IList<KeyValuePair<string, TaskInfo>> TasksWaitingForClose(int timeoutMilliseconds)
+        internal IList<KeyValuePair<string, TaskInfo>> TasksTimeoutInState(TaskState state, int timeoutMilliseconds)
         {
-            return _tasks.Where(t => t.Value.TaskState.CurrentState.Equals(TaskState.TaskWaitingForClose) && Timeout(t.Value.TimeStateUpdated, timeoutMilliseconds))
-                .Select(y => new KeyValuePair<string, TaskInfo>(y.Key, y.Value))
+            return _tasks.Where(t => t.Value.TaskState.CurrentState.Equals(state) && Timeout(t.Value.TimeStateUpdated, timeoutMilliseconds))
                 .ToList();
         }
 
         /// <summary>
         /// Check if the given DateTime has passed the timeoutMilliseconds
         /// </summary>
-        /// <param name="time"></param>
-        /// <param name="timeoutMilliseconds"></param>
-        /// <returns></returns>
-        private bool Timeout(DateTime time, int timeoutMilliseconds)
+        private static bool Timeout(DateTime time, int timeoutMilliseconds)
         {
             TimeSpan span = DateTime.Now - time;
             return span.Milliseconds > timeoutMilliseconds;
@@ -457,8 +441,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Then move the task state to WaitingTaskToClose
         /// Throw IMRUSystemException if runningTask is null or the running task is already added in the running task collection
         /// </summary>
-        /// <param name="runningTask"></param>
-        /// <param name="closeMessage"></param>
         internal void RecordRunningTaskDuringSystemFailure(IRunningTask runningTask, string closeMessage)
         {
             if (runningTask == null)
@@ -482,8 +464,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// For unknown exceptions or exceptions that doesn't belong to defined IMRU task exceptions
         /// treat then as application error.
         /// </summary>
-        /// <param name="failedTask"></param>
-        /// <returns></returns>
         private TaskStateEvent GetTaskErrorEventByExceptionType(IFailedTask failedTask)
         {
             var exception = failedTask.AsError();
@@ -543,7 +523,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <summary>
         /// Returns the number of application error caused by FailedTask
         /// </summary>
-        /// <returns></returns>
         internal int NumberOfAppErrors()
         {
             return _numberOfAppErrors;
@@ -552,7 +531,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <summary>
         /// Checks if all the tasks are in final states
         /// </summary>
-        /// <returns></returns>
         internal bool AreAllTasksInFinalState()
         {
             var notInFinalState = _tasks.Where(t => !t.Value.TaskState.IsFinalState()).Take(5).ToList();
@@ -590,8 +568,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <summary>
         /// Gets current state of the task
         /// </summary>
-        /// <param name="taskId"></param>
-        /// <returns></returns>
         internal TaskState GetTaskState(string taskId)
         {
             var taskInfo = GetTaskInfo(taskId);
@@ -602,8 +578,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Checks if all the tasks are in the state specified. 
         /// For example, passing TaskState.TaskRunning to check if all the tasks are in TaskRunning state
         /// </summary>
-        /// <param name="taskState"></param>
-        /// <returns></returns>
         internal bool AreAllTasksInState(TaskState taskState)
         {
             return _tasks.All(t => t.Value.TaskState.CurrentState == taskState);
@@ -652,7 +626,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <summary>
         /// Checks if master task has been added
         /// </summary>
-        /// <returns></returns>
         private bool MasterTaskExists()
         {
             return _tasks.ContainsKey(_masterTaskId);
@@ -662,8 +635,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Gets task Tuple based on the given taskId. 
         /// Throws IMRUSystemException if the task Tuple is not in the task collection.
         /// </summary>
-        /// <param name="taskId"></param>
-        /// <returns></returns>
         private TaskInfo GetTaskInfo(string taskId)
         {
             TaskInfo taskInfo;

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/MinTaskWaitingForCloseTimeout.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/MinTaskWaitingForCloseTimeout.cs
@@ -19,7 +19,7 @@ using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.IMRU.OnREEF.Parameters
 {
-    [NamedParameter("Minimum Timeout in milliseconds for TaskWaitingForClose", "TaskWaitingForCloseTimeout", "30000")]
+    [NamedParameter("Minimum timeout after which unresponsive tasks which are supposed to be closed will be killed together with their evaluators.", "TaskWaitingForCloseTimeout", "30000")]
     public sealed class MinTaskWaitingForCloseTimeout : Name<int>
     {
     }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/MinTaskWaitingForCloseTimeout.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/MinTaskWaitingForCloseTimeout.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.IMRU.OnREEF.Parameters
+{
+    [NamedParameter("Minimum Timeout in milliseconds for TaskWaitingForClose", "TaskWaitingForCloseTimeout", "30000")]
+    public sealed class MinTaskWaitingForCloseTimeout : Name<int>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/TimeoutMonitoringInterval.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/TimeoutMonitoringInterval.cs
@@ -19,7 +19,7 @@ using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.IMRU.OnREEF.Parameters
 {
-    [NamedParameter("Interval for timer in milliseconds for TimeoutMonitor", "TimeoutMonitoringInterval", "50000")]
+    [NamedParameter("Interval at which checks for timeout are done, in milliseconds.", "TimeoutMonitoringInterval", "50000")]
     public sealed class TimeoutMonitoringInterval : Name<int>
     {
     }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/TimeoutMonitoringInterval.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/TimeoutMonitoringInterval.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.IMRU.OnREEF.Parameters
+{
+    [NamedParameter("Interval for timer in milliseconds for TimeoutMonitor", "TimeoutMonitoringInterval", "50000")]
+    public sealed class TimeoutMonitoringInterval : Name<int>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
+++ b/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
@@ -128,6 +128,8 @@ under the License.
     <Compile Include="OnREEF\Parameters\SerializedUpdateFunctionCodecsConfiguration.cs" />
     <Compile Include="OnREEF\Parameters\SerializedUpdateTaskStateConfiguration.cs" />
     <Compile Include="OnREEF\Parameters\SleepIntervalParameter.cs" />
+    <Compile Include="OnREEF\Parameters\MinTaskWaitingForCloseTimeout.cs" />
+    <Compile Include="OnREEF\Parameters\TimeoutMonitoringInterval.cs" />
     <Compile Include="OnREEF\ResultHandler\DefaultResultHandler.cs" />
     <Compile Include="OnREEF\ResultHandler\ResultOutputLocation.cs" />
     <Compile Include="OnREEF\ResultHandler\WriteResultHandler.cs" />


### PR DESCRIPTION
During IMRU FT recovery, sometimes the tasks that supposed to close by driver don't send completed event back, causing the system hang. This PR adds the timeout for tasks closed by driver, and kill the evaluator if timeout.

The average closing time is recorded in the TaskManager. This number is a reference for define the time out on the fly. In case the average number is accessed before the average data is accumulated, or the average number is too low in some scenarios, we also have a configurable MinTaskWaitingForCloseTimeout to ensure the driver wait for enough time before killing the evaluator.

JIRA: [REEF-1511](https://issues.apache.org/jira/browse/REEF-1511)
This closes  #