### PR TITLE
[REEF-1578] Fix CoreCLR issues in Org.Apache.REEF.Utilities

### DIFF
--- a/lang/cs/BUILD.md
+++ b/lang/cs/BUILD.md
@@ -43,6 +43,8 @@ Prerequisites
 Instructions
 ------------
 
+***For Building projects:***
+
 To build and run tests in Visual Studio on local machine:
 
 1. Open solution `.\lang\cs\Org.Apache.REEF.sln`
@@ -60,6 +62,47 @@ To run .NET tests on local machine from command line, execute
     msbuild .\lang\cs\TestRunner.proj
 
 `TestRunner.proj` already has a filter set up to exclude Yarn tests.
+
+***For Building DotNet projects:***
+
+We are in the process of converting the C# support to use dotnet core as well as support for Visual Studio 2017. As a result 
+there are <projectname>.DotNet.csproj files that sit beside the existing csproj files. To build the dotnet projects, you will need 
+the .NET Core SDK installed on your machine as well as Visual Studio 2017. 
+
+**Note:** Building in Visual Studio 2017 is not yet supported. You will need to build at the command line using the .NET Core SDK tools (dotnet). However Visual Studio 2017 does support opening the DotNet solution. .NET Core applications are supported on both Windows and Linux, the projects will only build fully on Windows since they do target the .net45 framework. 
+
+The .NET Core SDK tools are located here:
+
+[https://github.com/dotnet/cli](https://github.com/dotnet/cli)
+
+Scroll down the page to access the latest builds of .NET Core SDK, download the Windows X64 installer. 
+
+At the time of writing the current version used is 2.0.0-preview1-005825. Any version that is equal or newer should also work.
+
+To build from Visual Studio 2017:
+
+This is not currently supported and you will need to build from the command line however VS2017 can be used to view the solution. 
+
+To open the project in VS2017, open the solution `.\lang\cs\Org.Apache.REEF.DotNet.sln`.
+
+To build from the command line, in the `reef\lang\cs` path, type the following:
+
+    dotnet clean Org.Apache.REEF.DotNet.sln
+    dotnet restore Org.Apache.REEF.DotNet.sln
+    dotnet build Org.Apache.REEF.DotNet.sln
+
+ * `clean` will clean any previously built binary
+ * `restore` restores nuget dependencies
+ * `build` builds the solution
+
+To build nuget packages, type the following:
+
+ * `dotnet pack Org.Apache.REEF.DotNet.sln`
+
+This will build nuget packages for each project.
+
+Projects will build out to `reef\bin\<AssemblyName>` and will contain all the platforms that the project supports. Each project 
+is in various stages as they are transitioning to dotnet core 2.0 - therefore they may only build .net45 and .net46 assemblies.
 
 Continuous Integration
 ----------------------

--- a/lang/cs/Org.Apache.REEF.DotNet.sln
+++ b/lang/cs/Org.Apache.REEF.DotNet.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.10
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.Reef.Utilities.DotNet", "Org.Apache.REEF.Utilities\Org.Apache.Reef.Utilities.DotNet.csproj", "{FE4CEA75-2F26-4C97-B256-375AA698B4A9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.REEF.Tang.DotNet", "Org.Apache.REEF.Tang\Org.Apache.REEF.Tang.DotNet.csproj", "{16E1218C-9A3C-49E2-A939-C29944BBB72E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FE4CEA75-2F26-4C97-B256-375AA698B4A9}.Debug|x64.ActiveCfg = Debug|x64
+		{FE4CEA75-2F26-4C97-B256-375AA698B4A9}.Debug|x64.Build.0 = Debug|x64
+		{FE4CEA75-2F26-4C97-B256-375AA698B4A9}.Release|x64.ActiveCfg = Release|x64
+		{FE4CEA75-2F26-4C97-B256-375AA698B4A9}.Release|x64.Build.0 = Release|x64
+		{16E1218C-9A3C-49E2-A939-C29944BBB72E}.Debug|x64.ActiveCfg = Debug|x64
+		{16E1218C-9A3C-49E2-A939-C29944BBB72E}.Debug|x64.Build.0 = Debug|x64
+		{16E1218C-9A3C-49E2-A939-C29944BBB72E}.Release|x64.ActiveCfg = Release|x64
+		{16E1218C-9A3C-49E2-A939-C29944BBB72E}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/lang/cs/Org.Apache.REEF.Tang/Org.Apache.REEF.Tang.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang/Org.Apache.REEF.Tang.DotNet.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+  <PropertyGroup>
+    <AssemblyName>Org.Apache.REEF.Tang</AssemblyName>
+    <Description>Tang is a dependency injection framework</Description>
+    <PackageTags> Apache REEF tang dependency injection</PackageTags>
+    <TargetFrameworks>net46;net451</TargetFrameworks>
+  </PropertyGroup>
+  <Import Project="..\build.DotNet.props" />
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
+    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Org.Apache.REEF.Utilities\Org.Apache.Reef.Utilities.DotNet.csproj" />
+  </ItemGroup>
+</Project>

--- a/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.REEF.Utilities.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.REEF.Utilities.DotNet.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+  <PropertyGroup>
+    <AssemblyName>Org.Apache.REEF.Utilities</AssemblyName>
+    <Description>Common utilities such as logging shared across Reef/Wake/Tang</Description>
+    <PackageTags>Apache REEF Reef/Wake/Tang common utilities</PackageTags>
+    <TargetFrameworks>netstandard2.0;net46;net451</TargetFrameworks>
+  </PropertyGroup>
+  <Import Project="..\build.DotNet.props" />
+  <ItemGroup>
+      <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+</Project>

--- a/lang/cs/build.DotNet.props
+++ b/lang/cs/build.DotNet.props
@@ -1,0 +1,46 @@
+<Project>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+  <PropertyGroup>
+    <Version>0.16.0</Version>
+    <Authors>Apache Software Foundation</Authors>
+    <Owners>The Apache REEF project</Owners>
+    <Product>Apache REEF</Product>
+    <ProductId>$(AssemblyName)</ProductId>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <FileVersion>$(Version)</FileVersion>
+    <NeutralLanguage>en</NeutralLanguage>
+    <Copyright>The Apache Software Foundation</Copyright>
+    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageProjectUrl>https://reef.apache.org</PackageProjectUrl>
+    <PackageIconUrl>https://reef.apache.org/ApacheREEF_logo_no_margin_small.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/apache/reef.git</RepositoryUrl>
+    <PackageReleaseNotes>Contact the Apache REEF development alias dev@reef.apache.org for questions or issues.</PackageReleaseNotes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/AssemblyInfo.cs;packages.config;*.nuspec</DefaultItemExcludes>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>..\bin\$(AssemblyName)</OutputPath>
+    <AvroVersion>1.5.6</AvroVersion>
+    <NewtonsoftJsonVersion>10.0.1</NewtonsoftJsonVersion>
+    <ProtobufVersion>2.0.0.668</ProtobufVersion>
+    <RxVersion>2.2.5</RxVersion>
+    <StyleCopVersion>4.7.49.1</StyleCopVersion>
+    <NSubstituteVersion>1.8.2.0</NSubstituteVersion>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This is an initial check-in of the dot net core library conversion. This
check-in contains a dotnet standard project that sits alongside the
.net45 project file. The new dotnet project builds a .netstandard2.0
library as well as a .net45 library. The project is currently using
dotnet 2.0.0-preview-005670. Tools can be downloaded from the dotnet cli
github repository.

JIRA:
  [REEF-1578](https://issues.apache.org/jira/browse/REEF-1578)

Pull request:
  This closes REEF-1578