### PR TITLE
[REEF-1707] Fix the compilation warning in reef-runtime-yarn Containers class

### DIFF
--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/Containers.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/Containers.java
@@ -104,6 +104,6 @@ final class Containers {
    * @return an Iterable of all the known container Ids.
    */
   synchronized Iterable<String> getContainerIds() {
-    return new ArrayList(this.containers.keySet());
+    return new ArrayList<>(this.containers.keySet());
   }
 }


### PR DESCRIPTION
Use the diamond operator instead of the unchecked class in `Containers.getContainerIds()` method.

JIRA: [REEF-1707](https://issues.apache.org/jira/browse/REEF-1707)

Closes PR #