### PR TITLE
[REEF-1752] Fix TestEvaluatorWithActiveContextDelayedPoison failures …

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Failure/SleepTask.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Failure/SleepTask.cs
@@ -41,7 +41,7 @@ namespace Org.Apache.REEF.Tests.Functional.Failure
         public byte[] Call(byte[] memento)
         {
             Logger.Log(Level.Info, Prefix + "Will sleep for 2 seconds (expecting to be poisoned faster).");
-            Thread.Sleep(2000);
+            Thread.Sleep(4000);
             Logger.Log(Level.Info, Prefix + "Task sleep finished successfully.");
             return null;
         }


### PR DESCRIPTION
…in AppVeyor

Modified the test validation condition in the case task is completed before evaluator fails.

JIRA: [REEF-1752](https://issues.apache.org/jira/browse/REEF-1752)
This closes  #