### PR TITLE
[REEF-1699] Use the {{JAVA_HOME}} notation when starting REEF Evaluators on YARN

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/UnixJVMPathProvider.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/UnixJVMPathProvider.java
@@ -30,6 +30,11 @@ public final class UnixJVMPathProvider implements RuntimePathProvider {
 
   @Override
   public String getPath() {
-    return System.getenv("JAVA_HOME") + "/bin/" + "java";
+    return "{{JAVA_HOME}}/bin/java";
+  }
+
+  @Override
+  public String toString() {
+    return getPath();
   }
 }


### PR DESCRIPTION

   * Use `{{JAVA_HOME}}` instead of locally-issued `.getenv()` call when launching REEF Evaluators on YARN
   * Implement a `.toString()` method for better logging

This fix is related to [REEF-1665](https://issues.apache.org/jira/browse/REEF-1665) that uses the same mechanism to launch the Driver

JIRA: [REEF-1699](https://issues.apache.org/jira/browse/REEF-1699)

Closes PR #