### PR TITLE
[REEF-1729] Fix test job timeouts in Travis CI

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
@@ -25,10 +25,12 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.ChannelGroupFuture;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.wake.EStage;
@@ -52,6 +54,8 @@ import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -217,18 +221,27 @@ public final class NettyMessagingTransport implements Transport {
 
     LOG.log(Level.FINE, "Closing netty transport socket address: {0}", this.localAddress);
 
-    this.clientChannelGroup.close().awaitUninterruptibly();
-    this.serverChannelGroup.close().awaitUninterruptibly();
+    final ChannelGroupFuture clientChannelGroupFuture = this.clientChannelGroup.close();
+    final ChannelGroupFuture serverChannelGroupFuture = this.serverChannelGroup.close();
+    final ChannelFuture acceptorFuture = this.acceptor.close();
+
+    final List<Future> eventLoopGroupFutures = new LinkedList<>();
+    eventLoopGroupFutures.add(this.clientWorkerGroup.shutdownGracefully());
+    eventLoopGroupFutures.add(this.serverBossGroup.shutdownGracefully());
+    eventLoopGroupFutures.add(this.serverWorkerGroup.shutdownGracefully());
+
+    clientChannelGroupFuture.awaitUninterruptibly();
+    serverChannelGroupFuture.awaitUninterruptibly();
 
     try {
-      this.acceptor.close().sync();
+      acceptorFuture.sync();
     } catch (final Exception ex) {
       LOG.log(Level.SEVERE, "Error closing the acceptor channel for " + this.localAddress, ex);
     }
 
-    this.clientWorkerGroup.shutdownGracefully().awaitUninterruptibly();
-    this.serverBossGroup.shutdownGracefully().awaitUninterruptibly();
-    this.serverWorkerGroup.shutdownGracefully().awaitUninterruptibly();
+    for (final Future eventLoopGroupFuture : eventLoopGroupFutures) {
+      eventLoopGroupFuture.awaitUninterruptibly();
+    }
 
     LOG.log(Level.FINE, "Closing netty transport socket address: {0} done", this.localAddress);
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
@@ -53,8 +53,8 @@ import java.net.BindException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -225,7 +225,7 @@ public final class NettyMessagingTransport implements Transport {
     final ChannelGroupFuture serverChannelGroupFuture = this.serverChannelGroup.close();
     final ChannelFuture acceptorFuture = this.acceptor.close();
 
-    final List<Future> eventLoopGroupFutures = new LinkedList<>();
+    final List<Future> eventLoopGroupFutures = new ArrayList<>(3);
     eventLoopGroupFutures.add(this.clientWorkerGroup.shutdownGracefully());
     eventLoopGroupFutures.add(this.serverBossGroup.shutdownGracefully());
     eventLoopGroupFutures.add(this.serverWorkerGroup.shutdownGracefully());


### PR DESCRIPTION
JIRA: [REEF-1729](https://issues.apache.org/jira/browse/REEF-1729)

This PR reduces the test running time by doing `awaitUninterruptibly()` after closing and shutting down all of the channels.  

Closes #