### PR TITLE
[REEF-1841] Adding nuget dependency for REEF client

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.nuspec
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.nuspec
@@ -34,9 +34,11 @@ under the License.
       <dependency id="Org.Apache.REEF.Common" version="$version$" />
       <dependency id="Org.Apache.REEF.Network" version="$version$" />
       <dependency id="Org.Apache.REEF.Driver" version="$version$" />
+      <dependency id="Org.Apache.REEF.Evaluator" version="$version$" />
       <dependency id="Org.Apache.REEF.Examples" version="$version$" />
       <dependency id="Rx-Core" version="2.2.5" />
       <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="TransientFaultHandling.Core" version="5.1.1209.1" />
     </dependencies>
   </metadata>
   <files>

--- a/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.nuspec
+++ b/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.nuspec
@@ -31,6 +31,7 @@ under the License.
     <dependencies>
       <dependency id="protobuf-net" version="2.0.0.668" />
       <dependency id="Rx-Core" version="2.2.5" />
+      <dependency id="TransientFaultHandling.Core" version="5.1.1209.1" />
       <dependency id="Org.Apache.REEF.Utilities" version="$version$" />
       <dependency id="Org.Apache.REEF.Tang" version="$version$" />
     </dependencies>


### PR DESCRIPTION
Adding TransientFaultHandling.Core and Evaluator NuGet as dependency of REEF.Client spec.
REEF client reference both in the project

JIRA: [REEF-1841](https://issues.apache.org/jira/browse/REEF-1841)
This closes #