### PR TITLE
[REEF-1492] Properly handle exception in ResultHandler.Dispose()

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/TaskHostBase.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/TaskHostBase.cs
@@ -111,7 +111,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
             }
             finally
             {
-                FinallyBlock();
                 _taskCloseCoordinator.SignalTaskStopped();
             }
             Logger.Log(Level.Info, "{0} returned with cancellation token:{1}.", TaskHostName, _cancellationSource.IsCancellationRequested);
@@ -133,13 +132,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         /// The body of Call method. Subclass must override it. 
         /// </summary>
         protected abstract byte[] TaskBody(byte[] memento);
-
-        /// <summary>
-        /// The code that needs to be executed no matter exception happens or not in Call() method.  
-        /// </summary>
-        protected virtual void FinallyBlock()
-        {
-        }
 
         /// <summary>
         /// Task host name

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
@@ -70,6 +70,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
                 _communicationGroupClient.GetBroadcastSender<MapInputWithControlMessage<TMapInput>>(IMRUConstants.BroadcastOperatorName);
             _dataReceiver = _communicationGroupClient.GetReduceReceiver<TMapOutput>(IMRUConstants.ReduceOperatorName);
             _resultHandler = resultHandler;
+            Logger.Log(Level.Info, "$$$$_resultHandler." + _resultHandler.GetType().AssemblyQualifiedName);
             Logger.Log(Level.Info, "UpdateTaskHost initialized.");
         }
 
@@ -132,22 +133,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         }
 
         /// <summary>
-        /// Dispose resultHandler
-        /// </summary>
-        protected override void FinallyBlock()
-        {
-            try
-            {
-                _resultHandler.Dispose();
-            }
-            catch (Exception e)
-            {
-                Logger.Log(Level.Error, "Exception in dispose result handler.", e);
-                //// TODO throw proper exceptions JIRA REEF-1492
-            }
-        }
-
-        /// <summary>
         /// Return UpdateHostName
         /// </summary>
         protected override string TaskHostName
