### PR TITLE
[REEF-1661] RejectedExecutionException thrown when closing the acceptor in NettyMessageTransport

### DIFF
--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/network/util/NetworkMessagingTestService.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/network/util/NetworkMessagingTestService.java
@@ -23,7 +23,6 @@ import org.apache.reef.io.network.Connection;
 import org.apache.reef.io.network.Message;
 import org.apache.reef.io.network.NetworkConnectionService;
 import org.apache.reef.io.network.impl.config.NetworkConnectionServiceIdFactory;
-import org.apache.reef.io.network.naming.NameResolver;
 import org.apache.reef.io.network.naming.NameResolverConfiguration;
 import org.apache.reef.io.network.naming.NameServer;
 import org.apache.reef.tang.Configuration;
@@ -51,8 +50,6 @@ public final class NetworkMessagingTestService implements AutoCloseable {
   private final NetworkConnectionService receiverNetworkConnService;
   private final NetworkConnectionService senderNetworkConnService;
   private final NameServer nameServer;
-  private final NameResolver receiverResolver;
-  private final NameResolver senderResolver;
 
   public NetworkMessagingTestService(final String localAddress) throws InjectionException {
     // name server
@@ -67,14 +64,12 @@ public final class NetworkMessagingTestService implements AutoCloseable {
     // network service for receiver
     final Injector injectorReceiver = injector.forkInjector(netConf);
     this.receiverNetworkConnService = injectorReceiver.getInstance(NetworkConnectionService.class);
-    this.receiverResolver = injectorReceiver.getInstance(NameResolver.class);
     this.factory = injectorReceiver.getNamedInstance(NetworkConnectionServiceIdFactory.class);
 
     // network service for sender
     LOG.log(Level.FINEST, "=== Test network connection service sender start");
     final Injector injectorSender = injector.forkInjector(netConf);
     senderNetworkConnService = injectorSender.getInstance(NetworkConnectionService.class);
-    this.senderResolver = injectorSender.getInstance(NameResolver.class);
   }
 
   public <T> void registerTestConnectionFactory(final Identifier connFactoryId,
@@ -101,8 +96,6 @@ public final class NetworkMessagingTestService implements AutoCloseable {
     senderNetworkConnService.close();
     receiverNetworkConnService.close();
     nameServer.close();
-    receiverResolver.close();
-    senderResolver.close();
   }
 
   public static final class MessageHandler<T> implements EventHandler<Message<T>> {


### PR DESCRIPTION
JIRA: [REEF-1661](https://issues.apache.org/jira/browse/REEF-1661)

The RejectedExecutionException occurs because `NameResolver` is closed twice in `NetworkConnectionServiceTest`. As the `NameResolver` is closed by `NetworkConnectionService`, we do not have to close it again in `NetworkMessagingTestService`. 
This PR removes the close calls of `NameResolver` in `NetworkMessagingTestService`.


Closes #