### PR TITLE
[REEF-1818] Upgrade System.Reactive.* to 3x for CoreCLR Compatibility

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.DotNet.csproj
@@ -28,8 +28,8 @@ under the License.
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
     <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
-    <PackageReference Include="System.Reactive.Core" Version="$(RxVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
+    <PackageReference Include="System.Reactive.Core" Version="$(SystemReactiveVersion)" />
+    <PackageReference Include="System.Reactive.Interfaces" Version="$(SystemReactiveVersion)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -39,14 +39,14 @@ under the License.
     <Reference Include="protobuf-net">
       <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Core">
-      <HintPath>$(PackagesDir)\Rx-Core.$(RxVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.Interfaces">
-      <HintPath>$(PackagesDir)\Rx-Interfaces.$(RxVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core">
+      <HintPath>$(PackagesDir)\System.Reactive.Core.$(SystemReactiveVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces">
+      <HintPath>$(PackagesDir)\System.Reactive.Interfaces.$(SystemReactiveVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Common/packages.config
+++ b/lang/cs/Org.Apache.REEF.Common/packages.config
@@ -21,7 +21,7 @@ under the License.
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.DotNet.csproj
@@ -21,8 +21,8 @@ under the License.
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
-    <PackageReference Include="System.Reactive.Core" Version="$(RxVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
+    <PackageReference Include="System.Reactive.Core" Version="$(SystemReactiveVersion)" />
+    <PackageReference Include="System.Reactive.Interfaces" Version="$(SystemReactiveVersion)" />
     <Reference Include="System" />
   </ItemGroup>
   <Import Project="..\xunit.DotNet.props" />

--- a/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -42,10 +42,10 @@ under the License.
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Reactive.Core">
-      <HintPath>$(PackagesDir)\Rx-Core.$(RxVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
+      <HintPath>$(PackagesDir)\System.Reactive.Core.$(SystemReactiveVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Interfaces">
-      <HintPath>$(PackagesDir)\Rx-Interfaces.$(RxVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <HintPath>$(PackagesDir)\System.Reactive.Interfaces.$(SystemReactiveVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Network.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/packages.config
@@ -18,9 +18,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.DotNet.csproj
@@ -27,8 +27,8 @@ under the License.
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
     <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
-    <PackageReference Include="System.Reactive.Core" Version="$(RxVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
+    <PackageReference Include="System.Reactive.Core" Version="$(SystemReactiveVersion)" />
+    <PackageReference Include="System.Reactive.Interfaces" Version="$(SystemReactiveVersion)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Caching" />

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -36,14 +36,14 @@ under the License.
     <Reference Include="protobuf-net">
       <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Core">
-      <HintPath>$(PackagesDir)\Rx-Core.$(RxVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.Interfaces">
-      <HintPath>$(PackagesDir)\Rx-Interfaces.$(RxVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core">
+      <HintPath>$(PackagesDir)\System.Reactive.Core.$(SystemReactiveVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces">
+      <HintPath>$(PackagesDir)\System.Reactive.Interfaces.$(SystemReactiveVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />

--- a/lang/cs/Org.Apache.REEF.Network/packages.config
+++ b/lang/cs/Org.Apache.REEF.Network/packages.config
@@ -21,7 +21,7 @@ under the License.
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -62,10 +62,10 @@ under the License.
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Reactive.Core">
-      <HintPath>$(PackagesDir)\Rx-Core.$(RxVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
+      <HintPath>$(PackagesDir)\System.Reactive.Core.$(SystemReactiveVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Interfaces">
-      <HintPath>$(PackagesDir)\Rx-Interfaces.$(RxVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <HintPath>$(PackagesDir)\System.Reactive.Interfaces.$(SystemReactiveVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(PackagesDir)\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>

--- a/lang/cs/Org.Apache.REEF.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tests/packages.config
@@ -24,9 +24,9 @@ under the License.
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="6.1.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.DotNet.csproj
@@ -21,8 +21,8 @@ under the License.
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
-    <PackageReference Include="System.Reactive.Core" Version="$(RxVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
+    <PackageReference Include="System.Reactive.Core" Version="$(SystemReactiveVersion)" />
+    <PackageReference Include="System.Reactive.Interfaces" Version="$(SystemReactiveVersion)" />
   </ItemGroup>
   <Import Project="..\xunit.DotNet.props" />
   <ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -37,10 +37,10 @@ under the License.
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Reactive.Core">
-      <HintPath>$(PackagesDir)\Rx-Core.$(RxVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
+      <HintPath>$(PackagesDir)\System.Reactive.Core.$(SystemReactiveVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Interfaces">
-      <HintPath>$(PackagesDir)\Rx-Interfaces.$(RxVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <HintPath>$(PackagesDir)\System.Reactive.Interfaces.$(SystemReactiveVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/packages.config
@@ -18,9 +18,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.DotNet.csproj
@@ -28,7 +28,7 @@ under the License.
     <Reference Include="System.Xml" />
     <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
     <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Core" Version="$(TransientFaultHandlingVersion)" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="$(RxVersion)" />
+    <PackageReference Include="System.Reactive.Interfaces" Version="$(SystemReactiveVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.REEF.Tang.DotNet.csproj" />

--- a/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -38,8 +38,12 @@ under the License.
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core">
+      <HintPath>$(PackagesDir)\System.Reactive.Core.$(SystemReactiveVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Reactive.Interfaces">
-      <HintPath>$(PackagesDir)\Rx-Interfaces.$(RxVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <HintPath>$(PackagesDir)\System.Reactive.Interfaces.$(SystemReactiveVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Wake/packages.config
+++ b/lang/cs/Org.Apache.REEF.Wake/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -19,8 +19,8 @@ under the License.
 -->
 <packages>
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net45" />
 </packages>

--- a/lang/cs/build.DotNet.props
+++ b/lang/cs/build.DotNet.props
@@ -41,10 +41,9 @@ under the License.
     <NewtonsoftJsonVersion>10.0.1</NewtonsoftJsonVersion>
     <NSubstituteVersion>1.8.2.0</NSubstituteVersion>
     <ProtobufVersion>2.0.0.668</ProtobufVersion>
-    <RxVersion>2.2.5</RxVersion>
+    <SystemReactiveVersion>3.1.1</SystemReactiveVersion>
     <StyleCopVersion>4.7.49.1</StyleCopVersion>
     <TransientFaultHandlingVersion>1.0.0</TransientFaultHandlingVersion>
-    <RxVersion>3.0.0</RxVersion>
     <NSubstituteVersion>2.0.3</NSubstituteVersion>
     <WindowsAzureStorageVersion>8.1.3</WindowsAzureStorageVersion>
   </PropertyGroup>

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -70,7 +70,7 @@ under the License.
     <AvroVersion>1.5.6</AvroVersion>
     <NewtonsoftJsonVersion>8.0.3</NewtonsoftJsonVersion>
     <ProtobufVersion>2.0.0.668</ProtobufVersion>
-    <RxVersion>2.2.5</RxVersion>
+    <SystemReactiveVersion>3.1.1</SystemReactiveVersion>
     <StyleCopVersion>4.7.49.1</StyleCopVersion>
     <NSubstituteVersion>1.8.2.0</NSubstituteVersion>
   </PropertyGroup>


### PR DESCRIPTION
This addressed the issue by
  * Removing the System.Rx.{Core,Interfaces} nugets
  * Adding the System.Reactive.{Core,Interfaces} nugets
  * Cleaning up the build to use "SystemReactive" variables instead of "Rx".

JIRA:
  [REEF-1818](https://issues.apache.org/jira/browse/REEF-1818)