### PR TITLE
[REEF-1802] Add *.log files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,11 +41,12 @@ atlassian-ide-plugin.xml
 tmp
 *~
 \#*
+*.log
+*.sw[op]
 #
 # ----------------------------------------------------------------------
 # Unknown Files. Please clean up over time
 # ----------------------------------------------------------------------
 ml-data
 tang.conf
-*.sw[op]
 profile-*.json

--- a/pom.xml
+++ b/pom.xml
@@ -286,8 +286,8 @@ under the License.
                             <exclude>REEF_LOCAL_RUNTIME/**</exclude>
                             <exclude>REEF_MESOS_RUNTIME/**</exclude>
                             <exclude>REEF_STANDALONE_RUNTIME/**</exclude>
-                            <!-- JVM error logs, especially troublesome on CI servers -->
-                            <exclude>**/hs_err_*.log</exclude>
+                            <!-- Error logs -->
+                            <exclude>**/*.log</exclude>
                             <!-- The Visual Studio and Nuget build files -->
                             <exclude>**/*.sln*</exclude>
                             <exclude>**/*.vcxproj*</exclude>


### PR DESCRIPTION
Changes:
   * Add `*.log` entry to `.gitignore`
   * Add `**/*.log` entry to exclude section of `apache-rat-plugin` in `pom.xml`

JIRA: [REEF-1802](https://issues.apache.org/jira/browse/REEF-1802)