### PR TITLE
[REEF-1842]  Making IMRU task and input data association deterministic

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ActiveContextManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ActiveContextManager.cs
@@ -35,7 +35,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
     internal sealed class ActiveContextManager : IDisposable, IObservable<IEnumerable<IActiveContext>>
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(ActiveContextManager));
-        private readonly IDictionary<string, IActiveContext> _activeContexts = new Dictionary<string, IActiveContext>();
+        private readonly IDictionary<string, IActiveContext> _activeContexts = new SortedDictionary<string, IActiveContext>();
         private readonly int _totalExpectedContexts;
         private IObserver<IEnumerable<IActiveContext>> _activeContextObserver;
 
@@ -112,7 +112,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
 
             if (AreAllContextsReceived && _activeContextObserver != null)
             {
-                _activeContextObserver.OnNext(_activeContexts.Values);
+                _activeContextObserver.OnNext(ActiveContexts);
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -392,7 +392,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                         : GetMapperTaskIdByEvaluatorId(activeContext.EvaluatorId);
                     commGroup.AddTask(taskId);
                     taskIdAndContextMapping.Add(taskId, activeContext);
-                    Logger.Log(Level.Info, "Adding {0} with associated context: {1} to group.", taskId, activeContext.Id);
+                    Logger.Log(Level.Info, "Adding {0} with associated context: {1} to communication group: {2}.", taskId, activeContext.Id, IMRUConstants.CommunicationGroupName);
                 }
 
                 foreach (var mapping in taskIdAndContextMapping)

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -392,6 +392,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                         : GetMapperTaskIdByEvaluatorId(activeContext.EvaluatorId);
                     commGroup.AddTask(taskId);
                     taskIdAndContextMapping.Add(taskId, activeContext);
