### PR TITLE
[REEF-1801] Improve logging when sending remote events in Wake

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientConnection.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientConnection.java
@@ -54,7 +54,7 @@ public final class ClientConnection {
    * @param status
    */
   public synchronized void send(final ReefServiceProtos.JobStatusProto status) {
-    LOG.log(Level.FINEST, "Sending:\n" + status);
+    LOG.log(Level.FINEST, "Sending to client: status={0}", status.getState());
     this.jobStatusHandler.onNext(status);
   }
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LoggingLinkListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LoggingLinkListener.java
@@ -38,9 +38,7 @@ public class LoggingLinkListener<T> implements LinkListener<T> {
    */
   @Override
   public void onSuccess(final T message) {
-    if (LOG.isLoggable(Level.FINEST)) {
-      LOG.log(Level.FINEST, "The message is successfully sent : {0}", new Object[]{message});
-    }
+    LOG.log(Level.FINEST, "Message successfully sent: {0}", message);
   }
 
   /**
@@ -49,8 +47,7 @@ public class LoggingLinkListener<T> implements LinkListener<T> {
   @Override
   public void onException(final Throwable cause, final SocketAddress remoteAddress, final T message) {
     if (LOG.isLoggable(Level.FINEST)) {
-      LOG.log(Level.FINEST, "The message to {0} is failed to be sent. message : {1}, cause : {2}",
-          new Object[]{remoteAddress, message, cause});
+      LOG.log(Level.FINEST, "Error sending message " + message + " to " + remoteAddress, cause);
     }
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
@@ -39,7 +39,9 @@ import java.util.logging.Logger;
 public class NettyLink<T> implements Link<T> {
 
   public static final int INT_SIZE = Integer.SIZE / Byte.SIZE;
+
   private static final Logger LOG = Logger.getLogger(NettyLink.class.getName());
+
   private final Channel channel;
   private final Encoder<? super T> encoder;
   private final LinkListener<? super T> listener;
@@ -61,13 +63,11 @@ public class NettyLink<T> implements Link<T> {
    * @param encoder  the encoder
    * @param listener the link listener
    */
-  public NettyLink(final Channel channel,
-                   final Encoder<? super T> encoder, final LinkListener<? super T> listener) {
+  public NettyLink(final Channel channel, final Encoder<? super T> encoder, final LinkListener<? super T> listener) {
     this.channel = channel;
     this.encoder = encoder;
     this.listener = listener;
   }
-
 
   /**
    * Writes the message to this link.
@@ -76,14 +76,10 @@ public class NettyLink<T> implements Link<T> {
    */
   @Override
   public void write(final T message) {
-    LOG.log(Level.FINEST, "write {0} {1}", new Object[]{channel, message});
-    final byte[] allData = encoder.encode(message);
-    // byte[] -> ByteBuf
+    LOG.log(Level.FINEST, "write {0} :: {1}", new Object[] {channel, message});
+    final ChannelFuture future = channel.writeAndFlush(Unpooled.wrappedBuffer(encoder.encode(message)));
     if (listener !=  null) {
-      channel.writeAndFlush(Unpooled.wrappedBuffer(allData))
-          .addListener(new NettyChannelFutureListener<>(message, listener));
-    } else {
-      channel.writeAndFlush(Unpooled.wrappedBuffer(allData));
+      future.addListener(new NettyChannelFutureListener<>(message, listener));
     }
   }
 
@@ -109,7 +105,7 @@ public class NettyLink<T> implements Link<T> {
 
   @Override
   public String toString() {
-    return "localAddr: " + getLocalAddress() + " remoteAddr: " + getRemoteAddress();
+    return "NettyLink: " + channel; // Channel has good .toString() implementation
   }
 }
 


### PR DESCRIPTION
Summary of changes:
   * Replace `ex.printStackTrace()` calls with proper log messages
   * Minor refactoring for readability and better performance in Wake identifier factory and around
   * Better logging in Wake
   * Other minor refactoring in Wake: implement some `.toString()` etc.

JIRA: [REEF-1801](https://issues.apache.org/jira/browse/REEF-1801)