### PR TITLE
[REEF-1715] Remove System.exit() at the end of the REEF launcher

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFEnvironment.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFEnvironment.java
@@ -31,7 +31,6 @@ import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.util.EnvironmentUtils;
 import org.apache.reef.util.REEFVersion;
-import org.apache.reef.util.ThreadLogger;
 import org.apache.reef.wake.profiler.WakeProfiler;
 import org.apache.reef.wake.time.Clock;
 
@@ -152,8 +151,6 @@ public final class REEFEnvironment implements Runnable, AutoCloseable {
         LOG.log(Level.SEVERE, "Error while closing the error handler", ex);
       }
     }
-
-    ThreadLogger.logThreads(LOG, Level.FINEST, "Threads running after REEFEnvironment.close():");
 
     LOG.exiting(CLASS_NAME, "close");
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
@@ -183,11 +183,9 @@ public final class REEFLauncher {
       throw fatal("Unable to configure and start REEFEnvironment.", ex);
     }
 
+    ThreadLogger.logThreads(LOG, Level.FINEST, "Threads running after REEFEnvironment.close():");
+
     LOG.log(Level.INFO, "Exiting REEFLauncher.main()");
-
-    System.exit(0);
-
-    ThreadLogger.logThreads(LOG, Level.FINEST, "Threads running after System.exit():");
   }
 
   /**


### PR DESCRIPTION
   * Remove `System.exit(0)` call at the end of the launcher process;
   * Move thread logging from `REEFEnvironment` to `REEFLauncher`

**NOTE:** Make sure all unit tests pass locally and on YARN before merging into master!

JIRA: [REEF-1715](https://issues.apache.org/jira/browse/REEF-1715)

Closes PR #