### PR TITLE
[REEF-1849] Fix CoreCLR incompatibilities in REEF Network

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network/Naming/Parameters/NameCacheConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/Parameters/NameCacheConfiguration.cs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
 using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.Network.Naming.Parameters
@@ -26,12 +27,19 @@ namespace Org.Apache.REEF.Network.Naming.Parameters
         {
         }
 
-        [NamedParameter("Maximum cache memory in MB", "cachememorylimit", "20")]
+        [NamedParameter("Frequency to check for cache expirations", "expirationscanfrequency", "00:20:00")]
+        public class ExpirationScanFrequency : Name<string>
+        {
+        }
+
+        [Obsolete("TODO[JIRA REEF-1856] This parameter will be removed.")]
+        [NamedParameter("Maximum cache memory in MB", "cachememorylimit")]
         public class CacheMemoryLimit : Name<string>
         {
         }
 
-        [NamedParameter("Polling interval for checking cache memory", "cachepollinginterval", "00:20:00")]
+        [Obsolete("TODO[JIRA REEF-1856] This parameter will be removed.")]
+        [NamedParameter("Polling interval for checking cache memory", "cachepollinginterval")]
         public class PollingInterval : Name<string>
         {
         }

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -30,6 +30,21 @@ under the License.
   </PropertyGroup>
   <Import Project="$(SolutionDir)\build.props" />
   <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Caching.Abstractions, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Caching.Abstractions.1.1.2\lib\netstandard1.0\Microsoft.Extensions.Caching.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Caching.Memory, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Caching.Memory.1.1.2\lib\net451\Microsoft.Extensions.Caching.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.1\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.1.1.2\lib\netstandard1.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.1.1.1\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Hadoop.Avro">
       <HintPath>$(PackagesDir)\Microsoft.Hadoop.Avro.$(AvroVersion)\lib\net45\Microsoft.Hadoop.Avro.dll</HintPath>
     </Reference>
@@ -37,7 +52,11 @@ under the License.
       <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net451\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Reactive.Core">
       <HintPath>$(PackagesDir)\System.Reactive.Core.$(SystemReactiveVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
@@ -45,8 +64,15 @@ under the License.
       <HintPath>$(PackagesDir)\System.Reactive.Interfaces.$(SystemReactiveVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.3.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(SolutionDir)\SharedAssemblyInfo.cs">

--- a/lang/cs/Org.Apache.REEF.Network/packages.config
+++ b/lang/cs/Org.Apache.REEF.Network/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -18,10 +18,49 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
+  <package id="Microsoft.Extensions.Caching.Abstractions" version="1.1.2" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Caching.Memory" version="1.1.2" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.1" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Options" version="1.1.2" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Primitives" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
[This](url) addressed the issue by
  * Switching `System.Runtime.Caching.MemoryCache` to `Microsoft.Extensions.Caching.Memory.MemoryCache` in `NameCache`
  * Changing the `NameCacheConfiguration` to match the new configuration parameters
  * Removing unused, meaningless internal methods from `NameCache`

JIRA:
  [REEF-1849](https://issues.apache.org/jira/browse/REEF-1849)

Pull request:
  This closes #