+                    Logger.Log(Level.Info, "Adding {0} with associated context: {1} to group.", taskId, activeContext.Id);
                 }
 
                 foreach (var mapping in taskIdAndContextMapping)

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/PartitionDescriptorContextIdBundle.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/PartitionDescriptorContextIdBundle.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+namespace Org.Apache.REEF.IMRU.OnREEF.Driver
+{
+    /// <summary>
+    /// It keeps the mapping between context id and partition descriptor id so that the context with the same id always bundled to the same partition data.
+    /// </summary>
+    internal sealed class PartitionDescriptorContextIdBundle
+    {
+        /// <summary>
+        /// Create an object of PartitionDescriptorContextIdBunddle to maintain the relationship.
+        /// If an evaluator failed and a new context is created, the same context id with the same partition data will be assigned to the new context
+        /// </summary>
+        /// <param name="partitionDescriptorId"></param>
+        /// <param name="contextId"></param>
+        internal PartitionDescriptorContextIdBundle(string partitionDescriptorId, string contextId)
+        {
+            PartitionDescriptorId = partitionDescriptorId;
+            ContextId = contextId;
+        }
+
+        internal string PartitionDescriptorId { get; private set; }
+
+        internal string ContextId { get; private set; }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
@@ -103,7 +103,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                 var msg = string.Format(CultureInfo.InvariantCulture,
                     "Partition descriptor for Failed evaluator:{0} not present",
                     evaluatorId);
-                throw new Exception(msg);
+                throw new IMRUSystemException(msg);
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Org.Apache.REEF.Common.Context;
 using Org.Apache.REEF.Common.Events;
 using Org.Apache.REEF.Common.Services;
@@ -43,22 +42,41 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(ServiceAndContextConfigurationProvider<TMapInput, TMapOutput, TPartitionType>));
 
-        private readonly Dictionary<string, string> _partitionIdProvider = new Dictionary<string, string>();
-        private readonly Stack<string> _partitionDescriptorIds = new Stack<string>();
+        /// <summary>
+        /// Mapping between Evaluator id and assigned partition descriptor/context ids
+        /// </summary>
+        private readonly Dictionary<string, PartitionDescriptorContextIdBundle> _partitionContextIdProvider = new Dictionary<string, PartitionDescriptorContextIdBundle>();
+
+        /// <summary>
+        /// Available partition descriptor and context ids stack
+        /// </summary>
+        private readonly Stack<PartitionDescriptorContextIdBundle> _avilablePartitionDescriptorContextIds = new Stack<PartitionDescriptorContextIdBundle>();
+
+        /// <summary>
+        /// Input partition data set
+        /// </summary>
         private readonly IPartitionedInputDataSet _dataset;
+
+        /// <summary>_configurationManager
+        /// Configuration manager that provides configurations
+        /// </summary>
         private readonly ConfigurationManager _configurationManager;
 
         /// <summary>
-        /// Constructs the object witch maintains partitionDescriptor Ids so that to provide proper data load configuration 
+        /// Constructs the object which maintains partitionDescriptor Ids so that to provide proper data load configuration
+        /// It also maintain the partitionDescriptor id and context id mapping to ensure same context id alway assign the same data partition
+        /// This is to ensure if the tasks are added to the typology based on the sequence of context id, the result is deterministic. 
         /// </summary>
         /// <param name="dataset">partition input dataset</param>
         /// <param name="configurationManager">Configuration manager that holds configurations for context and tasks</param>
         internal ServiceAndContextConfigurationProvider(IPartitionedInputDataSet dataset, ConfigurationManager configurationManager)
         {
             _dataset = dataset;
-            foreach (var descriptor in _dataset.Reverse())
+            int contextSequenceNumber = 0;
+            foreach (var descriptor in _dataset)
             {
-                _partitionDescriptorIds.Push(descriptor.Id);
+                var contextId = string.Format("DataLoadingContext-{0}", contextSequenceNumber++);
+                _avilablePartitionDescriptorContextIds.Push(new PartitionDescriptorContextIdBundle(descriptor.Id, contextId));
             }
             _configurationManager = configurationManager;
         }
@@ -71,13 +89,13 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <returns>Whether failed evaluator is master or not</returns>
         internal void RemoveEvaluatorIdFromPartitionIdProvider(string evaluatorId)
         {
-            if (!_partitionIdProvider.ContainsKey(evaluatorId))
+            if (!_partitionContextIdProvider.ContainsKey(evaluatorId))
             {
                 var msg = string.Format(CultureInfo.InvariantCulture, "Partition descriptor for Failed evaluator:{0} not present", evaluatorId);
                 Exceptions.Throw(new Exception(msg), Logger);
             }
-            _partitionDescriptorIds.Push(_partitionIdProvider[evaluatorId]);
-            _partitionIdProvider.Remove(evaluatorId);
+            _avilablePartitionDescriptorContextIds.Push(_partitionContextIdProvider[evaluatorId]);
+            _partitionContextIdProvider.Remove(evaluatorId);
         }
 
         /// <summary>
@@ -106,13 +124,13 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <returns></returns>
         internal string GetPartitionIdByEvaluatorId(string evaluatorId)
         {
-            if (!_partitionIdProvider.ContainsKey(evaluatorId))
+            if (!_partitionContextIdProvider.ContainsKey(evaluatorId))
             {
                 var msg = string.Format(CultureInfo.InvariantCulture, "Partition descriptor for evaluator:{0} is not present in the mapping", evaluatorId);
                 Exceptions.Throw(new IMRUSystemException(msg), Logger);
             }
 
-            return _partitionIdProvider[evaluatorId];
+            return _partitionContextIdProvider[evaluatorId].PartitionDescriptorId;
         }
 
         /// <summary>
@@ -120,15 +138,15 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// evaluator or new configuration
         /// </summary>
         /// <param name="evaluatorId"></param>
-        /// <returns></returns>
+        /// <returns>Configuration for context and service</returns>
         internal ContextAndServiceConfiguration GetDataLoadingConfigurationForEvaluatorById(string evaluatorId)
         {
-            if (_partitionDescriptorIds.Count == 0)
+            if (_avilablePartitionDescriptorContextIds.Count == 0)
             {
                 Exceptions.Throw(new IMRUSystemException("No more data configuration can be provided"), Logger);
             }
 
-            if (_partitionIdProvider.ContainsKey(evaluatorId))
+            if (_partitionContextIdProvider.ContainsKey(evaluatorId))
             {
                 var msg =
                     string.Format(
@@ -139,30 +157,32 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             }
 
             Logger.Log(Level.Info, "Getting a new data loading configuration");
-            _partitionIdProvider[evaluatorId] = _partitionDescriptorIds.Pop();
+            _partitionContextIdProvider[evaluatorId] = _avilablePartitionDescriptorContextIds.Pop();
 
             try
             {
+                var partitionIdContextId = _partitionContextIdProvider[evaluatorId];
                 IPartitionDescriptor partitionDescriptor =
-                    _dataset.GetPartitionDescriptorForId(_partitionIdProvider[evaluatorId]);
-                return GetDataLoadingContextAndServiceConfiguration(partitionDescriptor);
+                    _dataset.GetPartitionDescriptorForId(partitionIdContextId.PartitionDescriptorId);
+                return GetDataLoadingContextAndServiceConfiguration(partitionDescriptor, partitionIdContextId.ContextId);
             }
             catch (Exception e)
             {
                 var msg = string.Format(CultureInfo.InvariantCulture, "Error while trying to access partition descriptor:{0} from dataset",
-                    _partitionIdProvider[evaluatorId]);
+                    _partitionContextIdProvider[evaluatorId]);
                 Exceptions.Throw(e, msg, Logger);
                 return null;
             }
         }
 
         /// <summary>
-        /// Creates service and data loading context configuration for given evaluator id
+        /// Creates service and data loading context configuration for given context id and partition descriptor
         /// </summary>
         /// <param name="partitionDescriptor"></param>
-        /// <returns></returns>
+        /// <param name="contextId"></param>
+        /// <returns>Configuration for context and service</returns>
         private ContextAndServiceConfiguration GetDataLoadingContextAndServiceConfiguration(
-            IPartitionDescriptor partitionDescriptor)
+            IPartitionDescriptor partitionDescriptor, string contextId)
         {
             var dataLoadingContextConf =
                 TangFactory.GetTang()
@@ -184,7 +204,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                     .Build();
 
             var contextConf = ContextConfiguration.ConfigurationModule
-                .Set(ContextConfiguration.Identifier, string.Format("DataLoadingContext-{0}", partitionDescriptor.Id))
+                .Set(ContextConfiguration.Identifier, contextId)
                 .Build();
             return new ContextAndServiceConfiguration(contextConf, serviceConf);
         }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Org.Apache.REEF.Common.Context;
 using Org.Apache.REEF.Common.Events;
 using Org.Apache.REEF.Common.Services;
