### PR TITLE
[REEF-1713] Make REEF.submit() return the ID of the newly submitted application

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/REEF.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/REEF.java
@@ -49,7 +49,8 @@ public interface REEF extends AutoCloseable {
    * The Configuration needs to bind the Driver interface to an actual
    * implementation of that interface for the job at hand.
    *
-   * @param driverConf The driver configuration: including everything it needs to execute.  @see DriverConfiguration
+   * @param driverConf The driver configuration: including everything it needs to execute. @see DriverConfiguration
+   * @return ID of the submitted application.
    */
-  void submit(final Configuration driverConf);
+  String submit(final Configuration driverConf);
 }


### PR DESCRIPTION
We need this for the Unmanaged AM functionality. It is a backward-compatible API change that will not break any old client code.

We also add some extra logging and cleanup in the `REEF.close()` call.

JIRA: [REEF-1713](https://issues.apache.org/jira/browse/REEF-1713)

Closes #