### PR TITLE
[REEF-1705] implement SecurityTokenProvider.addToken()

### DIFF
--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/SecurityTokenProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/SecurityTokenProvider.java
@@ -31,4 +31,10 @@ public interface SecurityTokenProvider {
    * @return a ByteBuffer
    */
   byte[] getTokens();
+
+  /**
+   * Add serialized tokens to the credentials.
+   * @param tokens ByteBuffer containing tokens.
+   */
+  void addTokens(final byte[] tokens);
 }


### PR DESCRIPTION
   * Added the `.addToken()` method to the `SecurityTokenProvider` interface and its implementations
   * Implemented token serialization for YARN

We'll need that functionality for the Unmanaged AM mode. (that is also the reason we make class public)

JIRA: [REEF-1705](https://issues.apache.org/jira/browse/REEF-1705)

Closes PR #