### PR TITLE
[REEF-1756] Add TODO comment for all remaining System.exit() calls

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
@@ -187,7 +187,7 @@ public final class REEFLauncher {
 
     LOG.log(Level.INFO, "Exiting REEFLauncher.main()");
 
-    System.exit(0);
+    System.exit(0); // TODO[REEF-1715]: Should be able to exit cleanly at the end of main()
   }
 
   /**

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFYarnUnmanagedAM.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFYarnUnmanagedAM.java
@@ -80,8 +80,7 @@ public final class HelloREEFYarnUnmanagedAM {
     }
 
     ThreadLogger.logThreads(LOG, Level.FINEST, "Threads running after DriverLauncher.close():");
-
-    LOG.log(Level.INFO, "Clean exit!");
+    System.exit(0); // TODO[REEF-1715]: Should be able to exit cleanly at the end of main()
   }
 
   /** Empty private constructor to prohibit instantiation of utility class. */

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFYarnUnmanagedAM.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFYarnUnmanagedAM.java
@@ -60,7 +60,7 @@ public final class HelloREEFYarnUnmanagedAM {
    */
   public static void main(final String[] args) throws InjectionException {
 
-    LOG.log(Level.FINE, "Launching Unnmanaged AM: {0}", JAR_PATH);
+    LOG.log(Level.FINE, "Launching Unmanaged AM: {0}", JAR_PATH);
 
     try (final DriverLauncher client = DriverLauncher.getLauncher(RUNTIME_CONFIG)) {
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/reefonreef/ReefOnReefDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/reefonreef/ReefOnReefDriver.java
@@ -72,7 +72,7 @@ final class ReefOnReefDriver implements EventHandler<StartTime> {
   public void onNext(final StartTime startTime) {
 
     LOG.log(Level.INFO, "Driver started: app {0} :: {1}", new Object[] {this.hostApplicationId, startTime});
-    LOG.log(Level.FINE, "Launching Unnmanaged AM: {0}", JAR_PATH);
+    LOG.log(Level.FINE, "Launching Unmanaged AM: {0}", JAR_PATH);
 
     try (final DriverLauncher client = DriverLauncher.getLauncher(RUNTIME_CONFIG)) {
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/reefonreef/ReefOnReefDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/reefonreef/ReefOnReefDriver.java
@@ -92,7 +92,6 @@ final class ReefOnReefDriver implements EventHandler<StartTime> {
             new Object[] {innerApplicationId, status.getState()});
       }
 
-      ThreadLogger.logThreads(LOG, Level.FINEST, "Threads running after DriverLauncher.close():");
       LOG.log(Level.INFO,
           "REEF-on-REEF host job {0} completed: inner app {1} status {2}",
           new Object[] {this.hostApplicationId, innerApplicationId, client.getStatus()});
@@ -101,5 +100,7 @@ final class ReefOnReefDriver implements EventHandler<StartTime> {
       LOG.log(Level.SEVERE, "REEF-on-REEF configuration error", ex);
       throw new RuntimeException("REEF-on-REEF configuration error", ex);
     }
+
+    ThreadLogger.logThreads(LOG, Level.FINEST, "Threads running after DriverLauncher.close():");
   }
 }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/examples/TestHelloREEFYarnUnmanagedAM.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/examples/TestHelloREEFYarnUnmanagedAM.java
@@ -69,7 +69,7 @@ public final class TestHelloREEFYarnUnmanagedAM {
         "This test requires a YARN Resource Manager to connect to",
         Boolean.parseBoolean(System.getenv("REEF_TEST_YARN")));
 
-    LOG.log(Level.FINE, "Launching Unnmanaged AM: {0}", JAR_PATH);
+    LOG.log(Level.FINE, "Launching Unmanaged AM: {0}", JAR_PATH);
 
     try (final DriverLauncher client = DriverLauncher.getLauncher(RUNTIME_CONFIG)) {
 


### PR DESCRIPTION
Also, add `System.exit()` call to the end of the `HelloREEFYarnUnmanagedAM` app, and move thread logging for `ReefOnReefDriver` to the proper place.

JIRA: [REEF-1756](https://issues.apache.org/jira/browse/REEF-1756)

closes #