### PR TITLE
[REEF-1690] Replace Skip attribute with Trait for .NET tests on Yarn

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
@@ -18,7 +18,6 @@
 using System.Threading.Tasks;
 using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Examples.AllHandlers;
-using Org.Apache.REEF.Utilities.Logging;
 using Xunit;
 
 namespace Org.Apache.REEF.Tests.Functional.Bridge
@@ -26,9 +25,8 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
     [Collection("FunctionalTests")]
     public class TestBridgeClient : ReefFunctionalTest
     {
-        private static readonly Logger LOGGER = Logger.GetLogger(typeof(TestBridgeClient));
-
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         [Trait("Priority", "1")]
         [Trait("Category", "FunctionalGated")]
         [Trait("Description", "Run CLR Bridge on Yarn")]

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/BroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/BroadcastReduceTest.cs
@@ -42,7 +42,8 @@ namespace Org.Apache.REEF.Tests.Functional.Group
             CleanUp(testFolder);
         }
 
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         public void TestBroadcastAndReduceOnYarn()
         {
             int numTasks = 9;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/PipelinedBroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/PipelinedBroadcastReduceTest.cs
@@ -42,7 +42,8 @@ namespace Org.Apache.REEF.Tests.Functional.Group
             CleanUp(testFolder);
         }
 
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         public void TestPipelinedBroadcastAndReduceOnYarn()
         {
             const int numTasks = 9;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
@@ -42,7 +42,8 @@ namespace Org.Apache.REEF.Tests.Functional.Group
             CleanUp(testFolder);
         }
 
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         public void TestScatterAndReduceOnYarn()
         {
             int numTasks = 5;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBroadcastReduceTest.cs
@@ -57,7 +57,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             CleanUp(testFolder);
         }
 
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         [Trait("Description", "Run IMRU broadcast and reduce example as test on Yarn.")]
         void TestIMRUBroadcastReduceOnYarn()
         {

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBrodcastReduceWithoutIMRUClientTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUBrodcastReduceWithoutIMRUClientTest.cs
@@ -48,7 +48,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
         /// <summary>
         /// This test is for the normal scenarios of IMRUDriver and IMRUTasks on yarn
         /// </summary>
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         public void TestWithHandlersInIMRUDriverOnYarn()
         {
             int chunkSize = 2;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUCloseTaskTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUCloseTaskTest.cs
@@ -71,7 +71,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
         /// Same testing for running on YARN
         /// It sends close event for all the running tasks.
         /// </summary>
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         public void TestTaskCloseOnLocalRuntimeOnYarn()
         {
             const int chunkSize = 2;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUMapperCountTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/IMRUMapperCountTest.cs
@@ -39,7 +39,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             CleanUp(testFolder);
         }
 
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         [Trait("Description", "Run IMRU mapper count example as test on Yarn.")]
         void TestIMRUMapperCountOnYarn()
         {

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestExceptionInResultHandlerDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestExceptionInResultHandlerDispose.cs
@@ -76,7 +76,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
         /// <summary>
         /// This test is for the normal scenarios of IMRUDriver and IMRUTasks on yarn
         /// </summary>
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         public void TestExceptionInResultHandlerDisposerOnYarn()
         {
             int chunkSize = 2;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
@@ -76,10 +76,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             CleanUp(testFolder);
         }
 
-        /// <summary>
-        /// This test is for the normal scenarios of IMRUDriver and IMRUTasks on yarn
-        /// </summary>
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         public virtual void TestFailedMapperOnYarn()
         {
             int chunkSize = 2;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluatorsWithFailedResultHandlerOnDispose.cs
@@ -79,10 +79,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             CleanUp(testFolder);
         }
 
-        /// <summary>
-        /// This test is on yarn
-        /// </summary>
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         public override void TestFailedMapperOnYarn()
         {
             int chunkSize = 2;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailUpdateEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailUpdateEvaluator.cs
@@ -78,10 +78,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             CleanUp(testFolder);
         }
 
-        /// <summary>
-        /// This test is for the normal scenarios of IMRUDriver and IMRUTasks on yarn
-        /// </summary>
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         public virtual void TestFailedUpdateOnYarn()
         {
             int chunkSize = 2;

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailUpdateEvaluatorOnWaitingForEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailUpdateEvaluatorOnWaitingForEvaluator.cs
@@ -58,7 +58,8 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
         /// <summary>
         /// This test is to fail master evaluator at context start. The system will fail. 
         /// </summary>
-        [Fact(Skip = "Requires Yarn")]
+        [Fact]
+        [Trait("Environment", "Yarn")]
         public void TestFailUpdateEvaluatorAtContexStartOnOnYarn()
         {
             int chunkSize = 2;

--- a/lang/cs/xunit.targets
+++ b/lang/cs/xunit.targets
@@ -49,7 +49,7 @@ under the License.
     <Exec Command="$(SolutionDir)\.nuget\nuget.exe restore $(SolutionDir)\.nuget\packages.config -o $(PackagesDir)" />
   </Target>
   <Target Name="Test">
-    <Exec Command="$(PackagesDir)\xunit.runner.console.$(xUnitVersion)\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll -html $(OutputPath)\xunit_report.html"
+    <Exec Command="$(PackagesDir)\xunit.runner.console.$(xUnitVersion)\tools\xunit.console.exe $(OutputPath)\$(AssemblyName).dll -notrait Environment=Yarn -html $(OutputPath)\xunit_report.html"
           IgnoreStandardErrorWarningFormat="true"
       />
   </Target>


### PR DESCRIPTION
This change replaces [Fact(Skip)] annotation with [Trait("Environment", "Yarn")]
for .NET tests which are supposed to be executed on Yarn. This allows to execute
them (skipped tests can't be executed at all).

JIRA:
  [REEF-1690](https://issues.apache.org/jira/browse/REEF-1690)

Pull request:
  This closes #