### PR TITLE
[REEF-1829] pom.xml fix: Apache license checker complains about files in .vs/ directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,7 @@ under the License.
                             <!-- Error logs -->
                             <exclude>**/*.log</exclude>
                             <!-- The Visual Studio and Nuget build files -->
+                            <exclude>**/.vs/**</exclude>
                             <exclude>**/*.sln*</exclude>
                             <exclude>**/*.vcxproj*</exclude>
                             <exclude>**/*.csproj*</exclude>


### PR DESCRIPTION

Add `**/.vs/**` to `exclude` section of the `apache-rat-plugin` in root `pom.xml`

JIRA: [REEF-1829](https://issues.apache.org/jira/browse/REEF-1829)

Closes #