### PR TITLE
[REEF-1725] Set job done as task result if UpdateTask is done in IMRU

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/TestTaskManager.cs
@@ -205,7 +205,7 @@ namespace Org.Apache.REEF.IMRU.Tests
             taskManager.RecordCompletedTask(CreateMockCompletedTask(MapperTaskIdPrefix + 1));
             Assert.False(taskManager.IsMasterTaskCompletedRunning());
 
-            taskManager.RecordCompletedTask(CreateMockCompletedTask(MasterTaskId));
+            taskManager.RecordCompletedTask(CreateMockCompletedUpdateTask(MasterTaskId));
             Assert.True(taskManager.IsMasterTaskCompletedRunning());
 
             taskManager.RecordCompletedTask(CreateMockCompletedTask(MapperTaskIdPrefix + 2));
@@ -744,6 +744,18 @@ namespace Org.Apache.REEF.IMRU.Tests
         {
             var completedTask = Substitute.For<ICompletedTask>();
             completedTask.Id.Returns(taskId);
+            return completedTask;
+        }
+
+        /// <summary>
+        /// Creates a mock completed update task with the taskId specified
+        /// </summary>
+        /// <param name="taskId"></param>
+        /// <returns></returns>
+        private static ICompletedTask CreateMockCompletedUpdateTask(string taskId)
+        {
+            var completedTask = CreateMockCompletedTask(taskId);
+            completedTask.Message.Returns(ByteUtilities.StringToByteArrays(TaskManager.UpdateTaskCompleted));
             return completedTask;
         }
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
@@ -239,7 +239,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                     Logger.Log(Level.Info, "UpdateTask message {0}", message);
                 }
 
-                if (GetTaskInfo(completedTask.Id).TaskState.CurrentState.Equals(TaskState.TaskRunning) || message.Equals(TaskManager.UpdateTaskCompleted))
+                if (message.Equals(TaskManager.UpdateTaskCompleted))
                 {
                     _masterTaskCompletedRunning = true;
                 }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/TaskManager.cs
@@ -28,6 +28,7 @@ using Org.Apache.REEF.IMRU.OnREEF.Driver.StateMachine;
 using Org.Apache.REEF.IMRU.OnREEF.IMRUTasks;
 using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Utilities.Attributes;
 using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
@@ -59,6 +60,11 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Error message in Task exception to show the task received close event
         /// </summary>
         internal const string TaskKilledByDriver = "TaskKilledByDriver";
+
+        /// <summary>
+        /// Result sent from UpdateTaskHost with the ICompletedTask message
+        /// </summary>
+        internal const string UpdateTaskCompleted = "UpdateTaskCompleted";
 
         /// <summary>
         /// This Dictionary contains task information. The key is the Id of the Task, the value is TaskInfo which contains
@@ -215,8 +221,9 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
 
         /// <summary>
         /// This method is called when receiving ICompletedTask event during task running or system shutting down.
-        /// If it is master task and if the master task was running, mark _masterTaskCompletedRunning true. That indicates 
-        /// master task has successfully completed, which means the system has got the result from master task. 
+        /// If it is master task, if the master task was running or if the task message indicates the task has been done,
+        /// mark _masterTaskCompletedRunning true. That indicates master task has successfully completed, which means the 
+        /// system has got the result from master task. 
         /// Removes the task from running tasks if it was running
         /// Changes the task state from RunningTask to CompletedTask if the task was running
         /// Change the task stat from TaskWaitingForClose to TaskClosedByDriver if the task was in TaskWaitingForClose state
