### PR TITLE
[REEF-1585] Fix CoreCLR issues in Org.Apache.REEF.IMRU

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Exceptions/RecoverableNetworkException.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Exceptions/RecoverableNetworkException.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Org.Apache.REEF.Common.Exceptions
+{
+    /// <summary>
+    /// Encapsulates <see cref="Exception#ToString"/> for an Exception related to 
+    /// the Network that can be recovered from.
+    /// </summary>
+    [Serializable]
+    public sealed class RecoverableNetworkException : Exception
+    {
+        public RecoverableNetworkException()
+        {
+        }
+
+        public RecoverableNetworkException(string message) : base(message)
+        {
+        }
+
+        public RecoverableNetworkException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        public RecoverableNetworkException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -109,6 +109,7 @@ under the License.
     <Compile Include="Events\IContextStart.cs" />
     <Compile Include="Events\IContextStop.cs" />
     <Compile Include="Exceptions\JobException.cs" />
+    <Compile Include="Exceptions\RecoverableNetworkException.cs" />
     <Compile Include="Exceptions\NonSerializableEvaluatorException.cs" />
     <Compile Include="Exceptions\NonSerializableTaskException.cs" />
     <Compile Include="Files\PathUtilities.cs" />

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/TaskHostBase.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/TaskHostBase.cs
@@ -18,8 +18,8 @@
 using System;
 using System.IO;
 using System.Net.Sockets;
-using System.Runtime.Remoting;
 using System.Threading;
+using Org.Apache.REEF.Common.Exceptions;
 using Org.Apache.REEF.Common.Runtime;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Common.Tasks.Events;
@@ -128,7 +128,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         private static bool IsCommunicationException(Exception e)
         {
             if (e is OperationCanceledException || e is IOException || e is TcpClientConnectionException ||
-                e is RemotingException || e is SocketException ||
+                e is RecoverableNetworkException || e is SocketException ||
                 (e is AggregateException && e.InnerException != null && e.InnerException is IOException))
             {
                 return true;

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
@@ -18,8 +18,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Remoting;
 using System.Threading;
+using Org.Apache.REEF.Common.Exceptions;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Network.Group.Config;
@@ -393,7 +393,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
 
                 var leftOver = string.Join(",", identifiers.Where(e => !foundList.Contains(e)));
                 Logger.Log(Level.Error, "For node {0}, cannot find registered parent/children: {1}.", _selfId, leftOver);
-                Exceptions.Throw(new RemotingException("Failed to find parent/children nodes in operator topology for node: " + _selfId), Logger);
+                Exceptions.Throw(new RecoverableNetworkException("Failed to find parent/children nodes in operator topology for node: " + _selfId), Logger);
             }
         }
     }

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/NsConnection.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/NsConnection.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using System.Runtime.Remoting;
+using Org.Apache.REEF.Common.Exceptions;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Utilities.Logging;
@@ -77,7 +77,7 @@ namespace Org.Apache.REEF.Network.NetworkService
             IPEndPoint destAddr = _nameClient.CacheLookup(_destId.ToString());
             if (destAddr == null)
             {
-                throw new RemotingException("Cannot register Identifier with NameService");
+                throw new RecoverableNetworkException("Cannot register Identifier with NameService");
             }
 
             try


### PR DESCRIPTION
This addressed the issue by
  * Changing all uses of RemotingException references to standard error classes
  * Doing the same in all other solutions that interact with Org.Apache.REEF.IMRU

JIRA:
  [REEF-JIRA_1585](https://issues.apache.org/jira/browse/REEF-1585)