### PR TITLE
[REEF-1827] new Uri(path) in REEF.NET IO Returns Lowercase String

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileSystemTest.cs
+++ b/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFileSystemTest.cs
@@ -50,7 +50,7 @@ namespace Org.Apache.REEF.IO.TestClient
         {
             bool result = false;
 
-            var localFile = MakeLocalBanaryFile();
+            var localFile = MakeLocalBinaryFile();
             Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "localFile {0}: ", localFile));
 
             var localFileDownloaded = localFile + ".2";
@@ -109,7 +109,7 @@ namespace Org.Apache.REEF.IO.TestClient
             return true;
         }
 
-        private string MakeLocalBanaryFile()
+        private string MakeLocalBinaryFile()
         {
             var result = Path.GetTempFileName();
             WriteFileTest(result);

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
@@ -72,12 +72,12 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
             try
             {
                 uri = new Uri(path);
-                Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Uri {0} created in CreateUriForPath.", uri));
+                Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Uri {0} created in CreateUriForPath.", uri.AbsolutePath));
             }
             catch (UriFormatException)
             {
                 uri = new Uri(_uriPrefix + path);
-                Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Uri {0} created in CreateUriForPath with prefix added.", uri));
+                Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Uri {0} created in CreateUriForPath with prefix added.", uri.AbsolutePath));
             }
 
             return uri;
@@ -118,7 +118,7 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
         public void Delete(Uri fileUri)
         {
             // Delete the file via the hdfs command line.
-            _commandRunner.Run("dfs -rm " + fileUri);
+            _commandRunner.Run("dfs -rm " + fileUri.AbsolutePath);
         }
 
         public bool Exists(Uri fileUri)
@@ -126,38 +126,38 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
             // This determines the existence of a file based on the 'ls' command. 
             // Ideally, we'd use the 'test' command's return value, but we did not find a way to access that.
             return
-                _commandRunner.Run("dfs -ls " + fileUri).StdErr
+                _commandRunner.Run("dfs -ls " + fileUri.AbsolutePath).StdErr
                     .All(line => !NoSuchFileOrDirectoryRegEx.IsMatch(line));
         }
 
         public void Copy(Uri sourceUri, Uri destinationUri)
         {
-            _commandRunner.Run("dfs -cp " + sourceUri + " " + destinationUri);
+            _commandRunner.Run("dfs -cp " + sourceUri.AbsolutePath + " " + destinationUri.AbsolutePath);
         }
 
         public void CopyToLocal(Uri remoteFileUri, string localName)
         {
-            _commandRunner.Run("dfs -get " + remoteFileUri + " " + localName);
+            _commandRunner.Run("dfs -get " + remoteFileUri.AbsolutePath + " " + localName);
         }
 
         public void CopyFromLocal(string localFileName, Uri remoteFileUri)
         {
-            _commandRunner.Run("dfs -put " + localFileName + " " + remoteFileUri);
+            _commandRunner.Run("dfs -put " + localFileName + " " + remoteFileUri.AbsolutePath);
         }
 
         public void CreateDirectory(Uri directoryUri)
         {
-            _commandRunner.Run("dfs -mkdir " + directoryUri);
+            _commandRunner.Run("dfs -mkdir " + directoryUri.AbsolutePath);
         }
 
         public void DeleteDirectory(Uri directoryUri)
         {
-            _commandRunner.Run("dfs -rmdir " + directoryUri);
+            _commandRunner.Run("dfs -rmdir " + directoryUri.AbsolutePath);
         }
 
         public IEnumerable<Uri> GetChildren(Uri directoryUri)
         {
-            return _commandRunner.Run("dfs -ls " + directoryUri)
+            return _commandRunner.Run("dfs -ls " + directoryUri.AbsolutePath)
                 .StdOut.Where(line => !LsFirstLineRegex.IsMatch(line))
                 .Select(line => line.Split())
                 .Select(x => new Uri(x[x.Length - 1]));


### PR DESCRIPTION
This corresponds to [REEF-1827](https://issues.apache.org/jira/browse/REEF-1827). In the Org.Apache.REEF.IO.FileSystem.IFileSystem, we have many methods that are based on C#'s Uri. For example:
```
void CopyToLocal(Uri remoteFileUri, string localName);
void CreateDirectory(Uri directoryUri);
```
From the logging and my experiments, this converts path to lowercase characters. For example:
```
new Uri("hdfs://XYZ123/mypath/data.txt") // Returns "hdfs://xyz123/mypath/data.txt"
```
If we are interacting with hdfs, in the subsequent dfs command in Org.Apache.REEF.IO.FileSystem.Hadoop:
```
public void CopyToLocal(Uri remoteFileUri, string localName)
{
    _commandRunner.Run("dfs -get " + remoteFileUri + " " + localName);
}
```
this will fail, since hdfs is case-sensitive.

JIRA:
[REEF-1827](https://issues.apache.org/jira/browse/REEF-1827)

Pull request:
#1329