### PR TITLE
[REEF-1816] Upgrade nuget.exe to version 4.1.

### DIFF
--- a/lang/cs/.nuget/NuGet.targets
+++ b/lang/cs/.nuget/NuGet.targets
@@ -204,7 +204,7 @@ under the License.
 
                     Log.LogMessage("Downloading latest version of NuGet.exe...");
                     WebClient webClient = new WebClient();
-                    webClient.DownloadFile("https://www.nuget.org/nuget.exe", OutputFilename);
+                    webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe", OutputFilename);
 
                     return true;
                 }


### PR DESCRIPTION
  - Latest version of nuget.exe is required in order download some
    recent packages such as the latest version of Newtonsoft.Json.

JIRA:
  [REEF-1816](https://issues.apache.org/jira/browse/REEF-1816)

Pull Request
  This closses: