### PR TITLE
[REEF-1753] Intermittent failures of CloseEvaluatorTest in local runtime

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeParameters.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeParameters.java
@@ -30,7 +30,7 @@ public final class WakeParameters {
 
   public static final long EXECUTOR_SHUTDOWN_TIMEOUT = 1000;
 
-  public static final long REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT = 10000;
+  public static final long REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT = 20000;
 
   /**
    * Maximum frame length unit.

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
@@ -22,6 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.wake.EStage;
 import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.WakeParameters;
 import org.apache.reef.wake.remote.impl.DefaultTransportEStage;
 import org.apache.reef.wake.remote.impl.ObjectSerializableCodec;
 import org.apache.reef.wake.remote.impl.TransportEvent;
@@ -30,6 +31,21 @@ import org.apache.reef.wake.remote.impl.TransportEvent;
  * Configuration options and helper methods for Wake remoting.
  */
 public final class RemoteConfiguration {
+
+  /**
+   * The number of tries to reconnect the remote connection.
+   */
+  public static final long REMOTE_CONNECTION_NUMBER_OF_RETRIES = 3;
+
+  /**
+   * The timeout of connection retrying.
+   */
+  public static final long REMOTE_CONNECTION_RETRY_TIMEOUT =
+      WakeParameters.REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT / (REMOTE_CONNECTION_NUMBER_OF_RETRIES + 1);
+
+  private RemoteConfiguration() {
+    // empty
+  }
 
   /**
    * The name of the remote manager.
@@ -84,7 +100,7 @@ public final class RemoteConfiguration {
   /**
    * The number of tries.
    */
-  @NamedParameter(doc = "The number of tries.", default_value = "3")
+  @NamedParameter(doc = "The number of tries.", default_value = "" + REMOTE_CONNECTION_NUMBER_OF_RETRIES)
   public static final class NumberOfTries implements Name<Integer> {
     // Intentionally empty    
   }
@@ -92,7 +108,7 @@ public final class RemoteConfiguration {
   /**
    * The timeout of connection retrying.
    */
-  @NamedParameter(doc = "The timeout of connection retrying.", default_value = "10000")
+  @NamedParameter(doc = "The timeout of connection retrying.", default_value = "" + REMOTE_CONNECTION_RETRY_TIMEOUT)
   public static final class RetryTimeout implements Name<Integer> {
     // Intentionally empty       
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
@@ -39,6 +39,10 @@ public final class RemoteConfiguration {
 
   /**
    * The timeout of connection retrying.
+   * To prevent retrying connections from being rejected by the remote stages,
+   * the retrying_timeout * number_of_retries should be less than the remote_executor_shutdown_timeout.
+   * If not, the remote stage can shutdown the connection retries before it is established,
+   * and can drop a message that should be sent to the remote.
    */
   public static final long REMOTE_CONNECTION_RETRY_TIMEOUT =
       WakeParameters.REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT / (REMOTE_CONNECTION_NUMBER_OF_RETRIES + 1);


### PR DESCRIPTION
JIRA: [REEF-1753](https://issues.apache.org/jira/browse/REEF-1753)

This PR prevents RemoteStage from being closed while a thread is retrying to construct a connection. I fixed the code by making `REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT` greater than `REMOTE_CONNECTION_NUMBER_OF_RETRIES` * `REMOTE_CONNECTION_RETRY_TIMEOUT`

Closes #