### PR TITLE
[REEF-1721] Close the job submission handler when REEF client closes.

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/REEFImplementation.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/REEFImplementation.java
@@ -39,6 +39,7 @@ import org.apache.reef.util.logging.LoggingScopeFactory;
 
 import javax.inject.Inject;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -89,8 +90,21 @@ public final class REEFImplementation implements REEF {
 
   @Override
   public void close() {
+
+    LOG.log(Level.FINE, "Close REEF: shutdown jobs");
     this.runningJobs.closeAllJobs();
+
+    LOG.log(Level.FINE, "Close REEF: shutdown client");
     this.clientWireUp.close();
+
+    LOG.log(Level.FINE, "Close REEF: shutdown job submitter");
+    try {
+      this.jobSubmissionHandler.close();
+    } catch (final Exception ex) {
+      LOG.log(Level.WARNING, "Could not shutdown job submitter", ex);
+    }
+
+    LOG.log(Level.FINE, "Close REEF: done");
   }
 
   @Override
@@ -137,6 +151,4 @@ public final class REEFImplementation implements REEF {
   @NamedParameter(doc = "The driver remote identifier.")
   public static final class DriverRemoteIdentifier implements Name<String> {
   }
-
-
 }


### PR DESCRIPTION
Also add some extra logging in the `REEF.close()` call.

JIRA: [REEF-1721](https://issues.apache.org/jira/browse/REEF-1721)

Closes #