### PR TITLE
[REEF-1706] implement ApplicationMasterRegistration.toString()

### DIFF
--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/ApplicationMasterRegistration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/ApplicationMasterRegistration.java
@@ -59,4 +59,9 @@ final class ApplicationMasterRegistration {
   synchronized boolean isPresent() {
     return this.registration.isPresent();
   }
+
+  @Override
+  public synchronized String toString() {
+    return this.registration.toString();
+  }
 }


### PR DESCRIPTION
log the `ApplicationMasterRegistration` data structure, and implement the proper `.toString()` method for the class. The `registration` variable already has the `.toString()` method implemented.

JIRA: [REEF-1706](https://issues.apache.org/jira/browse/REEF-1706)

Closes PR #