### PR TITLE
[REEF-1830] Update Protobuf to version 2.1.0

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -37,7 +37,7 @@ under the License.
       <HintPath>$(PackagesDir)\Newtonsoft.Json.$(NewtonsoftJsonVersion)\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net">
-      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net451\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
+++ b/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
@@ -34,7 +34,7 @@ under the License.
       <HintPath>$(PackagesDir)\Microsoft.Hadoop.Avro.$(AvroVersion)\lib\net45\Microsoft.Hadoop.Avro.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net">
-      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net451\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/lang/cs/Org.Apache.REEF.Driver/packages.config
+++ b/lang/cs/Org.Apache.REEF.Driver/packages.config
@@ -20,6 +20,6 @@ under the License.
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/Org.Apache.REEF.Evaluator.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/Org.Apache.REEF.Evaluator.Tests.csproj
@@ -43,8 +43,8 @@ under the License.
       <HintPath>$(PackagesDir)\NSubstitute.$(NSubstituteVersion)\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="protobuf-net, Version=$(ProtobufVersion), Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
+    <Reference Include="protobuf-net">
+      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net451\protobuf-net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/packages.config
@@ -19,7 +19,7 @@ under the License.
 -->
 <packages>
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net45" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.csproj
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.csproj
@@ -41,7 +41,7 @@ under the License.
   <Import Project="$(SolutionDir)\build.props" />
   <ItemGroup>
     <Reference Include="protobuf-net">
-      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net451\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/lang/cs/Org.Apache.REEF.Evaluator/packages.config
+++ b/lang/cs/Org.Apache.REEF.Evaluator/packages.config
@@ -18,6 +18,6 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -34,7 +34,7 @@ under the License.
       <HintPath>$(PackagesDir)\Microsoft.Hadoop.Avro.$(AvroVersion)\lib\net45\Microsoft.Hadoop.Avro.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net">
-      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net451\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/lang/cs/Org.Apache.REEF.Network/packages.config
+++ b/lang/cs/Org.Apache.REEF.Network/packages.config
@@ -20,7 +20,7 @@ under the License.
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.csproj
@@ -41,7 +41,7 @@ under the License.
       <HintPath>$(PackagesDir)\Newtonsoft.Json.$(NewtonsoftJsonVersion)\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net">
-      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net451\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/packages.config
@@ -20,7 +20,7 @@ under the License.
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Tang/Org.Apache.REEF.Tang.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang/Org.Apache.REEF.Tang.csproj
@@ -37,7 +37,7 @@ under the License.
       <HintPath>$(PackagesDir)\Newtonsoft.Json.$(NewtonsoftJsonVersion)\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net">
-      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net451\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/lang/cs/Org.Apache.REEF.Tang/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tang/packages.config
@@ -20,6 +20,6 @@ under the License.
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tests/packages.config
@@ -23,7 +23,7 @@ under the License.
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />

--- a/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
@@ -42,7 +42,7 @@ under the License.
       <HintPath>$(PackagesDir)\TransientFaultHandling.Core.5.1.1209.1\lib\NET4\Microsoft.Practices.TransientFaultHandling.Core.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net">
-      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net451\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/lang/cs/Org.Apache.REEF.Wake/packages.config
+++ b/lang/cs/Org.Apache.REEF.Wake/packages.config
@@ -22,7 +22,7 @@ under the License.
   <package id="Microsoft.Avro.Tools" version="0.1.0" targetFramework="net451" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" developmentDependency="true" />
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />

--- a/lang/cs/build.DotNet.props
+++ b/lang/cs/build.DotNet.props
@@ -40,7 +40,7 @@ under the License.
     <AvroVersion>1.5.6</AvroVersion>
     <NewtonsoftJsonVersion>10.0.1</NewtonsoftJsonVersion>
     <NSubstituteVersion>1.8.2.0</NSubstituteVersion>
-    <ProtobufVersion>2.0.0.668</ProtobufVersion>
+    <ProtobufVersion>2.1.0</ProtobufVersion>
     <SystemReactiveVersion>3.1.1</SystemReactiveVersion>
     <StyleCopVersion>4.7.49.1</StyleCopVersion>
     <TransientFaultHandlingVersion>1.0.0</TransientFaultHandlingVersion>

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -69,7 +69,7 @@ under the License.
   <PropertyGroup>
     <AvroVersion>1.5.6</AvroVersion>
     <NewtonsoftJsonVersion>8.0.3</NewtonsoftJsonVersion>
-    <ProtobufVersion>2.0.0.668</ProtobufVersion>
+    <ProtobufVersion>2.1.0</ProtobufVersion>
     <SystemReactiveVersion>3.1.1</SystemReactiveVersion>
     <StyleCopVersion>4.7.49.1</StyleCopVersion>
     <NSubstituteVersion>1.8.2.0</NSubstituteVersion>


### PR DESCRIPTION
This updates our protobuf version to 2.1.0. This is needed to support
.net core 2.0 as the library contains netstandard binaries.

JIRA:
    [REEF-1830] https://issues.apache.org/jira/browse/REEF-1830

Pull Request:
    This closes #