### PR TITLE
[REEF-1711] Better toString() and logging in Wake components

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
@@ -235,7 +235,6 @@ public final class DefaultRemoteManagerImplementation implements RemoteManager {
 
   @Override
   public String toString() {
-    return String.format("RemoteManager: { class:%s, name:%s, id:%s }",
-        this.getClass().getCanonicalName(), this.name, this.myIdentifier);
+    return String.format("RemoteManager: { id:%s handler:%s }", this.myIdentifier, this.handlerContainer);
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
@@ -56,8 +56,13 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
     this.name = name;
     this.codec = codec;
 
-    LOG.log(Level.FINER, "Instantiated HandlerContainer {0} with codec {1}",
-        new String[] {this.name, this.codec.getClass().getCanonicalName()});
+    LOG.log(Level.FINER, "Instantiated {0}", this.toString());
+  }
+
+  @Override
+  public String toString() {
+    return String.format("HandlerContainer: {name:%s codec:%s}",
+        this.name, this.codec.getClass().getCanonicalName());
   }
 
   void setTransport(final Transport transport) {


### PR DESCRIPTION
Implement better `.toString()` method in the `RemoteManager` and `HandlerContainer` classes

JIRA: [REEF-1711](https://issues.apache.org/jira/browse/REEF-1711)

Closes PR #