@@ -159,6 +144,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         {
             if (Interlocked.Exchange(ref _disposed, 1) == 0)
             {
+                _resultHandler.Dispose();
                 _groupCommunicationsClient.Dispose();
                 var disposableTask = _updateTask as IDisposable;
                 if (disposableTask != null)

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/WriteResultHandler.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/WriteResultHandler.cs
@@ -42,11 +42,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.ResultHandler
         private readonly string _remoteFileName;
         private string _localFilename;
 
-        /// <summary>
-        /// Locks for dispose 
-        /// </summary>
-        private readonly object _disposeLock = new object();
-
         [Inject]
         private WriteResultHandler(
             IStreamingCodec<TResult> resultCodec,
@@ -103,14 +98,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.ResultHandler
         {
             if (_localFilename != null)
             {
-                lock (_disposeLock)
-                {
-                    if (_localFilename != null)
-                    {
-                        File.Delete(_localFilename);
-                        _localFilename = null;
-                    }
-                }
+                File.Delete(_localFilename);
+                _localFilename = null;
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBrodcastReduceTestBase.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBrodcastReduceTestBase.cs
@@ -26,6 +26,7 @@ using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.IMRU.OnREEF.Parameters;
+using Org.Apache.REEF.IMRU.OnREEF.ResultHandler;
 using Org.Apache.REEF.IO.PartitionedData.Random;
 using Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDriverAndTasks;
 using Org.Apache.REEF.Network.Group.Config;
@@ -230,6 +231,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
                 .SetMapInputPipelineDataConverterConfiguration(BuildDataConverterConfig(chunkSize))
                 .SetMapOutputPipelineDataConverterConfiguration(BuildDataConverterConfig(chunkSize))
                 .SetPartitionedDatasetConfiguration(BuildPartitionedDatasetConfiguration(numberofMappers))
+                .SetResultHandlerConfiguration(BuildResultHandlerConfig())
                 .SetJobName(IMRUJobName)
                 .SetNumberOfMappers(numberofMappers)
                 .SetMapperMemory(mapperMemory)
@@ -248,6 +250,17 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             }
 
             return builder.Build();
+        }
+
+        /// <summary>
+        /// Build default result handler configuration. Subclass can override it.
+        /// </summary>
+        /// <returns></returns>
+        protected virtual IConfiguration BuildResultHandlerConfig()
+        {
+            return TangFactory.GetTang().NewConfigurationBuilder()
+                    .BindImplementation(GenericType<IIMRUResultHandler<int[]>>.Class, GenericType<DefaultResultHandler<int[]>>.Class)
+                    .Build();
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestExceptionInResultHandlerDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestExceptionInResultHandlerDispose.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.Tang.Annotations;
@@ -48,7 +47,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
 
             string testFolder = DefaultRuntimeFolder + TestId;
             TestBroadCastAndReduce(false, numTasks, chunkSize, dims, iterations, mapperMemory, updateTaskMemory, numberOfRetryInRecovery, testFolder);
-            string[] lines = ReadLogFile(DriverStdout, "driver", testFolder, 360);
+            string[] lines = ReadLogFile(DriverStdout, "driver", testFolder, 120);
             var completedTaskCount = GetMessageCount(lines, "Received ICompletedTask");
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
@@ -56,7 +55,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
 
             // Master evaluator will fail after master task is completed. Depending on how quick the driver dispose contexts after the master task complete,
             // driver may or may not receive the IFailedEvalautor event. 
-            Assert.True(failedEvaluatorCount == 0 || failedEvaluatorCount == 1);
+            Assert.True(failedEvaluatorCount <= 1);
 
             // Scenario1: Driver receives FailedEvaluator caused by dispose of a completed task after all the tasks have been competed. 
             //            FailedEvaluator event will be ignored.
@@ -91,13 +90,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
         }
 
         /// <summary>
-        /// This method defines event handlers for driver. As default, it uses all the handlers defined in IMRUDriver.
+        /// This method defines event handlers for driver. As default, it uses all the handlers defined in IMRUDriver.Logger.Log(Level.Info, "Simulate exception in Resu
         /// </summary>
-        /// <typeparam name="TMapInput"></typeparam>
-        /// <typeparam name="TMapOutput"></typeparam>
-        /// <typeparam name="TResult"></typeparam>
-        /// <typeparam name="TPartitionType"></typeparam>
-        /// <returns></returns>
         protected override IConfiguration DriverEventHandlerConfigurations<TMapInput, TMapOutput, TResult, TPartitionType>()
         {
             return REEF.Driver.DriverConfiguration.ConfigurationModule
@@ -156,7 +150,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             /// </summary>
             public void Dispose()
             {
-                Logger.Log(Level.Info, "Simulate exception in ResultHandlerWithException.Dispose.");
+                Logger.Log(Level.Warning, "Simulate exception in ResultHandlerWithException.Dispose.");
                 throw new Exception("Exception from ResultHandlerWithException.Dispose()");
             }
         }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestExceptionInResultHandlerDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestExceptionInResultHandlerDispose.cs
@@ -1,0 +1,164 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Org.Apache.REEF.IMRU.API;
+using Org.Apache.REEF.IMRU.OnREEF.Driver;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
+
+namespace Org.Apache.REEF.Tests.Functional.IMRU
+{
+    [Collection("FunctionalTests")]
+    public class TestExceptionInResultHandlerDispose : IMRUBrodcastReduceTestBase
+    {
+        /// <summary>
+        /// This test is to throw exception in IIMRUResultHandler Dispose() method
+        /// </summary>
+        [Fact]
+        public void TestExceptionInResultHandlerDisposeOnLocalRuntime()
+        {
+            int chunkSize = 2;
+            int dims = 10;
+            int iterations = 10;
+            int mapperMemory = 5120;
+            int updateTaskMemory = 5120;
+            int numTasks = 4;
+            int numberOfRetryInRecovery = 4;
+
+            string testFolder = DefaultRuntimeFolder + TestId;
+            TestBroadCastAndReduce(false, numTasks, chunkSize, dims, iterations, mapperMemory, updateTaskMemory, numberOfRetryInRecovery, testFolder);
+            string[] lines = ReadLogFile(DriverStdout, "driver", testFolder, 360);
+            var completedTaskCount = GetMessageCount(lines, "Received ICompletedTask");
+            var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
+            var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
+            var jobSuccess = GetMessageCount(lines, IMRUDriver<int[], int[], int[], int[]>.DoneActionPrefix);
+
+            // Master evaluator will fail after master task is completed. Depending on how quick the driver dispose contexts after the master task complete,
+            // driver may or may not receive the IFailedEvalautor event. 
+            Assert.True(failedEvaluatorCount == 0 || failedEvaluatorCount == 1);
+
+            // Scenario1: Driver receives FailedEvaluator caused by dispose of a completed task after all the tasks have been competed. 
+            //            FailedEvaluator event will be ignored.
+            // Scenario2: Driver receives FailedEvaluator caused by dispose of master task before all the tasks have been competed.
+            //            Driver will send close event to the rest of the running tasks and enter shutdown state 
+            //            During this process, some tasks can still complete and some may fail due to communication error
+            //            As evaluator failure happens in finally block, therefore either ICompletedTask or IFailedTask event should be sent before it.
+            //            Considering once maser is done, rest of the contexts will be disposed, we have 
+            //            numTasks >= completedTask# + FailedTask#
+            Assert.True(numTasks >= completedTaskCount + failedTaskCount);
+
+            // As update task completion happens before update evaluator failure caused by dispose, eventually job should succeeds
+            Assert.Equal(1, jobSuccess);
+
+            CleanUp(testFolder);
+        }
+
+        /// <summary>
+        /// This test is for the normal scenarios of IMRUDriver and IMRUTasks on yarn
+        /// </summary>
+        [Fact(Skip = "Requires Yarn")]
+        public void TestExceptionInResultHandlerDisposerOnYarn()
+        {
+            int chunkSize = 2;
+            int dims = 10;
+            int iterations = 10;
+            int mapperMemory = 5120;
+            int updateTaskMemory = 5120;
+            int numTasks = 4;
+            int numberOfRetryInRecovery = 4;
+            TestBroadCastAndReduce(false, numTasks, chunkSize, dims, iterations, mapperMemory, updateTaskMemory, numberOfRetryInRecovery);
+        }
+
+        /// <summary>
+        /// This method defines event handlers for driver. As default, it uses all the handlers defined in IMRUDriver.
+        /// </summary>
+        /// <typeparam name="TMapInput"></typeparam>
+        /// <typeparam name="TMapOutput"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TPartitionType"></typeparam>
+        /// <returns></returns>
+        protected override IConfiguration DriverEventHandlerConfigurations<TMapInput, TMapOutput, TResult, TPartitionType>()
+        {
+            return REEF.Driver.DriverConfiguration.ConfigurationModule
+                .Set(REEF.Driver.DriverConfiguration.OnEvaluatorAllocated,
+                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
+                .Set(REEF.Driver.DriverConfiguration.OnDriverStarted,
+                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
+                .Set(REEF.Driver.DriverConfiguration.OnContextActive,
+                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
+                .Set(REEF.Driver.DriverConfiguration.OnTaskCompleted,
+                     GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
+                .Set(REEF.Driver.DriverConfiguration.OnEvaluatorFailed,
+                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
+                .Set(REEF.Driver.DriverConfiguration.OnContextFailed,
+                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
+                .Set(REEF.Driver.DriverConfiguration.OnTaskRunning,
+                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
+                .Set(REEF.Driver.DriverConfiguration.OnTaskFailed,
+                     GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
+                .Set(REEF.Driver.DriverConfiguration.CustomTraceLevel, TraceLevel.Info.ToString())
+                .Build();
+        }
+
+        /// <summary>
+        /// Bind ResultHandlerWithException as IIMRUResultHandler
+        /// </summary>
+        /// <returns></returns>
+        protected override IConfiguration BuildResultHandlerConfig()
+        {
+            return TangFactory.GetTang().NewConfigurationBuilder()
+                    .BindImplementation(GenericType<IIMRUResultHandler<int[]>>.Class, GenericType<ResultHandlerWithException<int[]>>.Class)
+                    .Build();
+        }
+
+        /// <summary>
+        /// An implementation of IIMRUResultHandler that throws exception in Dispose()
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        internal sealed class ResultHandlerWithException<TResult> : IIMRUResultHandler<TResult>
+        {
+            [Inject]
+            private ResultHandlerWithException()
+            {
+            }
+
+            /// <summary>
+            /// Specifies how to handle the IMRU results from UpdateTask. Does nothing
+            /// </summary>
+            /// <param name="result">The result of IMRU</param>
+            public void HandleResult(TResult result)
+            {
+            }
+
+            /// <summary>
+            /// Simulate exception 
+            /// </summary>
+            public void Dispose()
+            {
+                Logger.Log(Level.Info, "Simulate exception in ResultHandlerWithException.Dispose.");
+                throw new Exception("Exception from ResultHandlerWithException.Dispose()");
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestExceptionInResultHandlerDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestExceptionInResultHandlerDispose.cs
@@ -90,7 +90,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
         }
 
         /// <summary>
-        /// This method defines event handlers for driver. As default, it uses all the handlers defined in IMRUDriver.Logger.Log(Level.Info, "Simulate exception in Resu
+        /// This method defines event handlers for driver. As default, it uses all the handlers defined in IMRUDriver.
         /// </summary>
         protected override IConfiguration DriverEventHandlerConfigurations<TMapInput, TMapOutput, TResult, TPartitionType>()
         {

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose.cs
@@ -77,8 +77,9 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             // Tasks should fail or complete or disappear with failed evaluator
             Assert.Equal(numTasks, completedTaskCount + failedEvaluatorCount + failedTaskCount);
 
-            // We have failed two mappers and one update evaluator in the test code
-            Assert.Equal(3, failedEvaluatorCount);
+            // We have failed two mappers and one update evaluator in the test code. As the update evaluator failure 
+            // happens in Dispose(), driver may/may not receive FailedEvaluator before shut down.
+            Assert.True(failedEvaluatorCount <= 3 && failedEvaluatorCount >= 2);
 
             // eventually job fail because master evaluator fail before the iteration is completed
             Assert.Equal(0, jobSuccess);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose.cs
@@ -15,13 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System.Diagnostics;
 using Org.Apache.REEF.IMRU.API;
-using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
-using Org.Apache.REEF.IMRU.OnREEF.IMRUTasks;
-using Org.Apache.REEF.IMRU.OnREEF.Parameters;
-using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
@@ -30,10 +25,8 @@ using Xunit;
 namespace Org.Apache.REEF.Tests.Functional.IMRU
 {
     [Collection("FunctionalTests")]
-    public class TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose : IMRUBrodcastReduceTestBase
+    public class TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose : TestFailMapperEvaluators
     {
-        protected const int NumberOfRetry = 3;
-
         /// <summary>
         /// This test fails two mappers during the iterations. When driver is to close master task, 
         /// the ResultHandler in the Update task will throw exception in Dispose.
@@ -41,7 +34,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
         /// or by the finally block in TaskRuntime.Close() method, depending on which one is quicker. 
         /// </summary>
         [Fact]
-        public virtual void TestFailedMapperWithFailedResultHandlerInDisposeOnLocalRuntime()
+        public override void TestFailedMapperOnLocalRuntime()
         {
             int chunkSize = 2;
             int dims = 100;
@@ -87,10 +80,10 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
         }
 
         /// <summary>
-        /// This test is for the normal scenarios of IMRUDriver and IMRUTasks on yarn
+        /// This test is on yarn
         /// </summary>
         [Fact(Skip = "Requires Yarn")]
-        public virtual void TestFailedMapperWithFailedResultHandlerInDisposOnYarn()
+        public override void TestFailedMapperOnYarn()
         {
             int chunkSize = 2;
             int dims = 100;
@@ -99,140 +92,6 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             int updateTaskMemory = 5120;
             int numTasks = 4;
             TestBroadCastAndReduce(true, numTasks, chunkSize, dims, iterations, mapperMemory, updateTaskMemory);
-        }
-
-        /// <summary>
-        /// This method defines event handlers for driver. As default, it uses all the handlers defined in IMRUDriver.
-        /// </summary>
-        /// <typeparam name="TMapInput"></typeparam>
-        /// <typeparam name="TMapOutput"></typeparam>
-        /// <typeparam name="TResult"></typeparam>
-        /// <typeparam name="TPartitionType"></typeparam>
-        /// <returns></returns>
-        protected override IConfiguration DriverEventHandlerConfigurations<TMapInput, TMapOutput, TResult, TPartitionType>()
-        {
-            return REEF.Driver.DriverConfiguration.ConfigurationModule
-                .Set(REEF.Driver.DriverConfiguration.OnEvaluatorAllocated,
-                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
-                .Set(REEF.Driver.DriverConfiguration.OnDriverStarted,
-                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
-                .Set(REEF.Driver.DriverConfiguration.OnContextActive,
-                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
-                .Set(REEF.Driver.DriverConfiguration.OnTaskCompleted,
-                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
-                .Set(REEF.Driver.DriverConfiguration.OnEvaluatorFailed,
-                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
-                .Set(REEF.Driver.DriverConfiguration.OnContextFailed,
-                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
-                .Set(REEF.Driver.DriverConfiguration.OnTaskFailed,
-                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
-                .Set(REEF.Driver.DriverConfiguration.OnTaskRunning,
-                    GenericType<IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>>.Class)
-                .Set(REEF.Driver.DriverConfiguration.OnTaskCompleted, GenericType<MessageLogger>.Class)
-                .Set(REEF.Driver.DriverConfiguration.OnTaskFailed, GenericType<MessageLogger>.Class)
-                .Set(REEF.Driver.DriverConfiguration.OnTaskRunning, GenericType<MessageLogger>.Class)
-                .Set(REEF.Driver.DriverConfiguration.OnEvaluatorFailed, GenericType<MessageLogger>.Class)
-                .Set(REEF.Driver.DriverConfiguration.CustomTraceLevel, TraceLevel.Verbose.ToString())
-                .Build();
-        }
-
-        /// <summary>
-        /// Create IMRU Job Definition with IMRU required configurations
-        /// </summary>
-        /// <param name="numberofMappers"></param>
-        /// <param name="chunkSize"></param>
-        /// <param name="numIterations"></param>
-        /// <param name="dim"></param>
-        /// <param name="mapperMemory"></param>
-        /// <param name="updateTaskMemory"></param>
-        /// <param name="numberOfRetryInRecovery"></param>
-        /// <param name="numberOfChecksBeforeCancellingJob"></param>
-        /// <returns></returns>
-        protected override IMRUJobDefinition CreateIMRUJobDefinitionBuilder(int numberofMappers,
-            int chunkSize,
-            int numIterations,
-            int dim,
-            int mapperMemory,
-            int updateTaskMemory,
-            int numberOfRetryInRecovery,
-            int? numberOfChecksBeforeCancellingJob = null)
-        {
-            return new IMRUJobDefinitionBuilder()
-                .SetUpdateTaskStateConfiguration(UpdateTaskStateConfiguration())
-                .SetMapTaskStateConfiguration(MapTaskStateConfiguration())
-                .SetMapFunctionConfiguration(BuildMapperFunctionConfig())
-                .SetUpdateFunctionConfiguration(BuildUpdateFunctionConfiguration(numberofMappers, numIterations, dim))
-                .SetMapInputCodecConfiguration(BuildMapInputCodecConfig())
-                .SetUpdateFunctionCodecsConfiguration(BuildUpdateFunctionCodecsConfig())
-                .SetReduceFunctionConfiguration(BuildReduceFunctionConfig())
-                .SetMapInputPipelineDataConverterConfiguration(BuildDataConverterConfig(chunkSize))
-                .SetMapOutputPipelineDataConverterConfiguration(BuildDataConverterConfig(chunkSize))
-                .SetPartitionedDatasetConfiguration(BuildPartitionedDatasetConfiguration(numberofMappers))
-                .SetResultHandlerConfiguration(BuildResultHandlerConfig())
-                .SetJobName(IMRUJobName)
-                .SetNumberOfMappers(numberofMappers)
-                .SetMapperMemory(mapperMemory)
-                .SetUpdateTaskMemory(updateTaskMemory)
-                .SetMaxRetryNumberInRecovery(numberOfRetryInRecovery)
-                .Build();
-        }
-
-        /// <summary>
-        /// Mapper function configuration. Subclass can override it to have its own test function.
-        /// </summary>
-        /// <returns></returns>
-        protected override IConfiguration BuildMapperFunctionConfig()
-        {
-            var c1 = IMRUMapConfiguration<int[], int[]>.ConfigurationModule
-                .Set(IMRUMapConfiguration<int[], int[]>.MapFunction,
-                    GenericType<PipelinedBroadcastAndReduceWithFaultTolerant.SenderMapFunctionFT>.Class)
-                .Build();
-
-            var c2 = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindSetEntry<PipelinedBroadcastAndReduceWithFaultTolerant.TaskIdsToFail, string>(GenericType<PipelinedBroadcastAndReduceWithFaultTolerant.TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-2-")
-                .BindSetEntry<PipelinedBroadcastAndReduceWithFaultTolerant.TaskIdsToFail, string>(GenericType<PipelinedBroadcastAndReduceWithFaultTolerant.TaskIdsToFail>.Class, "IMRUMap-RandomInputPartition-3-")
-                .BindIntNamedParam<PipelinedBroadcastAndReduceWithFaultTolerant.FailureType>(PipelinedBroadcastAndReduceWithFaultTolerant.FailureType.EvaluatorFailureDuringTaskExecution.ToString())
-                .BindNamedParameter(typeof(MaxRetryNumberInRecovery), NumberOfRetry.ToString())
-                .BindNamedParameter(typeof(PipelinedBroadcastAndReduceWithFaultTolerant.TotalNumberOfForcedFailures), NumberOfRetry.ToString())
-                .Build();
-
-            return Configurations.Merge(c1, c2);
-        }
-
-        /// <summary>
-        /// Set update function to IMRUUpdateConfiguration configuration module. Return it with TCP configuration.
-        /// </summary>
-        /// <returns></returns>
-        protected override IConfiguration BuildUpdateFunctionConfigModule()
-        {
-            return IMRUUpdateConfiguration<int[], int[], int[]>.ConfigurationModule
-                .Set(IMRUUpdateConfiguration<int[], int[], int[]>.UpdateFunction,
-                    GenericType<PipelinedBroadcastAndReduceWithFaultTolerant.BroadcastSenderReduceReceiverUpdateFunctionFT>.Class)
-                .Build();
-        }
-
-        /// <summary>
-        /// Configuration for Map task state
-        /// </summary>
-        /// <returns></returns>
-        private IConfiguration MapTaskStateConfiguration()
-        {
-            return TangFactory.GetTang()
-                   .NewConfigurationBuilder()
-                   .BindImplementation(GenericType<ITaskState>.Class, GenericType<MapTaskState<int[]>>.Class)
-                   .Build();
-        }
-
-        /// <summary>
-        /// Configuration for Update task state
-        /// </summary>
-        /// <returns></returns>
-        private IConfiguration UpdateTaskStateConfiguration()
-        {
-            return TangFactory.GetTang()
-                   .NewConfigurationBuilder()
-                   .BindImplementation(GenericType<ITaskState>.Class, GenericType<UpdateTaskState<int[], int[]>>.Class)
-                   .Build();
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose.cs
@@ -30,7 +30,7 @@ using Xunit;
 namespace Org.Apache.REEF.Tests.Functional.IMRU
 {
     [Collection("FunctionalTests")]
-    public class TestFailedMapperWithFailedResultHandlerInDispose : IMRUBrodcastReduceTestBase
+    public class TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose : IMRUBrodcastReduceTestBase
     {
         protected const int NumberOfRetry = 3;
 

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -130,6 +130,8 @@ under the License.
     <Compile Include="Functional\IMRU\IMRUBrodcastReduceTestBase.cs" />
     <Compile Include="Functional\IMRU\IMRUCloseTaskTest.cs" />
     <Compile Include="Functional\IMRU\IMRUMapperCountTest.cs" />
+    <Compile Include="Functional\IMRU\TestExceptionInResultHandlerDispose.cs" />
+    <Compile Include="Functional\IMRU\TestFailedMapperWithFailedResultHandlerInDispose.cs" />
     <Compile Include="Functional\IMRU\TestFailUpdateEvaluatorOnWaitingForEvaluator.cs" />
     <Compile Include="Functional\IMRU\TestFailMapperTasksOnDispose.cs" />
     <Compile Include="Functional\IMRU\TestFailMapperEvaluatorsOnDispose.cs" />

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -131,7 +131,7 @@ under the License.
     <Compile Include="Functional\IMRU\IMRUCloseTaskTest.cs" />
     <Compile Include="Functional\IMRU\IMRUMapperCountTest.cs" />
     <Compile Include="Functional\IMRU\TestExceptionInResultHandlerDispose.cs" />
-    <Compile Include="Functional\IMRU\TestFailedMapperWithFailedResultHandlerInDispose.cs" />
+    <Compile Include="Functional\IMRU\TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose.cs" />
     <Compile Include="Functional\IMRU\TestFailUpdateEvaluatorOnWaitingForEvaluator.cs" />
     <Compile Include="Functional\IMRU\TestFailMapperTasksOnDispose.cs" />
     <Compile Include="Functional\IMRU\TestFailMapperEvaluatorsOnDispose.cs" />


### PR DESCRIPTION
Currentlythere are a few issues in about ResultHandler.Dispose()

* The sample implementation of ResultHandler uploads local file to remote in Dispose method, that is not right. Because in recovery scenarios, Dispose can be called in each retry with no result written to local file yet. The uploading should be only executed after the result is written to the local file.
* Dispose method should release resource only instead of containing complex logic so that to reduce the chance of failure.
* ResultHandler.Dispose()  is called in FinallyBlock() method in TaskHost. It should be called in Task.Dispose so that the same exception handling logic will be shared with Task.Dispose()

This PR is to fix those issues.

JIRA: [REEF-1492](https://issues.apache.org/jira/browse/REEF-1492)
This closes  #