### PR TITLE
[REEF-1688] IMRU: Don't fail if RM allocates extra evaluators

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/TestEvaluatorManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/TestEvaluatorManager.cs
@@ -89,8 +89,10 @@ namespace Org.Apache.REEF.IMRU.Tests
             var evaluatorManager = CreateEvaluatorManager(2, 1);
             evaluatorManager.AddMasterEvaluator(CreateMockAllocatedEvaluator(1));
             evaluatorManager.AddAllocatedEvaluator(CreateMockAllocatedEvaluator(2));
-            Action add = () => evaluatorManager.AddAllocatedEvaluator(CreateMockAllocatedEvaluator(3));
-            Assert.Throws<IMRUSystemException>(add);
+            evaluatorManager.AddAllocatedEvaluator(CreateMockAllocatedEvaluator(3));
+
+            // the last evaluator should be just ignored
+            Assert.False(evaluatorManager.IsAllocatedEvaluator(EvaluatorIdPrefix + "3"));
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/EvaluatorManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/EvaluatorManager.cs
@@ -128,15 +128,17 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
 
             if (NumberOfAllocatedEvaluators >= _totalExpectedEvaluators)
             {
-                string msg = string.Format("Trying to add an additional Evaluator {0}, but the total expected Evaluator number {1} has been reached.", evaluator.Id, _totalExpectedEvaluators);
-                Exceptions.Throw(new IMRUSystemException(msg), Logger);
+                string msg = string.Format("Trying to add an additional evaluator {0}, but the total expected Evaluator number {1} has been reached. Ignoring new evaluator", 
+                    evaluator.Id, _totalExpectedEvaluators);
+                Logger.Log(Level.Warning, msg);
+                return;
             }
            
             _allocatedEvaluatorIds.Add(evaluator.Id);
 
             if (_masterEvaluatorId == null && NumberOfAllocatedEvaluators == _totalExpectedEvaluators)
             {
-                string msg = string.Format("Added the last Evaluator {0} but master Evaluator is not added yet.", evaluator.Id);
+                string msg = string.Format("Added the last evaluator {0} but master evaluator is not added yet.", evaluator.Id);
                 Exceptions.Throw(new IMRUSystemException(msg), Logger);
             }
         }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -260,6 +260,10 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             }
             else
             {
+                if (!_evaluatorManager.IsAllocatedEvaluator(allocatedEvaluator.Id))
+                {
+                    return;
+                }
                 configs = _serviceAndContextConfigurationProvider
                     .GetDataLoadingConfigurationForEvaluatorById(
                         allocatedEvaluator.Id);


### PR DESCRIPTION
This change replaces exception thrown if RM allocates more
evaluators than IMRU driver requested with a warning and evaluator ignore.

JIRA:
  [REEF-1688](https://issues.apache.org/jira/browse/REEF-1688)

Pull request:
  This closes #