### PR TITLE
First cut of code changes required for reef-1583 which includes refac…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network/Naming/NameCache.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/NameCache.cs
@@ -18,9 +18,10 @@
 using System;
 using System.Collections.Specialized;
 using System.Net;
-using System.Runtime.Caching;
 using Org.Apache.REEF.Network.Naming.Parameters;
 using Org.Apache.REEF.Tang.Annotations;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 
 namespace Org.Apache.REEF.Network.Naming
 {
@@ -29,7 +30,8 @@ namespace Org.Apache.REEF.Network.Naming
     /// </summary>
     internal sealed class NameCache
     {
-        private readonly MemoryCache _cache;
+        ////private readonly MemoryCache _cache;
+        private readonly IMemoryCache _cache;
 
         /// <summary>
         /// Duration in milli seconds after which cache entry expires
@@ -43,14 +45,18 @@ namespace Org.Apache.REEF.Network.Naming
             [Parameter(typeof(NameCacheConfiguration.CacheMemoryLimit))] string memoryLimit,
             [Parameter(typeof(NameCacheConfiguration.PollingInterval))] string pollingInterval)
         {
-            var config = new NameValueCollection
+            /*var config = new NameValueCollection
             {
                 { "pollingInterval", pollingInterval },
                 { "physicalMemoryLimitPercentage", "0" },
                 { "cacheMemoryLimitMegabytes", memoryLimit }
-            };
+            };*/
 
-            _cache = new MemoryCache("NameClientCache", config);
+            ////_cache = new MemoryCache("NameClientCache", config);
+            _cache = new MemoryCache(new MemoryCacheOptions());
+            _cache.Set("pollingInterval", pollingInterval);
+            _cache.Set("physicalMemoryLimitPercentage", 0);
+            _cache.Set("cacheMemoryLimitMegabytes", memoryLimit);
             _expirationDuration = expirationDuration;
         }
 
@@ -89,7 +95,7 @@ namespace Org.Apache.REEF.Network.Naming
         /// </summary>
         internal long PhysicalMemoryLimit
         {
-            get { return _cache.CacheMemoryLimit; }
+            get { return (long)_cache.Get("cacheMemoryLimitMegabytes"); }
         }
 
         /// <summary>
@@ -97,7 +103,7 @@ namespace Org.Apache.REEF.Network.Naming
         /// </summary>
         internal TimeSpan PollingInterval
         {
-            get { return _cache.PollingInterval; }
+            get { return (TimeSpan)_cache.Get("pollingInterval"); }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -23,19 +23,44 @@ under the License.
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Org.Apache.REEF.Network</RootNamespace>
     <AssemblyName>Org.Apache.REEF.Network</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <RestorePackages>true</RestorePackages>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..</SolutionDir>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="$(SolutionDir)\build.props" />
   <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Caching.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Caching.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.Caching.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Caching.Memory, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Caching.Memory.1.1.0\lib\net451\Microsoft.Extensions.Caching.Memory.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.1.1.0\lib\netstandard1.0\Microsoft.Extensions.Options.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.1.1.0\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Hadoop.Avro">
       <HintPath>$(PackagesDir)\Microsoft.Hadoop.Avro.$(AvroVersion)\lib\net45\Microsoft.Hadoop.Avro.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net">
       <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Reactive.Core">
       <HintPath>$(PackagesDir)\Rx-Core.$(RxVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
@@ -45,8 +70,17 @@ under the License.
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.3.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(SolutionDir)\SharedAssemblyInfo.cs">
@@ -164,6 +198,7 @@ under the License.
     <Compile Include="Utilities\Utils.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Org.Apache.REEF.Network.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Network/app.config
+++ b/lang/cs/Org.Apache.REEF.Network/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/lang/cs/Org.Apache.REEF.Network/packages.config
+++ b/lang/cs/Org.Apache.REEF.Network/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -18,10 +18,49 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
+  <package id="Microsoft.Extensions.Caching.Abstractions" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Caching.Memory" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Options" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Primitives" version="1.1.0" targetFramework="net451" />
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
This is my first code refactor for reef-1583 which does the following to fix the first of the .net portability analyzer messages :
1) refactors the MemoryCache to use Microsoft.Extensions.Memory.MemoryCache
2) Bumps up the project to support .Net framework 4.5.1 