### PR TITLE
[REEF-1800] Migrate all tang projects to VS2017

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.DotNet.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -7,7 +7,9 @@ regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
+
 http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,22 +18,27 @@ specific language governing permissions and limitations
 under the License.
 -->
   <PropertyGroup>
-    <AssemblyName>Org.Apache.REEF.Wake</AssemblyName>
-    <Description>Wake is an event-driven framework</Description>
-    <PackageTags>wake event-driven</PackageTags>
+    <AssemblyName>Org.Apache.REEF.Common</AssemblyName>
+    <Description>Reef Common Infrastructure</Description>
+    <PackageTags>Reef Common Infrastructure</PackageTags>
     <TargetFrameworks>net46;net451</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
+    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
+    <PackageReference Include="System.Reactive.Core" Version="$(RxVersion)" />
+    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
-    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Core" Version="$(TransientFaultHandlingVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.Reef.Tang.DotNet.csproj" />
     <ProjectReference Include="..\Org.Apache.REEF.Utilities\Org.Apache.Reef.Utilities.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Wake\Org.Apache.Reef.Wake.DotNet.csproj" />
   </ItemGroup>
 </Project>
+

--- a/lang/cs/Org.Apache.REEF.Common/Properties/AssemblyInfo.DotNet.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Properties/AssemblyInfo.DotNet.cs
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Runtime.CompilerServices;
+
+
+// Common and Evaluator share APIs that should not be exposed to the user
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Evaluator")]
+
+// Common and Driver share APIs that should not be exposed to the user
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Driver")]
+
+// Common and IO share APIs that should not be exposed to the user
+[assembly: InternalsVisibleTo("Org.Apache.REEF.IO")]
+
+// Allow the tests access to `internal` APIs
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Common.Tests")]
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Tests")]
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Evaluator.Tests")]
+
+// Allow NSubstitute to create proxy implementations
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+

--- a/lang/cs/Org.Apache.REEF.DotNet.sln
+++ b/lang/cs/Org.Apache.REEF.DotNet.sln
@@ -11,6 +11,22 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.REEF.Wake.DotNet
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.REEF.Wake.Tests.DotNet", "Org.Apache.REEF.Wake.Tests\Org.Apache.REEF.Wake.Tests.DotNet.csproj", "{1E2B189D-239E-419F-BA09-2A3B28EF98EB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.REEF.Common.DotNet", "Org.Apache.REEF.Common\Org.Apache.REEF.Common.DotNet.csproj", "{F92D4129-C094-458D-8DFE-B1454A62DA0F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.REEF.Examples.DotNet", "Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.DotNet.csproj", "{4C617764-FD55-4915-BACA-29D88A6B7C55}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.REEF.Network.DotNet", "Org.Apache.REEF.Network\Org.Apache.REEF.Network.DotNet.csproj", "{E1CB058B-DFAC-48CB-818E-4790D2C1701F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.REEF.Network.Examples.DotNet", "Org.Apache.REEF.Network.Examples\Org.Apache.REEF.Network.Examples.DotNet.csproj", "{8DF28709-0405-4EF9-A525-19D177032073}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.REEF.Network.Tests.DotNet", "Org.Apache.REEF.Network.Tests\Org.Apache.REEF.Network.Tests.DotNet.csproj", "{C61EDCD2-36AB-4F46-8886-40E6BDE05FAC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.REEF.Tang.Examples.DotNet", "Org.Apache.REEF.Tang.Examples\Org.Apache.REEF.Tang.Examples.DotNet.csproj", "{421744DE-5FB7-4694-98A7-00E4248A8B8C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.REEF.Tang.Tests.DotNet", "Org.Apache.REEF.Tang.Tests\Org.Apache.REEF.Tang.Tests.DotNet.csproj", "{6AB95745-BE93-4BF0-B3D3-C99EAB716F6B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Org.Apache.REEF.Tang.Tools.DotNet", "Org.Apache.REEF.Tang.Tools\Org.Apache.REEF.Tang.Tools.DotNet.csproj", "{558927C3-045B-405D-A978-9E89D50BB51A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -33,6 +49,38 @@ Global
 		{1E2B189D-239E-419F-BA09-2A3B28EF98EB}.Debug|x64.Build.0 = Debug|x64
 		{1E2B189D-239E-419F-BA09-2A3B28EF98EB}.Release|x64.ActiveCfg = Release|x64
 		{1E2B189D-239E-419F-BA09-2A3B28EF98EB}.Release|x64.Build.0 = Release|x64
+		{F92D4129-C094-458D-8DFE-B1454A62DA0F}.Debug|x64.ActiveCfg = Debug|x64
+		{F92D4129-C094-458D-8DFE-B1454A62DA0F}.Debug|x64.Build.0 = Debug|x64
+		{F92D4129-C094-458D-8DFE-B1454A62DA0F}.Release|x64.ActiveCfg = Release|x64
+		{F92D4129-C094-458D-8DFE-B1454A62DA0F}.Release|x64.Build.0 = Release|x64
+		{4C617764-FD55-4915-BACA-29D88A6B7C55}.Debug|x64.ActiveCfg = Debug|x64
+		{4C617764-FD55-4915-BACA-29D88A6B7C55}.Debug|x64.Build.0 = Debug|x64
+		{4C617764-FD55-4915-BACA-29D88A6B7C55}.Release|x64.ActiveCfg = Release|x64
+		{4C617764-FD55-4915-BACA-29D88A6B7C55}.Release|x64.Build.0 = Release|x64
+		{E1CB058B-DFAC-48CB-818E-4790D2C1701F}.Debug|x64.ActiveCfg = Debug|x64
+		{E1CB058B-DFAC-48CB-818E-4790D2C1701F}.Debug|x64.Build.0 = Debug|x64
+		{E1CB058B-DFAC-48CB-818E-4790D2C1701F}.Release|x64.ActiveCfg = Release|x64
+		{E1CB058B-DFAC-48CB-818E-4790D2C1701F}.Release|x64.Build.0 = Release|x64
+		{8DF28709-0405-4EF9-A525-19D177032073}.Debug|x64.ActiveCfg = Debug|x64
+		{8DF28709-0405-4EF9-A525-19D177032073}.Debug|x64.Build.0 = Debug|x64
+		{8DF28709-0405-4EF9-A525-19D177032073}.Release|x64.ActiveCfg = Release|x64
+		{8DF28709-0405-4EF9-A525-19D177032073}.Release|x64.Build.0 = Release|x64
+		{C61EDCD2-36AB-4F46-8886-40E6BDE05FAC}.Debug|x64.ActiveCfg = Debug|x64
+		{C61EDCD2-36AB-4F46-8886-40E6BDE05FAC}.Debug|x64.Build.0 = Debug|x64
+		{C61EDCD2-36AB-4F46-8886-40E6BDE05FAC}.Release|x64.ActiveCfg = Release|x64
+		{C61EDCD2-36AB-4F46-8886-40E6BDE05FAC}.Release|x64.Build.0 = Release|x64
+		{421744DE-5FB7-4694-98A7-00E4248A8B8C}.Debug|x64.ActiveCfg = Debug|x64
+		{421744DE-5FB7-4694-98A7-00E4248A8B8C}.Debug|x64.Build.0 = Debug|x64
+		{421744DE-5FB7-4694-98A7-00E4248A8B8C}.Release|x64.ActiveCfg = Release|x64
+		{421744DE-5FB7-4694-98A7-00E4248A8B8C}.Release|x64.Build.0 = Release|x64
+		{6AB95745-BE93-4BF0-B3D3-C99EAB716F6B}.Debug|x64.ActiveCfg = Debug|x64
+		{6AB95745-BE93-4BF0-B3D3-C99EAB716F6B}.Debug|x64.Build.0 = Debug|x64
+		{6AB95745-BE93-4BF0-B3D3-C99EAB716F6B}.Release|x64.ActiveCfg = Release|x64
+		{6AB95745-BE93-4BF0-B3D3-C99EAB716F6B}.Release|x64.Build.0 = Release|x64
+		{558927C3-045B-405D-A978-9E89D50BB51A}.Debug|x64.ActiveCfg = Debug|x64
+		{558927C3-045B-405D-A978-9E89D50BB51A}.Debug|x64.Build.0 = Debug|x64
+		{558927C3-045B-405D-A978-9E89D50BB51A}.Release|x64.ActiveCfg = Release|x64
+		{558927C3-045B-405D-A978-9E89D50BB51A}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.DotNet.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -7,7 +7,9 @@ regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
+
 http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,22 +18,24 @@ specific language governing permissions and limitations
 under the License.
 -->
   <PropertyGroup>
-    <AssemblyName>Org.Apache.REEF.Wake</AssemblyName>
-    <Description>Wake is an event-driven framework</Description>
-    <PackageTags>wake event-driven</PackageTags>
+    <AssemblyName>Org.Apache.REEF.Driver</AssemblyName>
+    <Description>Driver for REEF.NET</Description>
+    <PackageTags>Reef Driver</PackageTags>
     <TargetFrameworks>net46;net451</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
+    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
+    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Core" Version="$(TransientFaultHandlingVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
+    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.Reef.Tang.DotNet.csproj" />
     <ProjectReference Include="..\Org.Apache.REEF.Utilities\Org.Apache.Reef.Utilities.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Common\Org.Apache.Reef.Common.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Wake\Org.Apache.Reef.Wake.DotNet.csproj" />
   </ItemGroup>
 </Project>
+

--- a/lang/cs/Org.Apache.REEF.Driver/Properties/AssemblyInfo.DotNet.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Properties/AssemblyInfo.DotNet.cs
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Runtime.CompilerServices;
+
+// Allow the bridge access to `internal` APIs
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Bridge")]
+

--- a/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.DotNet.csproj
@@ -7,7 +7,9 @@ regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
+
 http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,22 +18,26 @@ specific language governing permissions and limitations
 under the License.
 -->
   <PropertyGroup>
-    <AssemblyName>Org.Apache.REEF.Wake</AssemblyName>
-    <Description>Wake is an event-driven framework</Description>
-    <PackageTags>wake event-driven</PackageTags>
+    <AssemblyName>Org.Apache.REEF.Examples</AssemblyName>
+    <Description>Reef Examples</Description>
+    <PackageTags>Reef Examples</PackageTags>
     <TargetFrameworks>net46;net451</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Core" Version="$(TransientFaultHandlingVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
+    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.Reef.Tang.DotNet.csproj" />
     <ProjectReference Include="..\Org.Apache.REEF.Utilities\Org.Apache.Reef.Utilities.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Common\Org.Apache.Reef.Common.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Driver\Org.Apache.Reef.Driver.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Network\Org.Apache.Reef.Network.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Wake\Org.Apache.Reef.Wake.DotNet.csproj" />
   </ItemGroup>
 </Project>
+

--- a/lang/cs/Org.Apache.REEF.Network.Examples/Org.Apache.REEF.Network.Examples.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/Org.Apache.REEF.Network.Examples.DotNet.csproj
@@ -7,7 +7,9 @@ regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
+
 http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,22 +18,28 @@ specific language governing permissions and limitations
 under the License.
 -->
   <PropertyGroup>
-    <AssemblyName>Org.Apache.REEF.Wake</AssemblyName>
-    <Description>Wake is an event-driven framework</Description>
-    <PackageTags>wake event-driven</PackageTags>
+    <AssemblyName>Org.Apache.REEF.Network.Examples</AssemblyName>
+    <Description>Examples for network services for reef</Description>
+    <PackageTags>Reef Network services examples</PackageTags>
     <TargetFrameworks>net46;net451</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Core" Version="$(TransientFaultHandlingVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Org.Apache.REEF.Common\Org.Apache.Reef.Common.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Driver\Org.Apache.Reef.Driver.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Network\Org.Apache.Reef.Network.DotNet.csproj" />
     <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.Reef.Tang.DotNet.csproj" />
     <ProjectReference Include="..\Org.Apache.REEF.Utilities\Org.Apache.Reef.Utilities.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Wake\Org.Apache.Reef.Wake.DotNet.csproj" />
   </ItemGroup>
 </Project>
+

--- a/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.DotNet.csproj
@@ -16,22 +16,22 @@ specific language governing permissions and limitations
 under the License.
 -->
   <PropertyGroup>
-    <AssemblyName>Org.Apache.REEF.Wake</AssemblyName>
-    <Description>Wake is an event-driven framework</Description>
-    <PackageTags>wake event-driven</PackageTags>
+    <AssemblyName>Org.Apache.REEF.Network.Tests</AssemblyName>
     <TargetFrameworks>net46;net451</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Core" Version="$(TransientFaultHandlingVersion)" />
+    <PackageReference Include="System.Reactive.Core" Version="$(RxVersion)" />
     <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
+    <Reference Include="System" />
   </ItemGroup>
+  <Import Project="..\xunit.DotNet.props" />
   <ItemGroup>
+    <ProjectReference Include="..\Org.Apache.REEF.Common\Org.Apache.Reef.Common.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Examples\Org.Apache.Reef.Examples.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Network.Examples\Org.Apache.Reef.Network.Examples.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Network\Org.Apache.Reef.Network.DotNet.csproj" />
     <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.Reef.Tang.DotNet.csproj" />
-    <ProjectReference Include="..\Org.Apache.REEF.Utilities\Org.Apache.Reef.Utilities.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Wake\Org.Apache.Reef.Wake.DotNet.csproj" />
   </ItemGroup>
 </Project>

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.DotNet.csproj
@@ -7,7 +7,9 @@ regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
+
 http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,22 +18,29 @@ specific language governing permissions and limitations
 under the License.
 -->
   <PropertyGroup>
-    <AssemblyName>Org.Apache.REEF.Wake</AssemblyName>
-    <Description>Wake is an event-driven framework</Description>
-    <PackageTags>wake event-driven</PackageTags>
+    <AssemblyName>Org.Apache.REEF.Network</AssemblyName>
+    <Description>Network services for reef</Description>
+    <PackageTags>Reef Network services</PackageTags>
     <TargetFrameworks>net46;net451</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
+    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
+    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
+    <PackageReference Include="System.Reactive.Core" Version="$(RxVersion)" />
+    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
-    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Core" Version="$(TransientFaultHandlingVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.Reef.Tang.DotNet.csproj" />
     <ProjectReference Include="..\Org.Apache.REEF.Utilities\Org.Apache.Reef.Utilities.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Common\Org.Apache.Reef.Common.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Driver\Org.Apache.Reef.Driver.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Wake\Org.Apache.Reef.Wake.DotNet.csproj" />
   </ItemGroup>
 </Project>
+

--- a/lang/cs/Org.Apache.REEF.Network/Properties/AssemblyInfo.DotNet.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Properties/AssemblyInfo.DotNet.cs
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Runtime.CompilerServices;
+
+// Allow the tests access to `internal` APIs
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Network.Tests")]
+

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/Org.Apache.REEF.Tang.Examples.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/Org.Apache.REEF.Tang.Examples.DotNet.csproj
@@ -7,7 +7,9 @@ regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
+
 http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,22 +18,18 @@ specific language governing permissions and limitations
 under the License.
 -->
   <PropertyGroup>
-    <AssemblyName>Org.Apache.REEF.Wake</AssemblyName>
-    <Description>Wake is an event-driven framework</Description>
-    <PackageTags>wake event-driven</PackageTags>
+    <AssemblyName>Org.Apache.REEF.Tang.Examples</AssemblyName>
+    <Description>Examples using the Tang framework</Description>
+    <PackageTags> Apache REEF tang dependency injection examples</PackageTags>
     <TargetFrameworks>net46;net451</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Core" Version="$(TransientFaultHandlingVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.Reef.Tang.DotNet.csproj" />
-    <ProjectReference Include="..\Org.Apache.REEF.Utilities\Org.Apache.Reef.Utilities.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Wake\Org.Apache.Reef.Wake.DotNet.csproj" />
   </ItemGroup>
 </Project>

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.DotNet.csproj
@@ -16,22 +16,28 @@ specific language governing permissions and limitations
 under the License.
 -->
   <PropertyGroup>
-    <AssemblyName>Org.Apache.REEF.Wake</AssemblyName>
-    <Description>Wake is an event-driven framework</Description>
-    <PackageTags>wake event-driven</PackageTags>
+    <AssemblyName>Org.Apache.REEF.Tang.Tests</AssemblyName>
     <TargetFrameworks>net46;net451</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
+    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Core" Version="$(TransientFaultHandlingVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
+  </ItemGroup>
+  <Import Project="..\xunit.DotNet.props" />
+  <ItemGroup>
+      <None Include="simpleConstructorJavaProto.bin">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Org.Apache.REEF.Common\Org.Apache.Reef.Common.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Examples\Org.Apache.Reef.Examples.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Tang.Examples\Org.Apache.Reef.Tang.Examples.DotNet.csproj" />
     <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.Reef.Tang.DotNet.csproj" />
-    <ProjectReference Include="..\Org.Apache.REEF.Utilities\Org.Apache.Reef.Utilities.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Wake\Org.Apache.Reef.Wake.DotNet.csproj" />
   </ItemGroup>
 </Project>

--- a/lang/cs/Org.Apache.REEF.Tang.Tools/Org.Apache.REEF.Tang.Tools.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang.Tools/Org.Apache.REEF.Tang.Tools.DotNet.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -16,22 +16,17 @@ specific language governing permissions and limitations
 under the License.
 -->
   <PropertyGroup>
-    <AssemblyName>Org.Apache.REEF.Wake</AssemblyName>
-    <Description>Wake is an event-driven framework</Description>
-    <PackageTags>wake event-driven</PackageTags>
+    <AssemblyName>Org.Apache.REEF.Tang.Tools</AssemblyName>
+    <Description>Tools for Tang</Description>
+    <PackageTags>Apache REEF Tang dependency injection</PackageTags>
+    <OutputType>Exe</OutputType>
     <TargetFrameworks>net46;net451</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Core" Version="$(TransientFaultHandlingVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.Reef.Tang.DotNet.csproj" />
-    <ProjectReference Include="..\Org.Apache.REEF.Utilities\Org.Apache.Reef.Utilities.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.REEF.Tang.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Common\Org.Apache.REEF.Common.DotNet.csproj" />
+    <ProjectReference Include="..\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.DotNet.csproj" />
   </ItemGroup>
 </Project>
+

--- a/lang/cs/Org.Apache.REEF.Utilities/Properties/AssemblyInfo.DotNet.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Properties/AssemblyInfo.DotNet.cs
@@ -1,0 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Common")]
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Evaluator")]
+

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.DotNet.csproj
@@ -19,6 +19,7 @@ under the License.
     <AssemblyName>Org.Apache.REEF.Wake.Tests</AssemblyName>
     <TargetFrameworks>net46;net451</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|x64'" />
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
     <PackageReference Include="System.Reactive.Core" Version="$(RxVersion)" />

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.DotNet.csproj
@@ -19,7 +19,6 @@ under the License.
     <AssemblyName>Org.Apache.REEF.Wake.Tests</AssemblyName>
     <TargetFrameworks>net46;net451</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|x64'" />
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
     <PackageReference Include="System.Reactive.Core" Version="$(RxVersion)" />


### PR DESCRIPTION
Summary of changes:
    * Migrates remaining tang projects to VS2017 csproj format
    * Migrates all dependency projects (such as common, network and
    driver)

JIRA:
    [REEF-1800](https://issues.apache.org/jira/browse/REEF-1800)

Pull request
    This closes #