### PR TITLE
- Implement KillJobApplication for YARN jobs. Implementation of this …

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/API/IREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/IREEFClient.cs
@@ -50,5 +50,13 @@ namespace Org.Apache.REEF.Client.API
         /// <returns></returns>
         [Unstable("0.14", "Working in progress for rest API status returned")]
         Task<FinalState> GetJobFinalStatus(string appId);
+
+        /// <summary>
+        /// Kills the job application and return Job status
+        /// </summary>
+        /// <param name="appId"></param>
+        /// <returns></returns>
+        [Unstable("0.16", "Working in progress for rest API status returned")]
+        Task<FinalState> KillJobApplication(string appId);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/Local/LocalClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Local/LocalClient.cs
@@ -202,6 +202,17 @@ namespace Org.Apache.REEF.Client.Local
         }
 
         /// <summary>
+        /// Kills the job application and return Job status
+        /// </summary>
+        /// <param name="appId"></param>
+        /// <returns></returns>
+        public async Task<FinalState> KillJobApplication(string appId)
+        {
+            await Task.Delay(0);
+            return FinalState.SUCCEEDED;
+        }
+
+        /// <summary>
         /// Creates the temporary directory to hold the job submission.
         /// </summary>
         /// <returns></returns>

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -115,6 +115,7 @@ under the License.
     <Compile Include="YARN\Parameters\DriverMaxPermSizeMB.cs" />
     <Compile Include="YARN\Parameters\DriverStderrFilePath.cs" />
     <Compile Include="YARN\Parameters\DriverStdoutFilePath.cs" />
+    <Compile Include="YARN\RestClient\DataModel\KillApplication.cs" />
     <Compile Include="YARN\RestClient\HttpClient.cs" />
     <Compile Include="YARN\RestClient\IDeserializer.cs" />
     <Compile Include="YARN\RestClient\IHttpClient.cs" />

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/KillApplication.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/KillApplication.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Newtonsoft.Json;
+
+namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
+{
+    /// <summary>
+    /// Class generated based on schema provided in
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
+    /// </summary>
+    internal sealed class KillApplication
+    {
+        internal static readonly string Resource = @"cluster/apps/";
+        internal static readonly string StateTag = @"/state";
+
+        [JsonProperty("state")]
+        public State State { get; set; }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/IYarnRMClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/IYarnRMClient.cs
@@ -46,5 +46,18 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
         Task<Application> SubmitApplicationAsync(
             SubmitApplication submitApplicationRequest,
             CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Kills the application asynchronous.
+        /// </summary>
+        /// <param name="appId">The application identifier.</param>
+        void KillApplicationAsync(string appId);
+
+        /// <summary>
+        /// Kills the application asynchronous.
+        /// </summary>
+        /// <param name="appId">The application identifier.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        void KillApplicationAsync(string appId, CancellationToken cancellationToken);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
@@ -126,6 +126,35 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
             return await GetApplicationAsync(submitApplication.ApplicationId, cancellationToken);
         }
 
+        /// <summary>
+        /// Kills the application asynchronous.
+        /// </summary>
+        /// <param name="appId">The application identifier.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <exception cref="System.NotImplementedException"></exception>
+        public async void KillApplicationAsync(string appId, CancellationToken cancellationToken)
+        {
+            var killApplication = new KillApplication();
+            killApplication.State = State.KILLED;
+
+            var restParm = KillApplication.Resource + appId;
+            await new RemoveSynchronizationContextAwaiter();
+            var request = _requestFactory.CreateRestRequest(
+                restParm,
+                Method.PUT,
+                rootElement: null,
+                body: killApplication);
+
+            var response = await GenerateUrlAndExecuteRequestAsync(request, cancellationToken);
+
+            if (response.StatusCode != HttpStatusCode.Accepted)
+            {
+                throw new YarnRestAPIException(
+                    string.Format("Kill Application failed with HTTP STATUS {0}",
+                        response.StatusCode));
+            }
+        }
+
         private async Task<T> GenerateUrlAndExecuteRequestAsync<T>(RestRequest request,
             CancellationToken cancellationToken)
         {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClientNoCancellationToken.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClientNoCancellationToken.cs
@@ -53,5 +53,15 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
             await new RemoveSynchronizationContextAwaiter();
             return await SubmitApplicationAsync(submitApplicationRequest, CancellationToken.None);
         }
+
+        /// <summary>
+        /// Kills the application asynchronous.
+        /// </summary>
+        /// <param name="appId">The application identifier.</param>
+        public async void KillApplicationAsync(string appId)
+        {
+            await new RemoveSynchronizationContextAwaiter();
+            KillApplicationAsync(appId, CancellationToken.None);
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
@@ -105,6 +105,17 @@ namespace Org.Apache.REEF.Client.Yarn
             return application.FinalStatus;
         }
 
+        /// <summary>
+        /// Kills the job application and return Job status
+        /// </summary>
+        /// <param name="appId"></param>
+        /// <returns>FinalState of the application</returns>
+        public async Task<FinalState> KillJobApplication(string appId)
+        {
+             _yarnClient.KillApplicationAsync(appId);
+            return await GetJobFinalStatus(appId);
+        }
+
         private void Launch(JobRequest jobRequest, string driverFolderPath)
         {
             _driverFolderPreparationHelper.PrepareDriverFolder(jobRequest.AppParameters, driverFolderPath);

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetClient.cs
@@ -146,6 +146,17 @@ namespace Org.Apache.REEF.Client.YARN
             return application.FinalStatus;
         }
 
+        /// <summary>
+        /// Kills the job application and return Job status
+        /// </summary>
+        /// <param name="appId"></param>
+        /// <returns>FinalState of the application</returns>
+        public async Task<FinalState> KillJobApplication(string appId)
+        {
+            _yarnRMClient.KillApplicationAsync(appId);
+            return await GetJobFinalStatus(appId);
+        }
+
         private SubmitApplication CreateApplicationSubmissionRequest(
            JobParameters jobParameters,
            string appId,


### PR DESCRIPTION
…API involves in

  acctepting application id and invoking REST API to POST the state for the application
  to KILLED. This forces RM to unregister this application and move the running application
  to KILLED state.

JIRA:
  [REEF-1838](https://issues.apache.org/jira/browse/REEF-1838)

Pull Request:
  This closes #