### PR TITLE
[REEF-1687] Throw exception if task dispose throws exception after Ca…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Task/TaskRuntime.cs
@@ -136,8 +136,9 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                     }
                     catch (Exception e)
                     {
-                        Utilities.Diagnostics.Exceptions.Caught(
-                            e, Level.Error, "Exception in disposing Task but ignoring as Task has already completed.", Logger);
+                        var msg = "Exception during Task Dispose in task Call()";
+                        Logger.Log(Level.Error, msg);
+                        throw new InvalidOperationException(msg, e);
                     }
                 }
             });
@@ -201,11 +202,9 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Task
                 }
                 catch (Exception e)
                 {
-                    Utilities.Diagnostics.Exceptions.CaughtAndThrow(
-                        new InvalidOperationException("Cannot dispose task properly", e),
-                        Level.Error,
-                        "Exception during task dispose.",
-                        Logger);
+                    var msg = "Exception during Task Dispose in task Close()";
+                    Logger.Log(Level.Error, msg);
+                    throw new InvalidOperationException(msg, e);
                 }
             }
         }


### PR DESCRIPTION
…ll()

Currently in TaskRuntime, when dispose a task in Close method, if exception happens, we throw exception. While when dispose the task after calling Call() method, we just log but swallow the exception. This is inconsistent. It also results in TestFailMapperTasksOnDispose randomly failing because it really depends on which code path is quicker that determines where the task Dispose is called.

When Task Dispose() throw exception, that means some resources are not released properly. For fault tolerant, even if the task is returned from the Call(), either realy completed the task or closeddByDriver, if we are to reuse the evaluator to resubmit a task on it, it is not right. So the correct way is to throw exception to make evaluator fail, same as what we did in close() method.

This PR updaete both TaskRuntime and TestFailMapperTasksOnDispose

JIRA: [REEF-1687](https://issues.apache.org/jira/browse/REEF-1687)
This closes  #