### PR TITLE
[REEF-1754] Use finer log level when running unit tests in reef-tests

### DIFF
--- a/lang/java/reef-tests/pom.xml
+++ b/lang/java/reef-tests/pom.xml
@@ -150,6 +150,26 @@ under the License.
 
     <profiles>
         <profile>
+            <id>log</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <forkMode>pertest</forkMode>
+                            <systemProperties>
+                                <property>
+                                    <name>java.util.logging.config.class</name>
+                                    <value>org.apache.reef.util.logging.Config</value>
+                                </property>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>test</id>
             <activation>
                 <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
To test:
   * go to `lang/java/reef-tests` directory
   * run `mvn -Plog test` (or any other maven goal, e.g. `package` or `install`)
   * look at the logs make sure that unit tests use `FINEST` log level

JIRA: [REEF-1754](https://issues.apache.org/jira/browse/REEF-1754)

closes #