@@ -225,7 +232,14 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         {
             if (completedTask.Id.Equals(_masterTaskId))
             {
-                if (GetTaskInfo(completedTask.Id).TaskState.CurrentState.Equals(TaskState.TaskRunning))
+                string message = "";
+                if (completedTask.Message != null)
+                {
+                    message = ByteUtilities.ByteArraysToString(completedTask.Message);
+                    Logger.Log(Level.Info, "UpdateTask message {0}", message);
+                }
+
+                if (GetTaskInfo(completedTask.Id).TaskState.CurrentState.Equals(TaskState.TaskRunning) || message.Equals(TaskManager.UpdateTaskCompleted))
                 {
                     _masterTaskCompletedRunning = true;
                 }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/UpdateTaskHost.cs
@@ -25,6 +25,7 @@ using Org.Apache.REEF.IMRU.OnREEF.Parameters;
 using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Network.Group.Task;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Utilities.Attributes;
 using Org.Apache.REEF.Utilities.Logging;
 
@@ -45,6 +46,11 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         private readonly IBroadcastSender<MapInputWithControlMessage<TMapInput>> _dataAndControlMessageSender;
         private readonly IUpdateFunction<TMapInput, TMapOutput, TResult> _updateTask;
         private readonly IIMRUResultHandler<TResult> _resultHandler;
+
+        /// <summary>
+        /// It indicates if the update task has completed and result has been written.
+        /// </summary>
+        private bool _done;
 
         /// <summary>
         /// </summary>
@@ -114,6 +120,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
                     if (updateResult.HasResult)
                     {
                         _resultHandler.HandleResult(updateResult.Result);
+                        _done = true;
                     }
                 }
                 catch (Exception e)
@@ -129,6 +136,10 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
                 _dataAndControlMessageSender.Send(stopMessage);
             }
 
+            if (_done)
+            {
+                return ByteUtilities.StringToByteArrays(TaskManager.UpdateTaskCompleted);
+            }
             return null;
         }
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
@@ -63,7 +63,6 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var runningTaskCount = GetMessageCount(lines, RunningTaskMessage);
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
-            var updateTaskCompletedCount = GetMessageCount(lines, TaskManager.UpdateTaskCompleted);
             var jobSuccess = GetMessageCount(lines, IMRUDriver<int[], int[], int[], int[]>.DoneActionPrefix);
 
             // on each try each task should fail or complete or disappear with failed evaluator
@@ -71,7 +70,6 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             Assert.True((NumberOfRetry + 1) * numTasks >= completedTaskCount + failedEvaluatorCount + failedTaskCount);
             Assert.True(NumberOfRetry * numTasks < completedTaskCount + failedEvaluatorCount + failedTaskCount);
             Assert.Equal((NumberOfRetry + 1) * numTasks, runningTaskCount);
-            Assert.Equal(1, updateTaskCompletedCount);
 
             // eventually job succeeds
             Assert.Equal(1, jobSuccess);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/IMRU/TestFailMapperEvaluators.cs
@@ -63,6 +63,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             var runningTaskCount = GetMessageCount(lines, RunningTaskMessage);
             var failedEvaluatorCount = GetMessageCount(lines, FailedEvaluatorMessage);
             var failedTaskCount = GetMessageCount(lines, FailedTaskMessage);
+            var updateTaskCompletedCount = GetMessageCount(lines, TaskManager.UpdateTaskCompleted);
             var jobSuccess = GetMessageCount(lines, IMRUDriver<int[], int[], int[], int[]>.DoneActionPrefix);
 
             // on each try each task should fail or complete or disappear with failed evaluator
@@ -70,6 +71,7 @@ namespace Org.Apache.REEF.Tests.Functional.IMRU
             Assert.True((NumberOfRetry + 1) * numTasks >= completedTaskCount + failedEvaluatorCount + failedTaskCount);
             Assert.True(NumberOfRetry * numTasks < completedTaskCount + failedEvaluatorCount + failedTaskCount);
             Assert.Equal((NumberOfRetry + 1) * numTasks, runningTaskCount);
+            Assert.Equal(1, updateTaskCompletedCount);
 
             // eventually job succeeds
             Assert.Equal(1, jobSuccess);


### PR DESCRIPTION
Currently in IMRU fault tolerant system, when the master task is done, at the same time the task receives Close event caused by some other evaluator failures, the system state is changed to ShutDown, causing retry again.

This PR is to pass update job done information as task result back to driver. Driver will use this information to determine if the job is done regardless of any failures happen at the same time.

JIRA: [REEF-1725](https://issues.apache.org/jira/browse/REEF-1725)
This closes  #