@@ -55,7 +56,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         internal ServiceAndContextConfigurationProvider(IPartitionedInputDataSet dataset, ConfigurationManager configurationManager)
         {
             _dataset = dataset;
-            foreach (var descriptor in _dataset)
+            foreach (var descriptor in _dataset.Reverse())
             {
                 _partitionDescriptorIds.Push(descriptor.Id);
             }
@@ -144,7 +145,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             {
                 IPartitionDescriptor partitionDescriptor =
                     _dataset.GetPartitionDescriptorForId(_partitionIdProvider[evaluatorId]);
-                return GetDataLoadingContextAndServiceConfiguration(partitionDescriptor, evaluatorId);
+                return GetDataLoadingContextAndServiceConfiguration(partitionDescriptor);
             }
             catch (Exception e)
             {
@@ -159,11 +160,9 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// Creates service and data loading context configuration for given evaluator id
         /// </summary>
         /// <param name="partitionDescriptor"></param>
-        /// <param name="evaluatorId"></param>
         /// <returns></returns>
         private ContextAndServiceConfiguration GetDataLoadingContextAndServiceConfiguration(
-            IPartitionDescriptor partitionDescriptor,
-            string evaluatorId)
+            IPartitionDescriptor partitionDescriptor)
         {
             var dataLoadingContextConf =
                 TangFactory.GetTang()
@@ -185,7 +184,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                     .Build();
 
             var contextConf = ContextConfiguration.ConfigurationModule
-                .Set(ContextConfiguration.Identifier, string.Format("DataLoading-{0}", evaluatorId))
+                .Set(ContextConfiguration.Identifier, string.Format("DataLoadingContext-{0}", partitionDescriptor.Id))
                 .Build();
             return new ContextAndServiceConfiguration(contextConf, serviceConf);
         }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
@@ -67,7 +67,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
 
         /// <summary>
         /// Constructs the object which maintains partitionDescriptor Ids so that to provide proper data load configuration
-        /// It also maintain the partitionDescriptor id and context id mapping to ensure same context id alway assign the same data partition
+        /// It also maintains the partitionDescriptor id and context id mapping to ensure same context id alway assign the same data partition
         /// This is to ensure if the tasks are added to the typology based on the sequence of context id, the result is deterministic. 
         /// </summary>
         /// <param name="dataset">partition input dataset</param>
@@ -92,14 +92,19 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         /// <returns>Whether failed evaluator is master or not</returns>
         internal void RemoveEvaluatorIdFromPartitionIdProvider(string evaluatorId)
         {
-            if (!_partitionContextIdProvider.ContainsKey(evaluatorId))
+            PartitionDescriptorContextIdBundle partitionDescriptor;
+            if (_partitionContextIdProvider.TryGetValue(evaluatorId, out partitionDescriptor))
             {
-                var msg = string.Format(CultureInfo.InvariantCulture, 
-                    "Partition descriptor for Failed evaluator:{0} not present", evaluatorId);
-                Exceptions.Throw(new Exception(msg), Logger);
+                _availablePartitionDescriptorContextIds.Push(partitionDescriptor);
+                _partitionContextIdProvider.Remove(evaluatorId);
             }
-            _availablePartitionDescriptorContextIds.Push(_partitionContextIdProvider[evaluatorId]);
-            _partitionContextIdProvider.Remove(evaluatorId);
+            else
+            {
+                var msg = string.Format(CultureInfo.InvariantCulture,
+                    "Partition descriptor for Failed evaluator:{0} not present",
+                    evaluatorId);
+                throw new Exception(msg);
+            }
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
+++ b/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
@@ -85,6 +85,7 @@ under the License.
     <Compile Include="OnREEF\Driver\IMRUSystemException.cs" />
     <Compile Include="OnREEF\Driver\IMRUConstants.cs" />
     <Compile Include="OnREEF\Driver\IMRUDriver.cs" />
+    <Compile Include="OnREEF\Driver\PartitionDescriptorContextIdBundle.cs" />
     <Compile Include="OnREEF\Driver\ServiceAndContextConfigurationProvider.cs" />
     <Compile Include="OnREEF\Driver\StateMachine\TaskStateMachine.cs" />
     <Compile Include="OnREEF\Driver\StateMachine\StateTransition.cs" />


### PR DESCRIPTION
* Use partitionDescriptor id as part of the context id so that context id is associated with a fixed partitionDescriptor. Please notice that the partition descriptor id always follows the pattern like RandomInputPartition-x and is unique
* Make contexts stored in a sorted collection to ensure tasks with associated context/partitionDescriptor are always add to group in the same sequence.

JIRA: [REEF-1842](https://issues.apache.org/jira/browse/REEF-1842)
This closes #