### PR TITLE
[REEF-362] Implement a Wake Transport using HTTP

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/AbstractNettyEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/AbstractNettyEventListener.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
  * Generic functionality for the Netty event listener.
  * This is a base class for client and server versions.
  */
-abstract class AbstractNettyEventListener implements NettyEventListener {
+public abstract class AbstractNettyEventListener implements NettyEventListener {
 
   protected static final Logger LOG = Logger.getLogger(AbstractNettyEventListener.class.getName());
 
@@ -41,9 +41,9 @@ abstract class AbstractNettyEventListener implements NettyEventListener {
   protected final EStage<TransportEvent> stage;
   protected EventHandler<Exception> exceptionHandler;
 
-  AbstractNettyEventListener(
-      final ConcurrentMap<SocketAddress, LinkReference> addrToLinkRefMap,
-      final EStage<TransportEvent> stage) {
+  public AbstractNettyEventListener(
+          final ConcurrentMap<SocketAddress, LinkReference> addrToLinkRefMap,
+          final EStage<TransportEvent> stage) {
     this.addrToLinkRefMap = addrToLinkRefMap;
     this.stage = stage;
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
@@ -26,27 +26,27 @@ import java.util.concurrent.atomic.AtomicInteger;
  * A reference for a link.
  * When channel became active, LinkReference is created and mapped with remote address.
  */
-final class LinkReference {
+public final class LinkReference {
 
   private final AtomicInteger connectInProgress = new AtomicInteger(0);
   private Link<?> link;
 
-  LinkReference() {
+  public LinkReference() {
   }
 
-  LinkReference(final Link<?> link) {
+  public LinkReference(final Link<?> link) {
     this.link = link;
   }
 
-  synchronized Link<?> getLink() {
+  public synchronized Link<?> getLink() {
     return this.link;
   }
 
-  synchronized void setLink(final Link<?> link) {
+  public synchronized void setLink(final Link<?> link) {
     this.link = link;
   }
 
-  AtomicInteger getConnectInProgress() {
+  public AtomicInteger getConnectInProgress() {
     return this.connectInProgress;
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyEventListener.java
@@ -23,7 +23,7 @@ import io.netty.channel.ChannelHandlerContext;
 /**
  * Netty event listener.
  */
-interface NettyEventListener {
+public interface NettyEventListener {
 
   /**
    * Handles the message.

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/HttpMessagingTransportFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/HttpMessagingTransportFactory.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.remote.transport.netty.http;
+
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.wake.EStage;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.impl.SyncStage;
+import org.apache.reef.wake.remote.RemoteConfiguration;
+import org.apache.reef.wake.remote.address.LocalAddressProvider;
+import org.apache.reef.wake.remote.impl.TransportEvent;
+import org.apache.reef.wake.remote.ports.TcpPortProvider;
+import org.apache.reef.wake.remote.transport.Transport;
+import org.apache.reef.wake.remote.transport.TransportFactory;
+
+import javax.inject.Inject;
+
+/**
+ * Factory that creates a messaging transport.
+ */
+public final class HttpMessagingTransportFactory implements TransportFactory {
+
+  private final String localAddress;
+
+  @Inject
+  private HttpMessagingTransportFactory(final LocalAddressProvider localAddressProvider) {
+    this.localAddress = localAddressProvider.getLocalAddress();
+  }
+
+  /**
+   * Creates a transport.
+   *
+   * @param port          a listening port
+   * @param clientHandler a transport client side handler
+   * @param serverHandler a transport server side handler
+   * @param exHandler     a exception handler
+   */
+  @Override
+  public Transport newInstance(final int port,
+                               final EventHandler<TransportEvent> clientHandler,
+                               final EventHandler<TransportEvent> serverHandler,
+                               final EventHandler<Exception> exHandler) {
+
+    final Injector injector = Tang.Factory.getTang().newInjector();
+    injector.bindVolatileParameter(RemoteConfiguration.HostAddress.class, this.localAddress);
+    injector.bindVolatileParameter(RemoteConfiguration.Port.class, port);
+    injector.bindVolatileParameter(RemoteConfiguration.RemoteClientStage.class, new SyncStage<>(clientHandler));
+    injector.bindVolatileParameter(RemoteConfiguration.RemoteServerStage.class, new SyncStage<>(serverHandler));
+
+    final Transport transport;
+    try {
+      transport = injector.getInstance(NettyHttpMessagingTransport.class);
+      transport.registerErrorHandler(exHandler);
+      return transport;
+    } catch (final InjectionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Creates a transport.
+   *
+   * @param hostAddress   a host address
+   * @param port          a listening port
+   * @param clientStage   a client stage
+   * @param serverStage   a server stage
+   * @param numberOfTries a number of tries
+   * @param retryTimeout  a timeout for retry
+   */
+  @Override
+  public Transport newInstance(final String hostAddress,
+                               final int port,
+                               final EStage<TransportEvent> clientStage,
+                               final EStage<TransportEvent> serverStage,
+                               final int numberOfTries,
+                               final int retryTimeout) {
+    try {
+      TcpPortProvider tcpPortProvider = Tang.Factory.getTang().newInjector().getInstance(TcpPortProvider.class);
+      return newInstance(hostAddress, port, clientStage,
+              serverStage, numberOfTries, retryTimeout, tcpPortProvider);
+    } catch (final InjectionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Creates a transport.
+   *
+   * @param hostAddress     a host address
+   * @param port            a listening port
+   * @param clientStage     a client stage
+   * @param serverStage     a server stage
+   * @param numberOfTries   a number of tries
+   * @param retryTimeout    a timeout for retry
+   * @param tcpPortProvider a provider for TCP port
+   */
+  @Override
+  public Transport newInstance(final String hostAddress,
+                               final int port,
+                               final EStage<TransportEvent> clientStage,
+                               final EStage<TransportEvent> serverStage,
+                               final int numberOfTries,
+                               final int retryTimeout,
+                               final TcpPortProvider tcpPortProvider) {
+
+    final Injector injector = Tang.Factory.getTang().newInjector();
+    injector.bindVolatileParameter(RemoteConfiguration.HostAddress.class, hostAddress);
+    injector.bindVolatileParameter(RemoteConfiguration.Port.class, port);
+    injector.bindVolatileParameter(RemoteConfiguration.RemoteClientStage.class, clientStage);
+    injector.bindVolatileParameter(RemoteConfiguration.RemoteServerStage.class, serverStage);
+    injector.bindVolatileParameter(RemoteConfiguration.NumberOfTries.class, numberOfTries);
+    injector.bindVolatileParameter(RemoteConfiguration.RetryTimeout.class, retryTimeout);
+    injector.bindVolatileInstance(TcpPortProvider.class, tcpPortProvider);
+    try {
+      return injector.getInstance(NettyHttpMessagingTransport.class);
+    } catch (final InjectionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpChannelHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpChannelHandler.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.remote.transport.netty.http;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.util.ReferenceCountUtil;
+import org.apache.reef.wake.remote.transport.netty.NettyEventListener;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Netty channel handler for channel status(active/inactive) and incoming data.
+ */
+final class NettyHttpChannelHandler extends ChannelInboundHandlerAdapter {
+
+  private static final Logger LOG = Logger.getLogger(NettyHttpChannelHandler.class.getName());
+
+  private final String tag;
+  private final ChannelGroup channelGroup;
+  private final NettyEventListener listener;
+
+  /**
+   * Constructs a Netty channel handler.
+   *
+   * @param tag          tag string
+   * @param channelGroup the channel group
+   * @param listener     the Netty event listener
+   */
+  NettyHttpChannelHandler(
+      final String tag, final ChannelGroup channelGroup, final NettyEventListener listener) {
+    this.tag = tag;
+    this.channelGroup = channelGroup;
+    this.listener = listener;
+  }
+
+  /**
+   * Handle the incoming message: pass it to the listener.
+   *
+   * @param ctx the context object for this handler.
+   * @param msg the message.
+   * @throws Exception
+   */
+  @Override
+  public void channelRead(
+      final ChannelHandlerContext ctx, final Object msg) throws Exception {
+    try {
+      this.listener.channelRead(ctx, msg);
+    } finally {
+      ReferenceCountUtil.release(msg);
+    }
+  }
+
+  /**
+   * Flushes after channel read complete.
+   *
+   * @param ctx
+   * @throws Exception
+   */
+
+  @Override
+  public void channelReadComplete(final ChannelHandlerContext ctx) throws Exception {
+    ctx.flush();
+  }
+
+  /**
+   * Handles the channel active event.
+   *
+   * @param ctx the context object for this handler
+   * @throws Exception
+   */
+  @Override
+  public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+    this.channelGroup.add(ctx.channel());
+    this.listener.channelActive(ctx);
+    super.channelActive(ctx);
+  }
+
+  /**
+   * Handles the channel inactive event.
+   *
+   * @param ctx the context object for this handler
+   * @throws Exception
+   */
+  @Override
+  public void channelInactive(final ChannelHandlerContext ctx) throws Exception {
+    this.listener.channelInactive(ctx);
+    super.channelInactive(ctx);
+  }
+
+  /**
+   * Handles the exception event.
+   *
+   * @param ctx   the context object for this handler
+   * @param cause the cause
+   * @throws Exception
+   */
+  @Override
+  public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) {
+    final Channel channel = ctx.channel();
+
+    LOG.log(Level.INFO, "Unexpected exception from downstream. channel: {0} local: {1} remote: {2}",
+        new Object[]{channel, channel.localAddress(), channel.remoteAddress()});
+    LOG.log(Level.WARNING, "Unexpected exception from downstream.", cause);
+    channel.close();
+    this.listener.exceptionCaught(ctx, cause);
+  }
+
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpChannelHandlerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpChannelHandlerFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.remote.transport.netty.http;
+
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.group.ChannelGroup;
+import org.apache.reef.wake.remote.transport.netty.NettyChannelHandlerFactory;
+import org.apache.reef.wake.remote.transport.netty.NettyEventListener;
+
+/**
+ * Default Netty channel handler factory.
+ */
+final class NettyHttpChannelHandlerFactory implements NettyChannelHandlerFactory {
+
+  private final String tag;
+  private final ChannelGroup group;
+  private final NettyEventListener listener;
+
+  NettyHttpChannelHandlerFactory(
+      final String tag, final ChannelGroup group, final NettyEventListener listener) {
+    this.tag = tag;
+    this.group = group;
+    this.listener = listener;
+  }
+
+  /**
+   * Creates a Netty channel handler.
+   *
+   * @return a simple channel upstream handler.
+   */
+  @Override
+  public ChannelInboundHandlerAdapter createChannelInboundHandler() {
+    return new NettyHttpChannelHandler(this.tag, this.group, this.listener);
+  }
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpChannelInitializer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpChannelInitializer.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.remote.transport.netty.http;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.*;
+import io.netty.handler.ssl.SslContext;
+import org.apache.reef.wake.remote.transport.netty.NettyChannelHandlerFactory;
+
+/**
+ * Netty Http channel initializer for Transport.
+ */
+class NettyHttpChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+  static final int TYPE_SERVER = 0;
+  static final int TYPE_CLIENT = 1;
+
+  private final NettyChannelHandlerFactory handlerFactory;
+  private final SslContext sslContext;
+  private final int type;
+
+  NettyHttpChannelInitializer(
+          final NettyChannelHandlerFactory handlerFactory,
+          final SslContext sslContext,
+          final int type) {
+    if(type != TYPE_SERVER && type != TYPE_CLIENT){
+      throw new IllegalArgumentException("Invalid type of channel");
+    }
+    this.handlerFactory = handlerFactory;
+    this.sslContext = sslContext;
+    this.type = type;
+  }
+
+  @Override
+  protected void initChannel(final SocketChannel ch) throws Exception {
+    if(sslContext != null) {
+      ch.pipeline().addLast(sslContext.newHandler(ch.alloc()));
+    }
+    if(type == TYPE_SERVER) {
+      // Init channel for server
+      ch.pipeline()
+          .addLast("codec", new HttpServerCodec())
+          .addLast("requestDecoder", new HttpRequestDecoder())
+          .addLast("responseEncoder", new HttpResponseEncoder());
+    } else if (type == TYPE_CLIENT) {
+      // Init channel for client
+      ch.pipeline()
+          .addLast("codec", new HttpClientCodec())
+          .addLast("decompressor", new HttpContentDecompressor());
+    }
+    ch.pipeline().addLast("handler", handlerFactory.createChannelInboundHandler());
+  }
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpClientEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpClientEventListener.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.remote.transport.netty.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.CharsetUtil;
+import org.apache.reef.wake.EStage;
+import org.apache.reef.wake.remote.impl.TransportEvent;
+import org.apache.reef.wake.remote.transport.netty.AbstractNettyEventListener;
+import org.apache.reef.wake.remote.transport.netty.LinkReference;
+
+import java.net.SocketAddress;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A Netty event listener for server.
+ */
+final class NettyHttpClientEventListener extends AbstractNettyEventListener {
+
+  private static final Logger LOG = Logger.getLogger(NettyHttpClientEventListener.class.getName());
+  private StringBuilder buf = new StringBuilder();
+
+  NettyHttpClientEventListener(
+      final ConcurrentMap<SocketAddress, LinkReference> addrToLinkRefMap,
+      final EStage<TransportEvent> stage) {
+    super(addrToLinkRefMap, stage);
+  }
+
+  @Override
+  public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+    if (msg instanceof HttpResponse) {
+      System.out.println("CLIENT : IT IS HTTP RESPONSE");
+    } else if (msg instanceof HttpContent) {
+      System.out.println("CLIENT : It is HttpContent");
+      HttpContent httpContent = (HttpContent) msg;
+      ByteBuf content = httpContent.content();
+      if (content.isReadable()) {
+        buf.append("CONTENT: ");
+        buf.append(content.toString(CharsetUtil.UTF_8));
+        buf.append("\r\n");
+      }
+
+      if (msg instanceof LastHttpContent) {
+        final Channel channel = ctx.channel();
+        byte[] message = new byte[content.readableBytes()];
+        content.readBytes(message);
+        if (LOG.isLoggable(Level.FINEST)) {
+          LOG.log(Level.FINEST, "MessageEvent: local: {0} remote: {1} :: {2}", new Object[]{
+                  channel.localAddress(), channel.remoteAddress(), buf});
+        }
+
+        if (message.length > 0) {
+          // send to the dispatch stage
+          this.stage.onNext(this.getTransportEvent(message, channel));
+        }
+      }
+    } else {
+      LOG.log(Level.SEVERE, "Unknown type of message received: {0}", msg);
+    }
+
+  }
+
+  @Override
+  public void channelActive(final ChannelHandlerContext ctx) {
+    // noop
+    LOG.log(Level.FINEST, "{0}", ctx);
+  }
+
+  @Override
+  protected TransportEvent getTransportEvent(final byte[] message, final Channel channel) {
+    return new TransportEvent(message, channel.localAddress(), channel.remoteAddress());
+  }
+
+  @Override
+  protected void exceptionCleanup(final ChannelHandlerContext ctx, final Throwable cause) {
+    this.closeChannel(ctx.channel());
+  }
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpLink.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpLink.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.remote.transport.netty.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.handler.codec.http.*;
+import org.apache.reef.wake.remote.Encoder;
+import org.apache.reef.wake.remote.transport.Link;
+import org.apache.reef.wake.remote.transport.LinkListener;
+
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Link implementation with Netty Http.
+ *
+ * If you set a {@code LinkListener<T>}, it keeps message until writeAndFlush operation completes
+ * and notifies whether the sent message transferred successfully through the listener.
+ */
+public class NettyHttpLink<T> implements Link<T> {
+
+  public static final int INT_SIZE = Integer.SIZE / Byte.SIZE;
+
+  private static final Logger LOG = Logger.getLogger(NettyHttpLink.class.getName());
+
+  private final Channel channel;
+  private final Encoder<? super T> encoder;
+  private final LinkListener<? super T> listener;
+  private final URI uri;
+
+  /**
+   * Constructs a link.
+   *
+   * @param channel the channel
+   * @param encoder the encoder
+   */
+  public NettyHttpLink(final Channel channel, final Encoder<? super T> encoder) {
+    this(channel, encoder, null, URI.create("http://127.0.0.1"));
+  }
+
+  /**
+   * Constructs a link.
+   *
+   * @param channel  the channel
+   * @param encoder  the encoder
+   * @param listener the link listener
+   * @param uri the URI
+   */
+  public NettyHttpLink(
+          final Channel channel,
+          final Encoder<? super T> encoder,
+          final LinkListener<? super T> listener,
+          final URI uri) {
+    this.channel = channel;
+    this.encoder = encoder;
+    this.listener = listener;
+    this.uri = uri;
+  }
+
+  /**
+   * Writes the message to this link via HTTP.
+   *
+   * @param message the message
+   */
+  @Override
+  public void write(final T message) {
+
+    try {
+      LOG.log(Level.FINE, "write {0} :: {1}", new Object[] {channel, message});
+      FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, uri.getRawPath());
+      request.headers().set(HttpHeaders.Names.HOST, uri.getHost());
+      request.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+      request.headers().set(HttpHeaders.Names.ACCEPT_ENCODING, HttpHeaders.Values.GZIP);
+      request.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/wake-transport");
+      ByteBuf buf = Unpooled.copiedBuffer(encoder.encode(message));
+      request.headers().set(HttpHeaders.Names.CONTENT_LENGTH, buf.readableBytes());
+      request.content().clear().writeBytes(buf);
+      final ChannelFuture future = channel.writeAndFlush(request);
+      future.sync();
+      if (listener !=  null) {
+        future.addListener(new NettyHttpChannelFutureListener<>(message, listener));
+      }
+    } catch (InterruptedException ex) {
+      LOG.log(Level.SEVERE, "Cannot send request to " + uri.getHost(), ex);
+    }
+  }
+
+  /**
+   * Gets a local address of the link.
+   *
+   * @return a local socket address
+   */
+  @Override
+  public SocketAddress getLocalAddress() {
+    return channel.localAddress();
+  }
+
+  /**
+   * Gets a remote address of the link.
+   *
+   * @return a remote socket address
+   */
+  @Override
+  public SocketAddress getRemoteAddress() {
+    return channel.remoteAddress();
+  }
+
+  @Override
+  public String toString() {
+    return "NettyHttpLink: " + channel; // Channel has good .toString() implementation
+  }
+}
+
+class NettyHttpChannelFutureListener<T> implements ChannelFutureListener {
+
+  private final T message;
+  private LinkListener<T> listener;
+
+  NettyHttpChannelFutureListener(final T message, final LinkListener<T> listener) {
+    this.message = message;
+    this.listener = listener;
+  }
+
+  @Override
+  public void operationComplete(final ChannelFuture channelFuture) throws Exception {
+    if (channelFuture.isSuccess()) {
+      listener.onSuccess(message);
+    } else {
+      listener.onException(channelFuture.cause(), channelFuture.channel().remoteAddress(), message);
+    }
+  }
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpMessagingTransport.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.remote.transport.netty.http;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.ChannelGroupFuture;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GlobalEventExecutor;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.EStage;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.impl.DefaultThreadFactory;
+import org.apache.reef.wake.remote.Encoder;
+import org.apache.reef.wake.remote.RemoteConfiguration;
+import org.apache.reef.wake.remote.address.LocalAddressProvider;
+import org.apache.reef.wake.remote.exception.RemoteRuntimeException;
+import org.apache.reef.wake.remote.impl.TransportEvent;
+import org.apache.reef.wake.remote.ports.TcpPortProvider;
+import org.apache.reef.wake.remote.transport.Link;
+import org.apache.reef.wake.remote.transport.LinkListener;
+import org.apache.reef.wake.remote.transport.Transport;
+import org.apache.reef.wake.remote.transport.exception.TransportRuntimeException;
+import org.apache.reef.wake.remote.transport.netty.LinkReference;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.apache.reef.wake.remote.transport.netty.http.NettyHttpChannelInitializer.TYPE_CLIENT;
+import static org.apache.reef.wake.remote.transport.netty.http.NettyHttpChannelInitializer.TYPE_SERVER;
+
+/**
+ * Messaging transport implementation with Netty HTTP.
+ */
+public final class NettyHttpMessagingTransport implements Transport {
+
+  /**
+   * Indicates a hostname that isn't set or known.
+   */
+  public static final String UNKNOWN_HOST_NAME = "##UNKNOWN##";
+
+  private static final String CLASS_NAME = NettyHttpMessagingTransport.class.getSimpleName();
+
+  private static final Logger LOG = Logger.getLogger(CLASS_NAME);
+
+  private static final int SERVER_BOSS_NUM_THREADS = 3;
+  private static final int SERVER_WORKER_NUM_THREADS = 20;
+  private static final int CLIENT_WORKER_NUM_THREADS = 10;
+
+  private final ConcurrentMap<SocketAddress, LinkReference> addrToLinkRefMap = new ConcurrentHashMap<>();
+
+  private final EventLoopGroup clientWorkerGroup;
+  private final EventLoopGroup serverBossGroup;
+  private final EventLoopGroup serverWorkerGroup;
+
+  private final Bootstrap clientBootstrap;
+  private final ServerBootstrap serverBootstrap;
+  private final Channel acceptor;
+
+  private final ChannelGroup clientChannelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+  private final ChannelGroup serverChannelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+
+  private final int serverPort;
+  private final SocketAddress localAddress;
+
+  private final boolean ssl = System.getProperty("ssl") != null;
+  private final URI uri;
+
+  private final NettyHttpClientEventListener clientEventListener;
+  private final NettyHttpServerEventListener serverEventListener;
+
+  private final int numberOfTries;
+  private final int retryTimeout;
+
+  /**
+   * Constructs a messaging transport.
+   *
+   * @param hostAddress   the server host address
+   * @param port          the server listening port; when it is 0, randomly assign a port number
+   * @param clientStage   the client-side stage that handles transport events
+   * @param serverStage   the server-side stage that handles transport events
+   * @param numberOfTries the number of tries of connection
+   * @param retryTimeout  the timeout of reconnection
+   * @param tcpPortProvider  gives an iterator that produces random tcp ports in a range
+   */
+  @Inject
+  private NettyHttpMessagingTransport(
+      @Parameter(RemoteConfiguration.HostAddress.class) final String hostAddress,
+      @Parameter(RemoteConfiguration.Port.class) final int port,
+      @Parameter(RemoteConfiguration.RemoteClientStage.class) final EStage<TransportEvent> clientStage,
+      @Parameter(RemoteConfiguration.RemoteServerStage.class) final EStage<TransportEvent> serverStage,
+      @Parameter(RemoteConfiguration.NumberOfTries.class) final int numberOfTries,
+      @Parameter(RemoteConfiguration.RetryTimeout.class) final int retryTimeout,
+      final TcpPortProvider tcpPortProvider,
+      final LocalAddressProvider localAddressProvider) {
+
+    int p = port;
+    if (p < 0) {
+      throw new RemoteRuntimeException("Invalid server port: " + p);
+    }
+
+    final String host = UNKNOWN_HOST_NAME.equals(hostAddress) ? localAddressProvider.getLocalAddress() : hostAddress;
+
+    final SslContext sslContextClient;
+    final SslContext sslContextServer;
+    if(ssl){
+      try {
+        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        sslContextClient = SslContext.newServerContext(ssc.certificate(), ssc.privateKey());
+        sslContextServer = SslContext.newClientContext();
+        LOG.log(Level.FINE, "SSL context created");
+      } catch (Exception ex) {
+        final RuntimeException transportException =
+                new TransportRuntimeException("Could create SSL Context", ex);
+        LOG.log(Level.SEVERE, "Cannot create SSL Context", ex);
+        throw transportException;
+      }
+    } else {
+      LOG.log(Level.FINE, "System property 'ssl' is not set");
+      sslContextClient = null;
+      sslContextServer = null;
+    }
+
+    this.uri = URI.create(ssl ? "https://" : "http://" + hostAddress);
+
+    this.numberOfTries = numberOfTries;
+    this.retryTimeout = retryTimeout;
+    this.clientEventListener = new NettyHttpClientEventListener(this.addrToLinkRefMap, clientStage);
+    this.serverEventListener = new NettyHttpServerEventListener(this.addrToLinkRefMap, serverStage, this.uri);
+
+    this.serverBossGroup = new NioEventLoopGroup(SERVER_BOSS_NUM_THREADS,
+        new DefaultThreadFactory(CLASS_NAME + ":ServerBoss"));
+    this.serverWorkerGroup = new NioEventLoopGroup(SERVER_WORKER_NUM_THREADS,
+        new DefaultThreadFactory(CLASS_NAME + ":ServerWorker"));
+    this.clientWorkerGroup = new NioEventLoopGroup(CLIENT_WORKER_NUM_THREADS,
+        new DefaultThreadFactory(CLASS_NAME + ":ClientWorker"));
+
+    this.clientBootstrap = new Bootstrap();
+    this.clientBootstrap.group(this.clientWorkerGroup)
+        .channel(NioSocketChannel.class)
+        .handler(new NettyHttpChannelInitializer(new NettyHttpChannelHandlerFactory("client",
+            this.clientChannelGroup, this.clientEventListener), sslContextClient, TYPE_CLIENT))
+        .option(ChannelOption.SO_REUSEADDR, true)
+        .option(ChannelOption.SO_KEEPALIVE, true);
+
+    this.serverBootstrap = new ServerBootstrap();
+    this.serverBootstrap.group(this.serverBossGroup, this.serverWorkerGroup)
+        .channel(NioServerSocketChannel.class)
+        .childHandler(new NettyHttpChannelInitializer(new NettyHttpChannelHandlerFactory("server",
+            this.serverChannelGroup, this.serverEventListener), sslContextServer, TYPE_SERVER))
+        .option(ChannelOption.SO_BACKLOG, 128)
+        .option(ChannelOption.SO_REUSEADDR, true)
+        .childOption(ChannelOption.SO_KEEPALIVE, true);
+
+    LOG.log(Level.FINE, "Binding to {0}", p);
+
+    Channel acceptorFound = null;
+    try {
+      if (p > 0) {
+        acceptorFound = this.serverBootstrap.bind(new InetSocketAddress(host, p)).sync().channel();
+      } else {
+        final Iterator<Integer> ports = tcpPortProvider.iterator();
+        while (acceptorFound == null) {
+          if (!ports.hasNext()) {
+            throw new IllegalStateException("tcpPortProvider cannot find a free port.");
+          }
+          p = ports.next();
+          LOG.log(Level.FINEST, "Try port {0}", p);
+          try {
+            acceptorFound = this.serverBootstrap.bind(new InetSocketAddress(host, p)).sync().channel();
+          } catch (final Exception ex) {
+            if (ex instanceof BindException) {
+              LOG.log(Level.FINEST, "The port {0} is already bound. Try again", p);
+            } else {
+              throw ex;
+            }
+          }
+        }
+      }
+    } catch (final IllegalStateException ex) {
+      final RuntimeException transportException =
+                new TransportRuntimeException("tcpPortProvider failed to return free ports.", ex);
+      LOG.log(Level.SEVERE, "Cannot find a free port with " + tcpPortProvider, transportException);
+
+      this.clientWorkerGroup.shutdownGracefully();
+      this.serverBossGroup.shutdownGracefully();
+      this.serverWorkerGroup.shutdownGracefully();
+      throw transportException;
+
+    } catch (final Exception ex) {
+      final RuntimeException transportException =
+          new TransportRuntimeException("Cannot bind to port " + p, ex);
+      LOG.log(Level.SEVERE, "Cannot bind to port " + p, ex);
+
+      this.clientWorkerGroup.shutdownGracefully();
+      this.serverBossGroup.shutdownGracefully();
+      this.serverWorkerGroup.shutdownGracefully();
+      throw transportException;
+    }
+    this.acceptor = acceptorFound;
+    this.serverPort = p;
+    this.localAddress = new InetSocketAddress(host, this.serverPort);
+
+    LOG.log(Level.FINE, "Starting netty transport socket address: {0}", this.localAddress);
+  }
+
+  /**
+   * Closes all channels and releases all resources.
+   */
+  @Override
+  public void close() {
+
+    LOG.log(Level.FINE, "Closing netty transport socket address: {0}", this.localAddress);
+
+    final ChannelGroupFuture clientChannelGroupFuture = this.clientChannelGroup.close();
+    final ChannelGroupFuture serverChannelGroupFuture = this.serverChannelGroup.close();
+    final ChannelFuture acceptorFuture = this.acceptor.close();
+
+    final ArrayList<Future> eventLoopGroupFutures = new ArrayList<>(3);
+    eventLoopGroupFutures.add(this.clientWorkerGroup.shutdownGracefully());
+    eventLoopGroupFutures.add(this.serverBossGroup.shutdownGracefully());
+    eventLoopGroupFutures.add(this.serverWorkerGroup.shutdownGracefully());
+
+    clientChannelGroupFuture.awaitUninterruptibly();
+    serverChannelGroupFuture.awaitUninterruptibly();
+
+    try {
+      acceptorFuture.sync();
+    } catch (final Exception ex) {
+      LOG.log(Level.SEVERE, "Error closing the acceptor channel for " + this.localAddress, ex);
+    }
+
+    for (final Future eventLoopGroupFuture : eventLoopGroupFutures) {
+      eventLoopGroupFuture.awaitUninterruptibly();
+    }
+
+    LOG.log(Level.FINE, "Closing netty transport socket address: {0} done", this.localAddress);
+  }
+
+  /**
+   * Returns a link for the remote address if cached; otherwise opens, caches and returns.
+   * When it opens a link for the remote address, only one attempt for the address is made at a given time
+   *
+   * @param remoteAddr the remote socket address
+   * @param encoder    the encoder
+   * @param listener   the link listener
+   * @return a link associated with the address
+   */
+  @Override
+  public <T> Link<T> open(final SocketAddress remoteAddr, final Encoder<? super T> encoder,
+                          final LinkListener<? super T> listener) throws IOException {
+
+    Link<T> link = null;
+
+    for (int i = 0; i <= this.numberOfTries; ++i) {
+      LinkReference linkRef = this.addrToLinkRefMap.get(remoteAddr);
+
+      if (linkRef != null) {
+        link = (Link<T>) linkRef.getLink();
+        if (LOG.isLoggable(Level.FINE)) {
+          LOG.log(Level.FINE, "Link {0} for {1} found", new Object[]{link, remoteAddr});
+        }
+        if (link != null) {
+          return link;
+        }
+      }
+      
+      if (i == this.numberOfTries) {
+        // Connection failure 
+        throw new ConnectException("Connection to " + remoteAddr + " refused");
+      }
+
+      LOG.log(Level.FINE, "No cached link for {0} thread {1}",
+          new Object[]{remoteAddr, Thread.currentThread()});
+
+      // no linkRef
+      final LinkReference newLinkRef = new LinkReference();
+      final LinkReference prior = this.addrToLinkRefMap.putIfAbsent(remoteAddr, newLinkRef);
+      final AtomicInteger flag = prior != null ?
+          prior.getConnectInProgress() : newLinkRef.getConnectInProgress();
+
+      synchronized (flag) {
+        if (!flag.compareAndSet(0, 1)) {
+          while (flag.get() == 1) {
+            try {
+              flag.wait();
+            } catch (final InterruptedException ex) {
+              LOG.log(Level.WARNING, "Wait interrupted", ex);
+            }
+          }
+        }
+      }
+
+      linkRef = this.addrToLinkRefMap.get(remoteAddr);
+      link = (Link<T>) linkRef.getLink();
+
+      if (link != null) {
+        return link;
+      }
+
+      ChannelFuture connectFuture = null;
+      try {
+        connectFuture = this.clientBootstrap.connect(remoteAddr);
+        connectFuture.syncUninterruptibly();
+
+        link = new NettyHttpLink<>(connectFuture.channel(), encoder, listener, this.uri);
+        linkRef.setLink(link);
+
+        synchronized (flag) {
+          flag.compareAndSet(1, 2);
+          flag.notifyAll();
+        }
+        break;
+      } catch (final Exception e) {
+        if (e.getClass().getSimpleName().compareTo("ConnectException") == 0) {
+          LOG.log(Level.WARNING, "Connection refused. Retry {0} of {1}",
+              new Object[]{i + 1, this.numberOfTries});
+          synchronized (flag) {
+            flag.compareAndSet(1, 0);
+            flag.notifyAll();
+          }
+
+          if (i < this.numberOfTries) {
+            try {
+              Thread.sleep(retryTimeout);
+            } catch (final InterruptedException interrupt) {
+              LOG.log(Level.WARNING, "Thread {0} interrupted while sleeping", Thread.currentThread());
+            }
+          }
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    return link;
+  }
+
+  /**
+   * Returns a link for the remote address if already cached; otherwise, returns null.
+   *
+   * @param remoteAddr the remote address
+   * @return a link if already cached; otherwise, null
+   */
+  public <T> Link<T> get(final SocketAddress remoteAddr) {
+    final LinkReference linkRef = this.addrToLinkRefMap.get(remoteAddr);
+    return linkRef != null ? (Link<T>) linkRef.getLink() : null;
+  }
+
+  /**
+   * Gets a server local socket address of this transport.
+   *
+   * @return a server local socket address
+   */
+  @Override
+  public SocketAddress getLocalAddress() {
+    return this.localAddress;
+  }
+
+  /**
+   * Gets a server listening port of this transport.
+   *
+   * @return a listening port number
+   */
+  @Override
+  public int getListeningPort() {
+    return this.serverPort;
+  }
+
+  /**
+   * Registers the exception event handler.
+   *
+   * @param handler the exception event handler
+   */
+  @Override
+  public void registerErrorHandler(final EventHandler<Exception> handler) {
+    this.clientEventListener.registerErrorHandler(handler);
+    this.serverEventListener.registerErrorHandler(handler);
+  }
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpServerEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/NettyHttpServerEventListener.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.remote.transport.netty.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.*;
+import io.netty.util.CharsetUtil;
+import org.apache.reef.wake.EStage;
+import org.apache.reef.wake.remote.impl.ByteCodec;
+import org.apache.reef.wake.remote.impl.TransportEvent;
+import org.apache.reef.wake.remote.transport.netty.AbstractNettyEventListener;
+import org.apache.reef.wake.remote.transport.netty.ByteEncoder;
+import org.apache.reef.wake.remote.transport.netty.LinkReference;
+import org.apache.reef.wake.remote.transport.netty.LoggingLinkListener;
+
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+
+/**
+ * A Netty event listener for server side.
+ */
+final class NettyHttpServerEventListener extends AbstractNettyEventListener {
+
+  private HttpRequest httpRequest;
+  private final StringBuilder buf = new StringBuilder();
+  private final URI uri;
+
+  NettyHttpServerEventListener(
+      final ConcurrentMap<SocketAddress, LinkReference> addrToLinkRefMap,
+      final EStage<TransportEvent> stage,
+      final URI uri) {
+    super(addrToLinkRefMap, stage);
+    this.uri = uri;
+  }
+
+
+  @Override
+  public void channelActive(final ChannelHandlerContext ctx) {
+    final Channel channel = ctx.channel();
+
+    if (LOG.isLoggable(Level.FINEST)) {
+      LOG.log(Level.FINEST, "Channel active. key: {0}", channel.remoteAddress());
+    }
+
+    this.addrToLinkRefMap.putIfAbsent(
+        channel.remoteAddress(), new LinkReference(new NettyHttpLink<>(
+            channel, new ByteCodec(), new LoggingLinkListener<byte[]>(), uri)));
+
+    LOG.log(Level.FINER, "Add connected channel ref: {0}", this.addrToLinkRefMap.get(channel.remoteAddress()));
+
+  }
+
+  @Override
+  public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+    final HttpHeaders headers;
+    final HttpRequest request;
+    if(msg instanceof HttpRequest) {
+      LOG.log(Level.FINEST, "HttpRequest received");
+      request = (HttpRequest) msg;
+      this.httpRequest = request;
+      headers = request.headers();
+      if (!headers.isEmpty()) {
+        for (Map.Entry<String, String> h: headers) {
+          CharSequence key = h.getKey();
+          CharSequence value = h.getValue();
+          buf.append("HEADER: ").append(key).append(" = ").append(value).append("\r\n");
+        }
+        buf.append("\r\n");
+      }
+      appendDecoderResult(buf, request);
+    } else if (msg instanceof HttpContent) {
+      LOG.log(Level.FINEST, "HttpContent received");
+      HttpContent httpContent = (HttpContent) msg;
+      ByteBuf content = httpContent.content();
+      if (content.isReadable()) {
+        buf.append("CONTENT: ");
+        buf.append(content.toString(CharsetUtil.UTF_8));
+        buf.append("\r\n");
+        appendDecoderResult(buf, this.httpRequest);
+      }
+
+      if (msg instanceof LastHttpContent) {
+        buf.append("END OF CONTENT\r\n");
+        LastHttpContent trailer = (LastHttpContent) msg;
+        if (!trailer.trailingHeaders().isEmpty()) {
+          buf.append("\r\n");
+          for (CharSequence name: trailer.trailingHeaders().names()) {
+            for (CharSequence value: trailer.trailingHeaders().getAll(name)) {
+              buf.append("TRAILING HEADER: ");
+              buf.append(name).append(" = ").append(value).append("\r\n");
+            }
+          }
+          buf.append("\r\n");
+        }
+
+        final Channel channel = ctx.channel();
+        byte[] message = new byte[content.readableBytes()];
+        content.readBytes(message);
+        if (LOG.isLoggable(Level.FINEST)) {
+          LOG.log(Level.FINEST, "MessageEvent: local: {0} remote: {1} :: {2}", new Object[]{
+                  channel.localAddress(), channel.remoteAddress(), content});
+        }
+
+        if (message.length > 0) {
+          // send to the dispatch stage
+          this.stage.onNext(this.getTransportEvent(message, channel));
+        }
+      }
+    } else {
+      LOG.log(Level.SEVERE, "Unknown type of message received: {0}", msg);
+    }
+    LOG.log(Level.FINEST, buf.toString());
+  }
+
+  private static void appendDecoderResult(final StringBuilder buf, final HttpObject o) {
+    DecoderResult result = o.getDecoderResult();
+    if (result.isSuccess()) {
+      return;
+    }
+
+    buf.append(".. WITH DECODER FAILURE: ");
+    buf.append(result.cause());
+    buf.append("\r\n");
+  }
+
+
+
+  @Override
+  protected TransportEvent getTransportEvent(final byte[] message, final Channel channel) {
+    return new TransportEvent(message, new NettyHttpLink<>(channel, new ByteEncoder()));
+  }
+
+  @Override
+  protected void exceptionCleanup(final ChannelHandlerContext ctx, final Throwable cause) {
+    // noop
+  }
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/http/package-info.java
@@ -16,20 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.wake.remote.transport.netty;
-
-import io.netty.channel.ChannelInboundHandlerAdapter;
-
-
 /**
- * Factory that creates a Netty channel handler.
+ * Wake's remote transportation by HTTP.
  */
-public interface NettyChannelHandlerFactory {
-
-  /**
-   * Creates a channel inbound handler.
-   *
-   * @return a channel inbound handler adapter
-   */
-  ChannelInboundHandlerAdapter createChannelInboundHandler();
-}
+package org.apache.reef.wake.remote.transport.netty.http;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportHttpTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportHttpTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.test.remote;
+
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.wake.EStage;
+import org.apache.reef.wake.impl.LoggingUtils;
+import org.apache.reef.wake.impl.TimerStage;
+import org.apache.reef.wake.remote.Codec;
+import org.apache.reef.wake.remote.address.LocalAddressProvider;
+import org.apache.reef.wake.remote.impl.ObjectSerializableCodec;
+import org.apache.reef.wake.remote.impl.TransportEvent;
+import org.apache.reef.wake.remote.transport.Link;
+import org.apache.reef.wake.remote.transport.Transport;
+import org.apache.reef.wake.remote.transport.TransportFactory;
+import org.apache.reef.wake.remote.transport.netty.http.HttpMessagingTransportFactory;
+import org.apache.reef.wake.remote.transport.netty.LoggingLinkListener;
+import org.apache.reef.wake.test.util.Monitor;
+import org.apache.reef.wake.test.util.TimeoutHandler;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+
+
+/**
+ * Tests for Transport via http.
+ */
+public class TransportHttpTest {
+  private final LocalAddressProvider localAddressProvider;
+  private final TransportFactory tpFactory;
+
+  public TransportHttpTest() throws InjectionException {
+    final Injector injector = Tang.Factory.getTang().newInjector();
+    this.localAddressProvider = injector.getInstance(LocalAddressProvider.class);
+    this.tpFactory = injector.getInstance(HttpMessagingTransportFactory.class);
+  }
+
+  private static final String LOG_PREFIX = "TEST ";
+  @Rule
+  public TestName name = new TestName();
+
+  @Test
+  public void testHttpTransportString() throws Exception {
+    System.out.println(LOG_PREFIX + name.getMethodName());
+    LoggingUtils.setLoggingLevel(Level.INFO);
+
+    final Monitor monitor = new Monitor();
+    final TimerStage timer = new TimerStage(new TimeoutHandler(monitor), 2000, 2000);
+
+    final int expected = 2;
+
+    final String hostAddress = localAddressProvider.getLocalAddress();
+
+    // Codec<String>
+    final ReceiverStage<String> stage =
+        new ReceiverStage<>(new ObjectSerializableCodec<String>(), monitor, expected);
+    final Transport transport = tpFactory.newInstance(hostAddress, 0, stage, stage, 1, 10000);
+    final int port = transport.getListeningPort();
+
+    // sending side
+    final Link<String> link = transport.open(
+        new InetSocketAddress(hostAddress, port),
+        new ObjectSerializableCodec<String>(),
+        new LoggingLinkListener<String>());
+    link.write(new String("hello1"));
+    link.write(new String("hello2"));
+
+    monitor.mwait();
+    transport.close();
+    timer.close();
+
+    Assert.assertEquals(expected, stage.getCount());
+  }
+
+  @Test
+  public void testHttpTransportTestEvent() throws Exception {
+    System.out.println(LOG_PREFIX + name.getMethodName());
+    LoggingUtils.setLoggingLevel(Level.INFO);
+
+    final Monitor monitor = new Monitor();
+    final TimerStage timer = new TimerStage(new TimeoutHandler(monitor), 2000, 2000);
+
+    final int expected = 2;
+    final String hostAddress = localAddressProvider.getLocalAddress();
+
+    // Codec<TestEvent>
+    final ReceiverStage<TestEvent> stage =
+        new ReceiverStage<>(new ObjectSerializableCodec<TestEvent>(), monitor, expected);
+    final Transport transport = tpFactory.newInstance(hostAddress, 0, stage, stage, 1, 10000);
+    final int port = transport.getListeningPort();
+
+    // sending side
+    final Link<TestEvent> link = transport.open(
+        new InetSocketAddress(hostAddress, port),
+        new ObjectSerializableCodec<TestEvent>(),
+        new LoggingLinkListener<TestEvent>());
+    link.write(new TestEvent("hello1", 0.0));
+    link.write(new TestEvent("hello2", 1.0));
+
+    monitor.mwait();
+    transport.close();
+    timer.close();
+
+    Assert.assertEquals(expected, stage.getCount());
+  }
+
+  class ReceiverStage<T> implements EStage<TransportEvent> {
+
+    private final Codec<T> codec;
+    private final Monitor monitor;
+    private final int expected;
+    private AtomicInteger count = new AtomicInteger(0);
+
+    ReceiverStage(final Codec<T> codec, final Monitor monitor, final int expected) {
+      this.codec = codec;
+      this.monitor = monitor;
+      this.expected = expected;
+    }
+
+    int getCount() {
+      return count.get();
+    }
+
+    @Override
+    public void onNext(final TransportEvent value) {
+      codec.decode(value.getData());
+
+      if (count.incrementAndGet() == expected) {
+        monitor.mnotify();
+      }
+    }
+
+    @Override
+    public void close() throws Exception {
+    }
+
+  }
+
+}


### PR DESCRIPTION
Additional implementation for Wake via HTTP
* new package `org.apache.reef.wake.remote.transport.netty.http`
* followed default implementation of netty
* Added TransportHttpTest
* currently tested only for HTTP

JIRA:
[REEF-362](https://issues.apache.org/jira/browse/REEF-362)

Pull Request
This closes #