### PR TITLE
[REEF-1762] Fix the expected number of messages in NetworkServiceTest.testMultithreadedSharedConnMessagingNetworkServiceRate

### DIFF
--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/network/NetworkServiceTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/network/NetworkServiceTest.java
@@ -386,7 +386,7 @@ public class NetworkServiceTest {
 
           final Injector injectorNs2 = injector2.forkInjector();
           injectorNs2.bindVolatileParameter(NetworkServiceParameters.NetworkServiceHandler.class,
-              new MessageHandler<String>(name2, monitor, numMessages));
+              new MessageHandler<String>(name2, monitor, totalNumMessages));
           final NetworkService<String> ns2 = injectorNs2.getInstance(NetworkService.class);
 
           final Injector injectorNs1 = injector2.forkInjector();


### PR DESCRIPTION
JIRA: [REEF-1762](https://issues.apache.org/jira/browse/REEF-1762)

This PR addressed REEF-1762 by 
* setting the expected number of messages to`totalNumMessages`

Closes #