### PR TITLE
[REEF-1509] Fix broken links to the talks page

### DIFF
--- a/website/src/site/markdown/talks.md
+++ b/website/src/site/markdown/talks.md
@@ -20,27 +20,37 @@ under the License.
 # Talks
 On this page, we collect slides and videos of talks given by members of the REEF community.
 
-**BOSS 2015** ([Slides](http://1drv.ms/1OgHuwZ), [Files](https://cwiki.apache.org/confluence/display/REEF/BOSS+Tutorial))
+**BOSS 2015** 
+([Slides](https://cwiki.apache.org/confluence/download/attachments/61318556/ApacheREEF-BOSS2015-Final-Pub.pptx?api=v2),
+[Files](https://cwiki.apache.org/confluence/display/REEF/BOSS+Tutorial))
 
-This tutorial was part of the workshop on Big Data Open Source Systems ([BOSS](http://boss.dima.tu-berlin.de/)), co-located with VLDB 2015.
+This tutorial was part of the workshop on Big Data Open Source Systems 
+([BOSS](http://boss.dima.tu-berlin.de/)), co-located with VLDB 2015.
 
-**REEF.NET for Java developers** ([Slides](http://1drv.ms/1QQy3lN))
+**REEF.NET for Java developers** 
+([Slides](https://1drv.ms/p/s!AtrDv3JncgFYjcZylzGyL3xC2xau-A))
 
 This deck was used as part of a discussion during the 2015 Seoul REEF hackathon.
   
-**SIGMOD 2015** ([Slides](http://1drv.ms/1Gxpf30))
+**SIGMOD 2015** 
+([Slides](https://1drv.ms/p/s!AtrDv3JncgFYjcZu5-jt_TA-Hyl6GQ))
 
 REEF was presented in the industrial track of SIGMOD 2015. 
 
-**Workshop on Software Engineering for Machine Learning** ([Slides](http://1drv.ms/1GxpaMJ))
+**Workshop on Software Engineering for Machine Learning** 
+([Slides](https://1drv.ms/p/s!AtrDv3JncgFYiopVV147oFZgGrbROQ))
   
 Markus gave a talk at the 2014 Workshop on Software Engineering for Machine Learning at NIPS held in Montreal,
 Canada. It uses REEF as an example for potential pitfalls and learnings when making machine learning software.
 
-**GraphLab conference 2014** ([Slides](http://1drv.ms/1e7pIOX), [Video](http://www.youtube.com/watch?v=xPhsYioU80I))
+**GraphLab conference 2014** 
+([Slides](https://1drv.ms/p/s!AtrDv3JncgFYiatT9SWCRoqpGCQvVg), 
+[Video](http://www.youtube.com/watch?v=xPhsYioU80I))
 
 This was presented to the GraphLab conference. Some special focus is given to Machine Learning tasks.
 
-**Hadoop Summit 2014** ([Slides](http://1drv.ms/1e7pIOX), [Video](http://www.youtube.com/watch?v=5dWgF_9dnRE))
+**Hadoop Summit 2014** 
+([Slides](https://1drv.ms/p/s!AtrDv3JncgFYiM5pjfT3Ifx_uQeO2g), 
+[Video](http://www.youtube.com/watch?v=5dWgF_9dnRE))
 
 This is the first talk introducing Apache REEF, as opposed to Microsoft REEF.


### PR DESCRIPTION
This PR:

- Fixes the broken links to the talks page of our website

JIRA: [REEF-1509](https://issues.apache.org/jira/browse/REEF-1509)
closes