### PR TITLE
[REEF-1702] Restrict JUnit and Mockito dependencies to test in reef-runtime-local

### DIFF
--- a/lang/java/reef-runtime-local/pom.xml
+++ b/lang/java/reef-runtime-local/pom.xml
@@ -45,10 +45,12 @@ under the License.
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>        
     </dependencies>
 


### PR DESCRIPTION
Add `test` scope to JUnit and Mockito dependencies

JIRA: [REEF-1702](https://issues.apache.org/jira/browse/REEF-1702)

Closes PR #