### PR TITLE
[REEF-1473] Fix CanRunClrBridgeExampleOnLocalRuntime failures in AppVeyor

### DIFF
--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
@@ -59,6 +59,7 @@ namespace Org.Apache.REEF.Examples.AllHandlers
                 .Set(DriverConfiguration.OnTaskCompleted, GenericType<HelloTaskCompletedHandler>.Class)
                 .Set(DriverConfiguration.OnDriverStarted, GenericType<HelloDriverStartHandler>.Class)
                 .Set(DriverConfiguration.OnHttpEvent, GenericType<HelloHttpHandler>.Class)
+                .Set(DriverConfiguration.OnHttpEvent, GenericType<HelloTaskCompletedHandler>.Class)
                 .Set(DriverConfiguration.OnEvaluatorCompleted, GenericType<HelloCompletedEvaluatorHandler>.Class)
                 .Set(DriverConfiguration.CustomTraceListeners, GenericType<DefaultCustomTraceListener>.Class)
                 .Set(DriverConfiguration.CustomTraceLevel, Level.Info.ToString())


### PR DESCRIPTION
* Add retry in getting driverurl before sending http request
* Not to closet the context until receives client's request and all tasks are completed to ensure the web request can be received by the driver before the driver is shut down.

JIRA: [REEF-1473](https://issues.apache.org/jira/browse/REEF-1473)
This closes  #