### PR TITLE
[REEF-1724] Refactor HelloREEF example for the local runtime

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverLauncher.java
@@ -24,7 +24,6 @@ import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Unit;
-import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.util.Optional;
 import org.apache.reef.wake.EventHandler;
@@ -48,7 +47,16 @@ import java.util.logging.Logger;
 public final class DriverLauncher {
 
   private static final Logger LOG = Logger.getLogger(DriverLauncher.class.getName());
+
+  private static final Configuration CLIENT_CONFIG = ClientConfiguration.CONF
+      .set(ClientConfiguration.ON_JOB_RUNNING, RunningJobHandler.class)
+      .set(ClientConfiguration.ON_JOB_COMPLETED, CompletedJobHandler.class)
+      .set(ClientConfiguration.ON_JOB_FAILED, FailedJobHandler.class)
+      .set(ClientConfiguration.ON_RUNTIME_ERROR, RuntimeErrorHandler.class)
+      .build();
+
   private final REEF reef;
+
   private LauncherStatus status = LauncherStatus.INIT;
   private RunningJob theJob = null;
 
@@ -62,21 +70,11 @@ public final class DriverLauncher {
    *
    * @param runtimeConfiguration the resourcemanager configuration to be used
    * @return a DriverLauncher based on the given resourcemanager configuration
-   * @throws BindException      on configuration errors
    * @throws InjectionException on configuration errors
    */
-  public static DriverLauncher getLauncher(
-      final Configuration runtimeConfiguration) throws BindException, InjectionException {
-
-    final Configuration clientConfiguration = ClientConfiguration.CONF
-        .set(ClientConfiguration.ON_JOB_RUNNING, RunningJobHandler.class)
-        .set(ClientConfiguration.ON_JOB_COMPLETED, CompletedJobHandler.class)
-        .set(ClientConfiguration.ON_JOB_FAILED, FailedJobHandler.class)
-        .set(ClientConfiguration.ON_RUNTIME_ERROR, RuntimeErrorHandler.class)
-        .build();
-
+  public static DriverLauncher getLauncher(final Configuration runtimeConfiguration) throws InjectionException {
     return Tang.Factory.getTang()
-        .newInjector(runtimeConfiguration, clientConfiguration)
+        .newInjector(runtimeConfiguration, CLIENT_CONFIG)
         .getInstance(DriverLauncher.class);
   }
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEF.java
@@ -23,9 +23,9 @@ import org.apache.reef.client.DriverLauncher;
 import org.apache.reef.client.LauncherStatus;
 import org.apache.reef.runtime.local.client.LocalRuntimeConfiguration;
 import org.apache.reef.tang.Configuration;
-import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.util.EnvironmentUtils;
+import org.apache.reef.util.ThreadLogger;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -34,60 +34,42 @@ import java.util.logging.Logger;
  * The Client for Hello REEF example.
  */
 public final class HelloREEF {
+
   private static final Logger LOG = Logger.getLogger(HelloREEF.class.getName());
 
-  /**
-   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently.
-   */
-  private static final int MAX_NUMBER_OF_EVALUATORS = 2;
-
-  /**
-   * Number of milliseconds to wait for the job to complete.
-   */
+  /** Number of milliseconds to wait for the job to complete. */
   private static final int JOB_TIMEOUT = 10000; // 10 sec.
 
 
-  /**
-   * @return the configuration of the runtime
-   */
-  private static Configuration getRuntimeConfiguration() {
-    return LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
-        .build();
-  }
+  /** Configuration of the runtime. */
+  private static final Configuration RUNTIME_CONFIG =
+      LocalRuntimeConfiguration.CONF
+          .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, 2)
+          .build();
+
+  /** Configuration of the HelloREEF driver. */
+  private static final Configuration DRIVER_CONFIG =
+      DriverConfiguration.CONF
+          .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF")
+          .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(HelloDriver.class))
+          .set(DriverConfiguration.ON_DRIVER_STARTED, HelloDriver.StartHandler.class)
+          .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, HelloDriver.EvaluatorAllocatedHandler.class)
+          .build();
 
   /**
-   * @return the configuration of the HelloREEF driver.
-   */
-  private static Configuration getDriverConfiguration() {
-    return DriverConfiguration.CONF
-        .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(HelloDriver.class))
-        .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF")
-        .set(DriverConfiguration.ON_DRIVER_STARTED, HelloDriver.StartHandler.class)
-        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, HelloDriver.EvaluatorAllocatedHandler.class)
-        .build();
-  }
-
-  /**
-   * Start Hello REEF job.
-   *
+   * Start Hello REEF job with local runtime.
    * @param args command line parameters.
-   * @throws BindException      configuration error.
    * @throws InjectionException configuration error.
    */
-  public static void main(final String[] args) throws BindException, InjectionException {
-    final Configuration runtimeConf = getRuntimeConfiguration();
-    final Configuration driverConf = getDriverConfiguration();
+  public static void main(final String[] args) throws InjectionException {
 
-    final LauncherStatus status = DriverLauncher
-        .getLauncher(runtimeConf)
-        .run(driverConf, JOB_TIMEOUT);
+    final LauncherStatus status = DriverLauncher.getLauncher(RUNTIME_CONFIG).run(DRIVER_CONFIG, JOB_TIMEOUT);
+
     LOG.log(Level.INFO, "REEF job completed: {0}", status);
+
+    ThreadLogger.logThreads(LOG, Level.FINE, "Threads running at the end of HelloREEF:");
   }
 
-  /**
-   * Empty private constructor to prohibit instantiation of utility class.
-   */
-  private HelloREEF() {
-  }
+  /** Empty private constructor to prohibit instantiation of utility class. */
+  private HelloREEF() { }
 }


### PR DESCRIPTION
   * Make code more readable and idiomatic;
   * Log all running threads at the end of the **client** process;
   * remove references to `BindException` from the example and from `DriverLauncher`;

**NOTE:** The updated HelloREEF example can be used to verify that all threads are closed before the client exit as per [REEF-1721](https://issues.apache.org/jira/browse/REEF-1721) (PR #1234).

JIRA: [REEF-1724](https://issues.apache.org/jira/browse/REEF-1724)