### PR TITLE
[REEF-1629] Move Wake profiling parameter from REEFEnvironment into Wake package

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFEnvironment.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFEnvironment.java
@@ -30,6 +30,7 @@ import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.util.EnvironmentUtils;
 import org.apache.reef.util.REEFVersion;
 import org.apache.reef.wake.profiler.WakeProfiler;
+import org.apache.reef.wake.profiler.ProfilerState;
 import org.apache.reef.wake.time.Clock;
 
 import java.util.logging.Level;
@@ -74,7 +75,7 @@ public final class REEFEnvironment implements Runnable, AutoCloseable {
 
     final Injector injector = TANG.newInjector(config);
 
-    if (injector.getNamedInstance(WakeProfiler.ProfilingEnabled.class)) {
+    if (ProfilerState.isProfilingEnabled(injector)) {
       final WakeProfiler profiler = new WakeProfiler();
       ProfilingStopHandler.setProfiler(profiler);
       injector.bindAspect(profiler);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFEnvironment.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFEnvironment.java
@@ -26,8 +26,6 @@ import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.util.EnvironmentUtils;
 import org.apache.reef.util.REEFVersion;
@@ -43,13 +41,6 @@ import java.util.logging.Logger;
  * the runtime clock and calling .run() on it.
  */
 public final class REEFEnvironment implements Runnable, AutoCloseable {
-
-  /**
-   * Parameter to enable Wake network profiling. By default profiling is disabled.
-   * TODO[REEF-1629] Move that parameter and related code into Wake package.
-   */
-  @NamedParameter(doc = "If true, profiling will be enabled", short_name = "profiling", default_value = "false")
-  private static final class ProfilingEnabled implements Name<Boolean> { }
 
   private static final Logger LOG = Logger.getLogger(REEFEnvironment.class.getName());
 
@@ -83,7 +74,7 @@ public final class REEFEnvironment implements Runnable, AutoCloseable {
 
     final Injector injector = TANG.newInjector(config);
 
-    if (injector.getNamedInstance(ProfilingEnabled.class)) {
+    if (injector.getNamedInstance(WakeProfiler.ProfilingEnabled.class)) {
       final WakeProfiler profiler = new WakeProfiler();
       ProfilingStopHandler.setProfiler(profiler);
       injector.bindAspect(profiler);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/ProfilerState.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/ProfilerState.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.profiler;
+
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.tang.exceptions.InjectionException;
+
+/**
+ * A class that contains parameters and states for wake profiler.
+ */
+public final class ProfilerState {
+
+  private ProfilerState() {}
+
+  /**
+   * Parameter to enable Wake network profiling. By default profiling is disabled.
+   */
+  @NamedParameter(doc = "If true, profiling will be enabled", short_name = "profiling", default_value = "false")
+  private static final class ProfilingEnabled implements Name<Boolean> { }
+
+  /**
+   * Gets the class of the NamedParameter ProfilingEnabled.
+   *
+   * @return Class of ProflingEnabled which should be Name<Boolean>
+   */
+  private static Class<? extends Name<Boolean>> getProfilingEnabledClass() {
+    return ProfilingEnabled.class;
+  }
+
+  /**
+   * Checks if profiling is enabled.
+   *
+   * @param injector the tang injector that stores value of ProfilingEnabled.
+   * @return true if profiling is enabled
+   * @throws InjectionException if name resolution fails
+   */
+  public static boolean isProfilingEnabled(final Injector injector) throws InjectionException {
+    return injector.getNamedInstance(getProfilingEnabledClass());
+  }
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
@@ -23,6 +23,8 @@ import net.sf.cglib.proxy.MethodInterceptor;
 import net.sf.cglib.proxy.MethodProxy;
 import org.apache.reef.tang.Aspect;
 import org.apache.reef.tang.InjectionFuture;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.tang.types.ConstructorDef;
 import org.apache.reef.tang.util.MonotonicHashMap;
 import org.apache.reef.tang.util.ReflectionUtilities;
@@ -44,6 +46,12 @@ public class WakeProfiler implements Aspect {
   private final Map<InjectionFuture<?>, Object> futures = new MonotonicHashMap<>();
   private final Map<Object, Stats> stats = new MonotonicHashMap<>();
 
+  /**
+   * Parameter to enable Wake network profiling. By default profiling is disabled.
+   */
+  @NamedParameter(doc = "If true, profiling will be enabled", short_name = "profiling", default_value = "false")
+  public static final class ProfilingEnabled implements Name<Boolean> { }
+  
   @Override
   public Aspect createChildAspect() {
     return this;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
@@ -23,8 +23,6 @@ import net.sf.cglib.proxy.MethodInterceptor;
 import net.sf.cglib.proxy.MethodProxy;
 import org.apache.reef.tang.Aspect;
 import org.apache.reef.tang.InjectionFuture;
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.tang.types.ConstructorDef;
 import org.apache.reef.tang.util.MonotonicHashMap;
 import org.apache.reef.tang.util.ReflectionUtilities;
@@ -45,12 +43,6 @@ public class WakeProfiler implements Aspect {
   private final Map<Object, Vertex<?>> vertexObject = new MonotonicHashMap<>();
   private final Map<InjectionFuture<?>, Object> futures = new MonotonicHashMap<>();
   private final Map<Object, Stats> stats = new MonotonicHashMap<>();
-
-  /**
-   * Parameter to enable Wake network profiling. By default profiling is disabled.
-   */
-  @NamedParameter(doc = "If true, profiling will be enabled", short_name = "profiling", default_value = "false")
-  public static final class ProfilingEnabled implements Name<Boolean> { }
   
   @Override
   public Aspect createChildAspect() {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
@@ -43,7 +43,7 @@ public class WakeProfiler implements Aspect {
   private final Map<Object, Vertex<?>> vertexObject = new MonotonicHashMap<>();
   private final Map<InjectionFuture<?>, Object> futures = new MonotonicHashMap<>();
   private final Map<Object, Stats> stats = new MonotonicHashMap<>();
-  
+
   @Override
   public Aspect createChildAspect() {
     return this;


### PR DESCRIPTION
[REEF-1629] Move Wake profiling parameter from REEFEnvironment into Wake package
 
This addressed the issue by 
  * Moving ProfilingEnabled from REEFEnvironment to WakeProfiler
  * Making ProfilingEnabled exposed
 
JIRA:
  [REEF-1629](https://issues.apache.org/jira/browse/REEF-1629)