### PR TITLE
[REEF-1712] Make JobSubmissionHandler return the Application ID

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionHandler.java
@@ -27,6 +27,10 @@ import org.apache.reef.wake.EventHandler;
 @RuntimeAuthor
 public interface JobSubmissionHandler extends EventHandler<JobSubmissionEvent>, AutoCloseable {
 
-  @Override
-  void close();
+  /**
+   * Get the RM application ID.
+   * Return null if the application has not been submitted yet, or was submitted unsuccessfully.
+   * @return string application ID or null if no app has been submitted yet.
+   */
+  String getApplicationId();
 }

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightJobSubmissionHandler.java
@@ -57,7 +57,7 @@ public final class HDInsightJobSubmissionHandler implements JobSubmissionHandler
   private final ClasspathProvider classpath;
   private final DriverConfigurationProvider driverConfigurationProvider;
 
-  private String applicationId = null;
+  private String applicationId;
 
   @Inject
   HDInsightJobSubmissionHandler(final AzureUploader uploader,

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightJobSubmissionHandler.java
@@ -57,6 +57,8 @@ public final class HDInsightJobSubmissionHandler implements JobSubmissionHandler
   private final ClasspathProvider classpath;
   private final DriverConfigurationProvider driverConfigurationProvider;
 
+  private String applicationId = null;
+
   @Inject
   HDInsightJobSubmissionHandler(final AzureUploader uploader,
                                 final JobJarMaker jobJarMaker,
@@ -83,16 +85,15 @@ public final class HDInsightJobSubmissionHandler implements JobSubmissionHandler
     try {
 
       LOG.log(Level.FINE, "Requesting Application ID from HDInsight.");
-      final ApplicationID applicationID = this.hdInsightInstance.getApplicationID();
+      final String appId = this.hdInsightInstance.getApplicationID().getApplicationId();
 
-      LOG.log(Level.INFO, "Submitting application {0} to YARN.", applicationID.getApplicationId());
+      LOG.log(Level.INFO, "Submitting application {0} to YARN.", appId);
 
       LOG.log(Level.FINE, "Creating a job folder on Azure.");
-      final URI jobFolderURL = this.uploader.createJobFolder(applicationID.getApplicationId());
+      final URI jobFolderURL = this.uploader.createJobFolder(appId);
 
       LOG.log(Level.FINE, "Assembling Configuration for the Driver.");
-      final Configuration driverConfiguration =
-          makeDriverConfiguration(jobSubmissionEvent, applicationID.getApplicationId(), jobFolderURL);
+      final Configuration driverConfiguration = makeDriverConfiguration(jobSubmissionEvent, appId, jobFolderURL);
 
       LOG.log(Level.FINE, "Making Job JAR.");
       final File jobSubmissionJarFile =
@@ -105,7 +106,7 @@ public final class HDInsightJobSubmissionHandler implements JobSubmissionHandler
       final String command = getCommandString(jobSubmissionEvent);
 
       final ApplicationSubmission applicationSubmission = new ApplicationSubmission()
-          .setApplicationId(applicationID.getApplicationId())
+          .setApplicationId(appId)
           .setApplicationName(jobSubmissionEvent.getIdentifier())
           .setResource(getResource(jobSubmissionEvent))
           .setAmContainerSpec(new AmContainerSpec()
@@ -113,13 +114,23 @@ public final class HDInsightJobSubmissionHandler implements JobSubmissionHandler
                   .setCommand(command));
 
       this.hdInsightInstance.submitApplication(applicationSubmission);
-      LOG.log(Level.INFO, "Submitted application to HDInsight. The application id is: {0}",
-          applicationID.getApplicationId());
+      this.applicationId = appId;
+      LOG.log(Level.INFO, "Submitted application to HDInsight. The application id is: {0}", appId);
 
     } catch (final IOException ex) {
       LOG.log(Level.SEVERE, "Error submitting HDInsight request", ex);
       throw new RuntimeException(ex);
     }
+  }
+
+  /**
+   * Get the RM application ID.
+   * Return null if the application has not been submitted yet, or was submitted unsuccessfully.
+   * @return string application ID or null if no app has been submitted yet.
+   */
+  @Override
+  public String getApplicationId() {
+    return this.applicationId;
   }
 
   /**
@@ -159,12 +170,10 @@ public final class HDInsightJobSubmissionHandler implements JobSubmissionHandler
 
   private Configuration makeDriverConfiguration(
       final JobSubmissionEvent jobSubmissionEvent,
-      final String applicationId,
+      final String appId,
       final URI jobFolderURL) throws IOException {
 
-    return this.driverConfigurationProvider.getDriverConfiguration(jobFolderURL,
-                                                            jobSubmissionEvent.getRemoteId(),
-                                                            applicationId,
-                                                            jobSubmissionEvent.getConfiguration());
+    return this.driverConfigurationProvider.getDriverConfiguration(
+        jobFolderURL, jobSubmissionEvent.getRemoteId(), appId, jobSubmissionEvent.getConfiguration());
   }
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
@@ -54,7 +54,7 @@ public final class LocalJobSubmissionHandler implements JobSubmissionHandler {
   private final LoggingScopeFactory loggingScopeFactory;
   private final DriverConfigurationProvider driverConfigurationProvider;
 
-  private String applicationId = null;
+  private String applicationId;
 
   @Inject
   LocalJobSubmissionHandler(

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
@@ -54,6 +54,8 @@ public final class LocalJobSubmissionHandler implements JobSubmissionHandler {
   private final LoggingScopeFactory loggingScopeFactory;
   private final DriverConfigurationProvider driverConfigurationProvider;
 
+  private String applicationId = null;
+
   @Inject
   LocalJobSubmissionHandler(
       final ExecutorService executor,
@@ -108,10 +110,22 @@ public final class LocalJobSubmissionHandler implements JobSubmissionHandler {
         this.configurationSerializer.toFile(driverConfiguration,
             new File(driverFolder, this.fileNames.getDriverConfigurationPath()));
         this.driverLauncher.launch(driverFolder);
+        this.applicationId = t.getIdentifier();
+
       } catch (final Exception e) {
         LOG.log(Level.SEVERE, "Unable to setup driver.", e);
         throw new RuntimeException("Unable to setup driver.", e);
       }
     }
+  }
+
+  /**
+   * Get the RM application ID.
+   * Return null if the application has not been submitted yet, or was submitted unsuccessfully.
+   * @return string application ID or null if no app has been submitted yet.
+   */
+  @Override
+  public String getApplicationId() {
+    return this.applicationId;
   }
 }

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/MesosJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/MesosJobSubmissionHandler.java
@@ -59,7 +59,7 @@ final class MesosJobSubmissionHandler implements JobSubmissionHandler {
   private final String rootFolderName;
   private final DriverConfigurationProvider driverConfigurationProvider;
 
-  private String applicationId = null;
+  private String applicationId;
 
   @Inject
   MesosJobSubmissionHandler(@Parameter(RootFolder.class) final String rootFolderName,

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/MesosJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/MesosJobSubmissionHandler.java
@@ -59,6 +59,8 @@ final class MesosJobSubmissionHandler implements JobSubmissionHandler {
   private final String rootFolderName;
   private final DriverConfigurationProvider driverConfigurationProvider;
 
+  private String applicationId = null;
+
   @Inject
   MesosJobSubmissionHandler(@Parameter(RootFolder.class) final String rootFolderName,
                             final ConfigurationSerializer configurationSerializer,
@@ -138,8 +140,21 @@ final class MesosJobSubmissionHandler implements JobSubmissionHandler {
               .redirectError(errFile)
               .redirectOutput(outFile)
               .start();
+
+      this.applicationId = jobSubmissionEvent.getIdentifier();
+
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Get the RM application ID.
+   * Return null if the application has not been submitted yet, or was submitted unsuccessfully.
+   * @return string application ID or null if no app has been submitted yet.
+   */
+  @Override
+  public String getApplicationId() {
+    return this.applicationId;
   }
 }

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnJobSubmissionHandler.java
@@ -64,7 +64,7 @@ final class YarnJobSubmissionHandler implements JobSubmissionHandler {
   private final SecurityTokenProvider tokenProvider;
   private final DriverConfigurationProvider driverConfigurationProvider;
 
-  private String applicationId = null;
+  private String applicationId;
 
   @Inject
   YarnJobSubmissionHandler(


### PR DESCRIPTION
Add `.getApplicationId()` method to `JobSubmissionHandler` interface and all its implementations.

JIRA: [REEF-1712](https://issues.apache.org/jira/browse/REEF-1712)

Closes PR #