### PR TITLE
[REEF-1768] Update Avro from 1.7.7 to 1.8.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ under the License.
         <bundle.snappy>false</bundle.snappy>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hadoop.version>2.6.0</hadoop.version>
-        <avro.version>1.7.7</avro.version>
+        <avro.version>1.8.1</avro.version>
         <jetty.version>6.1.26</jetty.version>
         <jackson.version>1.9.13</jackson.version>
         <protobuf.version>2.5.0</protobuf.version>


### PR DESCRIPTION
This PR addresses the need of updating Avro from 1.7.7 to 1.8.1. Currently all tests passed on local builds both for Java and .Net.

JIRA:
[REEF-1768](https://issues.apache.org/jira/browse/REEF-1768)

Pull request:
This closes #1285 