### PR TITLE
[REEF-1854] Add netcoreapp2.0 and netstandard2.0 to target framework in

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.DotNet.csproj
@@ -27,7 +27,7 @@ under the License.
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
+    <PackageReference Include="Microsoft.Avro.Core" Version="$(AvroVersion)" />
     <PackageReference Include="System.Reactive.Core" Version="$(SystemReactiveVersion)" />
     <PackageReference Include="System.Reactive.Interfaces" Version="$(SystemReactiveVersion)" />
     <Reference Include="System" />

--- a/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.DotNet.csproj
@@ -26,7 +26,7 @@ under the License.
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
+    <PackageReference Include="Microsoft.Avro.Core" Version="$(AvroVersion)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.DotNet.csproj
@@ -26,7 +26,7 @@ under the License.
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
+    <PackageReference Include="Microsoft.Avro.Core" Version="$(AvroVersion)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.DotNet.csproj
@@ -26,7 +26,7 @@ under the License.
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
+    <PackageReference Include="Microsoft.Avro.Core" Version="$(AvroVersion)" />
     <PackageReference Include="System.Reactive.Core" Version="$(SystemReactiveVersion)" />
     <PackageReference Include="System.Reactive.Interfaces" Version="$(SystemReactiveVersion)" />
     <Reference Include="System" />

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.DotNet.csproj
@@ -23,7 +23,7 @@ under the License.
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
+    <PackageReference Include="Microsoft.Avro.Core" Version="$(AvroVersion)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Tang/Org.Apache.REEF.Tang.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang/Org.Apache.REEF.Tang.DotNet.csproj
@@ -21,13 +21,13 @@ under the License.
     <AssemblyName>Org.Apache.REEF.Tang</AssemblyName>
     <Description>Tang is a dependency injection framework</Description>
     <PackageTags> Apache REEF tang dependency injection</PackageTags>
-    <TargetFrameworks>net46;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.0;net46;net451</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="protobuf-net" Version="$(ProtobufVersion)" />
-    <PackageReference Include="Microsoft.Hadoop.Avro" Version="$(AvroVersion)" />
+    <PackageReference Include="Microsoft.Avro.Core" Version="$(AvroVersion)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.REEF.Utilities.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.REEF.Utilities.DotNet.csproj
@@ -19,7 +19,7 @@ under the License.
     <AssemblyName>Org.Apache.REEF.Utilities</AssemblyName>
     <Description>Common utilities such as logging shared across REEF/Wake/Tang</Description>
     <PackageTags>Apache REEF REEF/Wake/Tang common utilities</PackageTags>
-    <TargetFrameworks>netstandard2.0;net46;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.0;net46;net451</TargetFrameworks>
   </PropertyGroup>
   <Import Project="..\build.DotNet.props" />
   <ItemGroup>

--- a/lang/cs/build.DotNet.props
+++ b/lang/cs/build.DotNet.props
@@ -37,7 +37,7 @@ under the License.
     <PlatformTarget>x64</PlatformTarget>
     <DefineConstants>DOTNET_BUILD</DefineConstants>
     <OutputPath>..\bin\$(AssemblyName)</OutputPath>
-    <AvroVersion>1.5.6</AvroVersion>
+    <AvroVersion>0.1.0</AvroVersion>
     <NewtonsoftJsonVersion>10.0.1</NewtonsoftJsonVersion>
     <NSubstituteVersion>1.8.2.0</NSubstituteVersion>
     <ProtobufVersion>2.1.0</ProtobufVersion>


### PR DESCRIPTION
Org.Apachee.REEF.Tang
 
This addressed the issue by 
   adding netcoreapp2.0 to csproj file

 
JIRA:
  [REEF-1854](https://issues.apache.org/jira/browse/REEF-1854)
 
Pull request:
  This closes #