### PR TITLE
[REEF-1761] Race condition in NetworkMessagingTestService

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnectionServiceMessage.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnectionServiceMessage.java
@@ -101,15 +101,7 @@ final class NetworkConnectionServiceMessage<T> implements Message<T> {
    * @return a string representation of this object
    */
   public String toString() {
-    final StringBuilder builder = new StringBuilder();
-    builder.append("NSMessage");
-    builder.append(" remoteID=");
-    builder.append(destId);
-    builder.append(" message=[| ");
-    for (final T message : messages) {
-      builder.append(message).append(" |");
-    }
-    builder.append("]");
-    return builder.toString();
+    return String.format("%s[%s -> %s]: size %d",
+        this.getClass().getSimpleName(), this.srcId, this.destId, this.messages.size());
   }
 }

--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/network/NetworkConnectionServiceTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/network/NetworkConnectionServiceTest.java
@@ -28,6 +28,7 @@ import org.apache.reef.wake.IdentifierFactory;
 import org.apache.reef.wake.remote.Codec;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
 import org.apache.reef.wake.remote.impl.ObjectSerializableCodec;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -179,7 +180,11 @@ public class NetworkConnectionServiceTest {
    */
   @Test
   public void testMessagingNetworkConnServiceRate() throws Exception {
+
+    Assume.assumeFalse("Use log level INFO to run benchmarking", LOG.isLoggable(Level.FINEST));
+
     LOG.log(Level.FINEST, name.getMethodName());
+
     final int[] messageSizes = {1, 16, 32, 64, 512, 64 * 1024, 1024 * 1024};
 
     for (final int size : messageSizes) {
@@ -220,7 +225,11 @@ public class NetworkConnectionServiceTest {
    */
   @Test
   public void testMessagingNetworkConnServiceRateDisjoint() throws Exception {
+
+    Assume.assumeFalse("Use log level INFO to run benchmarking", LOG.isLoggable(Level.FINEST));
+
     LOG.log(Level.FINEST, name.getMethodName());
+
     final BlockingQueue<Object> barrier = new LinkedBlockingQueue<>();
 
     final int numThreads = 4;
@@ -277,7 +286,11 @@ public class NetworkConnectionServiceTest {
 
   @Test
   public void testMultithreadedSharedConnMessagingNetworkConnServiceRate() throws Exception {
+
+    Assume.assumeFalse("Use log level INFO to run benchmarking", LOG.isLoggable(Level.FINEST));
+
     LOG.log(Level.FINEST, name.getMethodName());
+
     final int[] messageSizes = {2000}; // {1,16,32,64,512,64*1024,1024*1024};
 
     for (final int size : messageSizes) {
@@ -331,6 +344,9 @@ public class NetworkConnectionServiceTest {
    */
   @Test
   public void testMessagingNetworkConnServiceBatchingRate() throws Exception {
+
+    Assume.assumeFalse("Use log level INFO to run benchmarking", LOG.isLoggable(Level.FINEST));
+
     LOG.log(Level.FINEST, name.getMethodName());
 
     final int batchSize = 1024 * 1024;

--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/network/NetworkServiceTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/network/NetworkServiceTest.java
@@ -38,6 +38,8 @@ import org.apache.reef.wake.Identifier;
 import org.apache.reef.wake.IdentifierFactory;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
 import org.apache.reef.wake.remote.transport.netty.MessagingTransportFactory;
+import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -147,6 +149,9 @@ public class NetworkServiceTest {
    */
   @Test
   public void testMessagingNetworkServiceRate() throws Exception {
+
+    Assume.assumeFalse("Use log level INFO to run benchmarking", LOG.isLoggable(Level.FINEST));
+
     LOG.log(Level.FINEST, name.getMethodName());
 
     final IdentifierFactory factory = new StringIdentifierFactory();
@@ -233,6 +238,9 @@ public class NetworkServiceTest {
    */
   @Test
   public void testMessagingNetworkServiceRateDisjoint() throws Exception {
+
+    Assume.assumeFalse("Use log level INFO to run benchmarking", LOG.isLoggable(Level.FINEST));
+
     LOG.log(Level.FINEST, name.getMethodName());
 
     final IdentifierFactory factory = new StringIdentifierFactory();
@@ -342,6 +350,9 @@ public class NetworkServiceTest {
 
   @Test
   public void testMultithreadedSharedConnMessagingNetworkServiceRate() throws Exception {
+
+    Assume.assumeFalse("Use log level INFO to run benchmarking", LOG.isLoggable(Level.FINEST));
+
     LOG.log(Level.FINEST, name.getMethodName());
 
     final IdentifierFactory factory = new StringIdentifierFactory();
@@ -444,6 +455,9 @@ public class NetworkServiceTest {
    */
   @Test
   public void testMessagingNetworkServiceBatchingRate() throws Exception {
+
+    Assume.assumeFalse("Use log level INFO to run benchmarking", LOG.isLoggable(Level.FINEST));
+
     LOG.log(Level.FINEST, name.getMethodName());
 
     final IdentifierFactory factory = new StringIdentifierFactory();
@@ -535,7 +549,7 @@ public class NetworkServiceTest {
     private final String name;
     private final int expected;
     private final Monitor monitor;
-    private AtomicInteger count = new AtomicInteger(0);
+    private final AtomicInteger count = new AtomicInteger(0);
 
     MessageHandler(final String name, final Monitor monitor, final int expected) {
       this.name = name;
@@ -546,17 +560,13 @@ public class NetworkServiceTest {
     @Override
     public void onNext(final Message<T> value) {
 
-      count.incrementAndGet();
+      final int currentCount = count.incrementAndGet();
 
-      LOG.log(Level.FINEST,
-          "OUT: {0} received {1} from {2} to {3}",
-          new Object[]{name, value.getData(), value.getSrcId(), value.getDestId()});
+      LOG.log(Level.FINER, "{0} Message {1}/{2} :: {3}", new Object[] {name, currentCount, expected, value});
 
-      for (final T obj : value.getData()) {
-        LOG.log(Level.FINEST, "OUT: data: {0}", obj);
-      }
+      Assert.assertTrue(currentCount <= expected);
 
-      if (count.get() == expected) {
+      if (currentCount >= expected) {
         monitor.mnotify();
       }
     }


### PR DESCRIPTION
Summary of changes:
   * Fix the race condition in `NetworkMessagingTestService.MessageHandler.onNext()`
   * Disable benchmarking in `NetworkConnectionServiceTest` if logging is too detailed
   * Remove some excessive logging in `NetworkMessagingTestService`
   * Make output of `NetworkConnectionServiceMessage.toString()` shorter
   * Use proper assertions in `NetworkMessagingTestService`
   * Other minor refactoring

JIRA: [REEF-1761](https://issues.apache.org/jira/browse/REEF-1761)