### PR TITLE
[REEF-1843] Update Hadoop version to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ under the License.
         <reef.log.dir>${project.build.directory}/log</reef.log.dir>
         <bundle.snappy>false</bundle.snappy>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hadoop.version>2.6.0</hadoop.version>
+        <hadoop.version>2.7.0</hadoop.version>
         <spark.version>2.1.0</spark.version>
         <avro.version>1.8.1</avro.version>
         <parquet.version>1.9.0</parquet.version>


### PR DESCRIPTION
JIRA: [REEF-1843](https://issues.apache.org/jira/browse/REEF-1843)

This PR updates Hadoop version to 2.7.

This closes #