### PR TITLE
[REEF-1838] Add API to Kill Yarn Job Application from .Net client

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -119,6 +119,7 @@ under the License.
     <Compile Include="YARN\Parameters\DriverStderrFilePath.cs" />
     <Compile Include="YARN\Parameters\DriverStdoutFilePath.cs" />
     <Compile Include="YARN\Parameters\FileSystemUrl.cs" />
+    <Compile Include="YARN\RestClient\DataModel\KillApplication.cs" />
     <Compile Include="YARN\RestClient\HttpClient.cs" />
     <Compile Include="YARN\RestClient\IDeserializer.cs" />
     <Compile Include="YARN\RestClient\IHttpClient.cs" />

--- a/lang/cs/Org.Apache.REEF.Client/YARN/IYarnREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/IYarnREEFClient.cs
@@ -36,13 +36,11 @@ namespace Org.Apache.REEF.Client.YARN
         Task<IReadOnlyDictionary<string, IApplicationReport>> GetApplicationReports();
 
         /// <summary>
-        /// Kills the job application and returns Job status
-        /// If application id is invalid, or application has been completed throw InvalidOperationException.
-        /// If rest request is not accepted, throw YarnRestAPIException.
+        /// Kills the job application
         /// </summary>
         /// <param name="appId">Application id to kill.</param>
-        /// <returns>It returns the Job Final State.</returns>
+        /// <returns>Returns true if the application is killed otherwise return false.</returns>
         [Unstable("0.17", "Working in progress for rest API status returned")]
-        Task<FinalState> KillJobApplication(string appId);
+        bool KillJobApplication(string appId);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/IYarnREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/IYarnREEFClient.cs
@@ -36,9 +36,10 @@ namespace Org.Apache.REEF.Client.YARN
         Task<IReadOnlyDictionary<string, IApplicationReport>> GetApplicationReports();
 
         /// <summary>
-        /// Kills the job application and return Job status
+        /// Kills the job application and returns Job status
+        /// If Application Id is invalid or application has been completed, exception will be thrown.
         /// </summary>
-        /// <param name="appId"></param>
+        /// <param name="appId">Application id to kill.</param>
         /// <returns></returns>
         [Unstable("0.17", "Working in progress for rest API status returned")]
         Task<FinalState> KillJobApplication(string appId);

--- a/lang/cs/Org.Apache.REEF.Client/YARN/IYarnREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/IYarnREEFClient.cs
@@ -37,10 +37,11 @@ namespace Org.Apache.REEF.Client.YARN
 
         /// <summary>
         /// Kills the job application and returns Job status
-        /// If Application Id is invalid or application has been completed, exception will be thrown.
+        /// If application id is invalid, or application has been completed throw InvalidOperationException.
+        /// If rest request is not accepted, throw YarnRestAPIException.
         /// </summary>
         /// <param name="appId">Application id to kill.</param>
-        /// <returns></returns>
+        /// <returns>It returns the Job Final State.</returns>
         [Unstable("0.17", "Working in progress for rest API status returned")]
         Task<FinalState> KillJobApplication(string appId);
     }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/IYarnREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/IYarnREEFClient.cs
@@ -18,6 +18,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Org.Apache.REEF.Client.API;
+using Org.Apache.REEF.Client.YARN.RestClient.DataModel;
 using Org.Apache.REEF.Utilities.Attributes;
 
 namespace Org.Apache.REEF.Client.YARN
@@ -33,5 +34,13 @@ namespace Org.Apache.REEF.Client.YARN
         /// <returns></returns>
         [Unstable("0.17", "Working in progress for rest API id returned")]
         Task<IReadOnlyDictionary<string, IApplicationReport>> GetApplicationReports();
+
+        /// <summary>
+        /// Kills the job application and return Job status
+        /// </summary>
+        /// <param name="appId"></param>
+        /// <returns></returns>
+        [Unstable("0.17", "Working in progress for rest API status returned")]
+        Task<FinalState> KillJobApplication(string appId);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/IYarnREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/IYarnREEFClient.cs
@@ -36,11 +36,11 @@ namespace Org.Apache.REEF.Client.YARN
         Task<IReadOnlyDictionary<string, IApplicationReport>> GetApplicationReports();
 
         /// <summary>
-        /// Kills the job application
+        /// Kills the application with specified application id.
         /// </summary>
         /// <param name="appId">Application id to kill.</param>
         /// <returns>Returns true if the application is killed otherwise return false.</returns>
         [Unstable("0.17", "Working in progress for rest API status returned")]
-        bool KillJobApplication(string appId);
+        Task<bool> KillApplication(string appId);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/KillApplication.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/KillApplication.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,32 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System;
-using System.Threading;
-using Org.Apache.REEF.Common.Tasks;
-using Org.Apache.REEF.Tang.Annotations;
+using Newtonsoft.Json;
 
-namespace Org.Apache.REEF.Examples.HelloREEF
+namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
     /// <summary>
-    /// A Task that merely prints a greeting and exits.
+    /// Class generated based on schema provided in
+    /// <a href="http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API</a> documentation.
     /// </summary>
-    public sealed class HelloTask : ITask
+    internal sealed class KillApplication
     {
-        [Inject]
-        private HelloTask()
-        {
-        }
+        internal static readonly string Resource = @"cluster/apps/";
+        internal static readonly string StateTag = @"/state";
 
-        public void Dispose()
-        {
-            Console.WriteLine("Disposed.");
-        }
-
-        public byte[] Call(byte[] memento)
-        {
-            Console.WriteLine("Hello, REEF!");
-            return null;
-        }
+        [JsonProperty("state")]
+        public State State { get; set; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/IYarnRMClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/IYarnRMClient.cs
@@ -65,19 +65,17 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
 
         /// <summary>
         /// Kills the application asynchronous.
-        /// If application id is invalid, or application has been completed throw InvalidOperationException.
-        /// If rest request is not accepted, throw YarnRestAPIException.
         /// </summary>
         /// <param name="appId">The application identifier.</param>
-        void KillApplicationAsync(string appId);
+        /// <returns>Returns true if the application is killed otherwise return false.</returns>
+        Task<bool> KillApplicationAsync(string appId);
 
         /// <summary>
         /// Kills the application asynchronous.
-        /// If application id is invalid, or application has been completed throw InvalidOperationException.
-        /// If rest request is not accepted, throw YarnRestAPIException.
         /// </summary>
         /// <param name="appId">The application identifier.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        void KillApplicationAsync(string appId, CancellationToken cancellationToken);
+        /// <returns>Returns true if the application is killed otherwise returns false.</returns>
+        Task<bool> KillApplicationAsync(string appId, CancellationToken cancellationToken);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/IYarnRMClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/IYarnRMClient.cs
@@ -62,5 +62,18 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
         Task<Application> SubmitApplicationAsync(
             SubmitApplication submitApplicationRequest,
             CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Kills the application asynchronous.
+        /// </summary>
+        /// <param name="appId">The application identifier.</param>
+        void KillApplicationAsync(string appId);
+
+        /// <summary>
+        /// Kills the application asynchronous.
+        /// </summary>
+        /// <param name="appId">The application identifier.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        void KillApplicationAsync(string appId, CancellationToken cancellationToken);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/IYarnRMClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/IYarnRMClient.cs
@@ -65,12 +65,16 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
 
         /// <summary>
         /// Kills the application asynchronous.
+        /// If application id is invalid, or application has been completed throw InvalidOperationException.
+        /// If rest request is not accepted, throw YarnRestAPIException.
         /// </summary>
         /// <param name="appId">The application identifier.</param>
         void KillApplicationAsync(string appId);
 
         /// <summary>
         /// Kills the application asynchronous.
+        /// If application id is invalid, or application has been completed throw InvalidOperationException.
+        /// If rest request is not accepted, throw YarnRestAPIException.
         /// </summary>
         /// <param name="appId">The application identifier.</param>
         /// <param name="cancellationToken">The cancellation token.</param>

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
@@ -148,13 +148,12 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
 
         /// <summary>
         /// Kills the application asynchronous.
-        /// If application id is invalid, or application has been completed throw InvalidOperationException.
-        /// If rest request is not accepted, throw YarnRestAPIException.
         /// </summary>
         /// <param name="appId">The application identifier.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <exception cref="System.NotImplementedException"></exception>
-        public async void KillApplicationAsync(string appId, CancellationToken cancellationToken)
+        /// <returns>Returns true if the application is killed otherwise returns false.</returns>
+        /// <exception cref="YarnRestAPIException"></exception>
+        public async Task<bool> KillApplicationAsync(string appId, CancellationToken cancellationToken)
         {
             try
             {
@@ -170,8 +169,7 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
                     body: killApplication);
 
                 var response = await GenerateUrlAndExecuteRequestAsync(request, cancellationToken);
-                
-                Logger.Log(Level.Info, "StatueCode from response {0}", response.StatusCode);
+                Logger.Log(Level.Info, "StatusCode from response {0}", response.StatusCode);
 
                 if (response.StatusCode != HttpStatusCode.Accepted)
                 {
@@ -179,11 +177,12 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
                         string.Format("Kill Application failed with HTTP STATUS {0}",
                             response.StatusCode));
                 }
+                return true;
             }
             catch (AggregateException e)
             {
                 Logger.Log(Level.Error, "YarnClient:KillApplicationAsync got exception for application id {0}, {1}", appId, e);
-                throw new InvalidOperationException("Fail to Kill the application.", e);
+                return false;
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
@@ -157,8 +157,10 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
         {
             try
             {
-                var killApplication = new KillApplication();
-                killApplication.State = State.KILLED;
+                var killApplication = new KillApplication()
+                {
+                    State = State.KILLED
+                };
 
                 var restParm = KillApplication.Resource + appId + KillApplication.StateTag;
                 await new RemoveSynchronizationContextAwaiter();

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
@@ -153,24 +153,34 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
         /// <exception cref="System.NotImplementedException"></exception>
         public async void KillApplicationAsync(string appId, CancellationToken cancellationToken)
         {
-            var killApplication = new KillApplication();
-            killApplication.State = State.KILLED;
-
-            var restParm = KillApplication.Resource + appId;
-            await new RemoveSynchronizationContextAwaiter();
-            var request = _requestFactory.CreateRestRequest(
-                restParm,
-                Method.PUT,
-                rootElement: null,
-                body: killApplication);
-
-            var response = await GenerateUrlAndExecuteRequestAsync(request, cancellationToken);
-
-            if (response.StatusCode != HttpStatusCode.Accepted)
+            try
             {
-                throw new YarnRestAPIException(
-                    string.Format("Kill Application failed with HTTP STATUS {0}",
-                        response.StatusCode));
+                var killApplication = new KillApplication();
+                killApplication.State = State.KILLED;
+
+                var restParm = KillApplication.Resource + appId + KillApplication.StateTag;
+                await new RemoveSynchronizationContextAwaiter();
+                var request = _requestFactory.CreateRestRequest(
+                    restParm,
+                    Method.PUT,
+                    rootElement: null,
+                    body: killApplication);
+
+                var response = await GenerateUrlAndExecuteRequestAsync(request, cancellationToken);
+                
+                Logger.Log(Level.Info, "StatueCode from response {0}", response.StatusCode);
+
+                if (response.StatusCode != HttpStatusCode.Accepted)
+                {
+                    throw new YarnRestAPIException(
+                        string.Format("Kill Application failed with HTTP STATUS {0}",
+                            response.StatusCode));
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Log(Level.Error, "YarnClient:KillApplicationAsync got exception", e);
+                throw e;
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Net;
 using System.Threading;
@@ -147,6 +148,8 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
 
         /// <summary>
         /// Kills the application asynchronous.
+        /// If application id is invalid, or application has been completed throw InvalidOperationException.
+        /// If rest request is not accepted, throw YarnRestAPIException.
         /// </summary>
         /// <param name="appId">The application identifier.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
@@ -177,10 +180,10 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
                             response.StatusCode));
                 }
             }
-            catch (Exception e)
+            catch (AggregateException e)
             {
-                Logger.Log(Level.Error, "YarnClient:KillApplicationAsync got exception", e);
-                throw e;
+                Logger.Log(Level.Error, "YarnClient:KillApplicationAsync got exception for application id {0}, {1}", appId, e);
+                throw new InvalidOperationException("Fail to Kill the application.", e);
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClient.cs
@@ -145,6 +145,35 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
             return await GetApplicationAsync(submitApplication.ApplicationId, cancellationToken);
         }
 
+        /// <summary>
+        /// Kills the application asynchronous.
+        /// </summary>
+        /// <param name="appId">The application identifier.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <exception cref="System.NotImplementedException"></exception>
+        public async void KillApplicationAsync(string appId, CancellationToken cancellationToken)
+        {
+            var killApplication = new KillApplication();
+            killApplication.State = State.KILLED;
+
+            var restParm = KillApplication.Resource + appId;
+            await new RemoveSynchronizationContextAwaiter();
+            var request = _requestFactory.CreateRestRequest(
+                restParm,
+                Method.PUT,
+                rootElement: null,
+                body: killApplication);
+
+            var response = await GenerateUrlAndExecuteRequestAsync(request, cancellationToken);
+
+            if (response.StatusCode != HttpStatusCode.Accepted)
+            {
+                throw new YarnRestAPIException(
+                    string.Format("Kill Application failed with HTTP STATUS {0}",
+                        response.StatusCode));
+            }
+        }
+
         private async Task<T> GenerateUrlAndExecuteRequestAsync<T>(RestRequest request,
             CancellationToken cancellationToken)
         {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClientNoCancellationToken.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClientNoCancellationToken.cs
@@ -78,5 +78,15 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
             await new RemoveSynchronizationContextAwaiter();
             return await SubmitApplicationAsync(submitApplicationRequest, CancellationToken.None);
         }
+
+        /// <summary>
+        /// Kills the application asynchronous.
+        /// </summary>
+        /// <param name="appId">The application identifier.</param>
+        public async void KillApplicationAsync(string appId)
+        {
+            await new RemoveSynchronizationContextAwaiter();
+            KillApplicationAsync(appId, CancellationToken.None);
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClientNoCancellationToken.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnClientNoCancellationToken.cs
@@ -83,10 +83,11 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
         /// Kills the application asynchronous.
         /// </summary>
         /// <param name="appId">The application identifier.</param>
-        public async void KillApplicationAsync(string appId)
+        /// <returns>Returns true if the application is killed otherwise returns false.</returns>
+        public async Task<bool> KillApplicationAsync(string appId)
         {
             await new RemoveSynchronizationContextAwaiter();
-            KillApplicationAsync(appId, CancellationToken.None);
+            return KillApplicationAsync(appId, CancellationToken.None).Result;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
@@ -146,6 +146,7 @@ namespace Org.Apache.REEF.Client.Yarn
 
         /// <summary>
         /// Kills the job application and returns Job status
+        /// If Application Id is invalid or application has been completed, exception will be thrown.
         /// </summary>
         /// <param name="appId"></param>
         /// <returns>FinalState of the application</returns>

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
@@ -145,16 +145,13 @@ namespace Org.Apache.REEF.Client.Yarn
         }
 
         /// <summary>
-        /// Kills the job application and returns Job status
-        /// If application id is invalid, or application has been completed throw InvalidOperationException.
-        /// If rest request is not accepted, throw YarnRestAPIException.
+        /// Kills the job application.
         /// </summary>
-        /// <param name="appId">application id to kill</param>
-        /// <returns>FinalState of the application</returns>
-        public async Task<FinalState> KillJobApplication(string appId)
+        /// <param name="appId">Application id to kill.</param>
+        /// <returns>Returns true if the application is killed otherwise returns false.</returns>
+        public bool KillJobApplication(string appId)
         {
-            _yarnClient.KillApplicationAsync(appId);
-            return await GetJobFinalStatus(appId);
+            return _yarnClient.KillApplicationAsync(appId).Result;
         }
 
         private void Launch(JobRequest jobRequest, string driverFolderPath)

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
@@ -146,9 +146,10 @@ namespace Org.Apache.REEF.Client.Yarn
 
         /// <summary>
         /// Kills the job application and returns Job status
-        /// If Application Id is invalid or application has been completed, exception will be thrown.
+        /// If application id is invalid, or application has been completed throw InvalidOperationException.
+        /// If rest request is not accepted, throw YarnRestAPIException.
         /// </summary>
-        /// <param name="appId"></param>
+        /// <param name="appId">application id to kill</param>
         /// <returns>FinalState of the application</returns>
         public async Task<FinalState> KillJobApplication(string appId)
         {

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
@@ -145,13 +145,13 @@ namespace Org.Apache.REEF.Client.Yarn
         }
 
         /// <summary>
-        /// Kills the job application.
+        /// Kills the application with specified application id.
         /// </summary>
         /// <param name="appId">Application id to kill.</param>
         /// <returns>Returns true if the application is killed otherwise returns false.</returns>
-        public bool KillJobApplication(string appId)
+        public async Task<bool> KillApplication(string appId)
         {
-            return _yarnClient.KillApplicationAsync(appId).Result;
+            return await _yarnClient.KillApplicationAsync(appId);
         }
 
         private void Launch(JobRequest jobRequest, string driverFolderPath)

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YARNREEFClient.cs
@@ -144,6 +144,17 @@ namespace Org.Apache.REEF.Client.Yarn
             return new ReadOnlyDictionary<string, IApplicationReport>(appReports);
         }
 
+        /// <summary>
+        /// Kills the job application and returns Job status
+        /// </summary>
+        /// <param name="appId"></param>
+        /// <returns>FinalState of the application</returns>
+        public async Task<FinalState> KillJobApplication(string appId)
+        {
+            _yarnClient.KillApplicationAsync(appId);
+            return await GetJobFinalStatus(appId);
+        }
+
         private void Launch(JobRequest jobRequest, string driverFolderPath)
         {
             _driverFolderPreparationHelper.PrepareDriverFolder(jobRequest.AppParameters, driverFolderPath);

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetClient.cs
@@ -158,13 +158,13 @@ namespace Org.Apache.REEF.Client.YARN
         }
 
         /// <summary>
-        /// Kills the job application.
+        /// Kills the application with specified application id.
         /// </summary>
         /// <param name="appId"></param>
         /// <returns>Returns true if the application is killed otherwise returns false.</returns>
-        public bool KillJobApplication(string appId)
+        public async Task<bool> KillApplication(string appId)
         {
-            return _yarnRMClient.KillApplicationAsync(appId).Result;
+            return await _yarnRMClient.KillApplicationAsync(appId);
         }
 
         private SubmitApplication CreateApplicationSubmissionRequest(

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetClient.cs
@@ -157,6 +157,17 @@ namespace Org.Apache.REEF.Client.YARN
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Kills the job application and return Job status
+        /// </summary>
+        /// <param name="appId"></param>
+        /// <returns>FinalState of the application</returns>
+        public async Task<FinalState> KillJobApplication(string appId)
+        {
+            _yarnRMClient.KillApplicationAsync(appId);
+            return await GetJobFinalStatus(appId);
+        }
+
         private SubmitApplication CreateApplicationSubmissionRequest(
            JobParameters jobParameters,
            string appId,

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YarnREEFDotNetClient.cs
@@ -158,14 +158,13 @@ namespace Org.Apache.REEF.Client.YARN
         }
 
         /// <summary>
-        /// Kills the job application and return Job status
+        /// Kills the job application.
         /// </summary>
         /// <param name="appId"></param>
-        /// <returns>FinalState of the application</returns>
-        public async Task<FinalState> KillJobApplication(string appId)
+        /// <returns>Returns true if the application is killed otherwise returns false.</returns>
+        public bool KillJobApplication(string appId)
         {
-            _yarnRMClient.KillApplicationAsync(appId);
-            return await GetJobFinalStatus(appId);
+            return _yarnRMClient.KillApplicationAsync(appId).Result;
         }
 
         private SubmitApplication CreateApplicationSubmissionRequest(

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
@@ -95,7 +95,6 @@ namespace Org.Apache.REEF.Examples.HelloREEF
                 .Build();
 
             var result = _reefClient.SubmitAndGetJobStatus(helloJobRequest);
-
             LogApplicationReport();
             var state = PullFinalJobStatus(result);
             Logger.Log(Level.Info, "Application state : {0}.", state);
@@ -112,6 +111,17 @@ namespace Org.Apache.REEF.Examples.HelloREEF
             {
                 Logger.Log(Level.Info, "Application report -- AppId {0}: {1}.", r.Key, r.Value.ToString());
             }
+        }
+
+        /// <summary>
+        /// Kill Job Application.
+        /// </summary>
+        /// <param name="appId"></param>
+        private void KillJobApplication(string appId)
+        {
+            Logger.Log(Level.Info, "killing Application {0} ...", appId);
+            var state = _reefClient.KillJobApplication(appId);
+            Logger.Log(Level.Info, "Application killed with state: ", state);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
@@ -98,7 +98,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
             LogApplicationReport();
 
             //// This is an example to Kill Job Application
-            //// KillJobApplication(result.AppId);
+            //// KillApplication(result.AppId);
 
             var state = PullFinalJobStatus(result);
             Logger.Log(Level.Info, "Application final state : {0}.", state);
@@ -121,9 +121,9 @@ namespace Org.Apache.REEF.Examples.HelloREEF
         /// Sample code to kill Job Application.
         /// </summary>
         /// <param name="appId">Application id to kill</param>
-        private void KillJobApplication(string appId)
+        private void KillApplication(string appId)
         {
-            if (_reefClient.KillJobApplication(appId))
+            if (_reefClient.KillApplication(appId).Result)
             {
                 Logger.Log(Level.Info, "Application {0} is killed successfully.", appId);
             }

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using Org.Apache.REEF.Client.API;
 using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Client.Yarn;
+using Org.Apache.REEF.Client.Yarn.RestClient;
 using Org.Apache.REEF.Client.YARN;
 using Org.Apache.REEF.Client.YARN.RestClient.DataModel;
 using Org.Apache.REEF.Driver;
@@ -99,9 +100,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
             LogApplicationReport();
 
             //// This is to test Kill Job Application
-            //// KillJobApplication(result.AppId);
-
-            LogApplicationReport(result.AppId);
+            KillJobApplication(result.AppId);
 
             var state = PullFinalJobStatus(result);
             Logger.Log(Level.Info, "Application final state : {0}.", state);
@@ -121,36 +120,13 @@ namespace Org.Apache.REEF.Examples.HelloREEF
         }
 
         /// <summary>
-        /// Get application report and log for given appId
-        /// </summary>
-        private void LogApplicationReport(string appId)
-        {
-            Logger.Log(Level.Info, "Getting Application report...");
-            var apps = _reefClient.GetApplicationReports().Result;
-            Logger.Log(Level.Info, "Got Application report: {0}", apps.Count);
-            IApplicationReport report;
-            apps.TryGetValue(appId, out report);
-            if (report != null)
-            {
-                Logger.Log(Level.Info, "Application report -- AppId {0}: {1}.", appId, report.ToString());
-            }
-        }
-
-        /// <summary>
         /// Kill Job Application.
         /// </summary>
         /// <param name="appId">Application id to kill</param>
         private void KillJobApplication(string appId)
         {
-            try
-            {
-                var state = _reefClient.KillJobApplication(appId);
-                Logger.Log(Level.Info, "Application killed with state: ", state);
-            }
-            catch (Exception e)
-            {
-                Logger.Log(Level.Error, "Fail to kill Application with exception:", e);
-            }
+            var state = _reefClient.KillJobApplication(appId);
+            Logger.Log(Level.Info, "Application killed with state: ", state);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -23,7 +22,6 @@ using System.Threading;
 using Org.Apache.REEF.Client.API;
 using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Client.Yarn;
-using Org.Apache.REEF.Client.Yarn.RestClient;
 using Org.Apache.REEF.Client.YARN;
 using Org.Apache.REEF.Client.YARN.RestClient.DataModel;
 using Org.Apache.REEF.Driver;
@@ -99,15 +97,15 @@ namespace Org.Apache.REEF.Examples.HelloREEF
             var result = _reefClient.SubmitAndGetJobStatus(helloJobRequest);
             LogApplicationReport();
 
-            //// This is to test Kill Job Application
-            KillJobApplication(result.AppId);
+            //// This is an example to Kill Job Application
+            //// KillJobApplication(result.AppId);
 
             var state = PullFinalJobStatus(result);
             Logger.Log(Level.Info, "Application final state : {0}.", state);
         }
 
         /// <summary>
-        /// Get application report and log.
+        /// Sample code to get application report and log.
         /// </summary>
         private void LogApplicationReport()
         {
@@ -120,17 +118,25 @@ namespace Org.Apache.REEF.Examples.HelloREEF
         }
 
         /// <summary>
-        /// Kill Job Application.
+        /// Sample code to kill Job Application.
         /// </summary>
         /// <param name="appId">Application id to kill</param>
         private void KillJobApplication(string appId)
         {
-            var state = _reefClient.KillJobApplication(appId);
-            Logger.Log(Level.Info, "Application killed with state: ", state);
+            if (_reefClient.KillJobApplication(appId))
+            {
+                Logger.Log(Level.Info, "Application {0} is killed successfully.", appId);
+            }
+            else
+            {
+                Logger.Log(Level.Info, 
+                    "Failed to kill application {0}, possible reasons are application id is invalid or application has completed.", 
+                    appId);
+            }
         }
 
         /// <summary>
-        /// This is to pull job final status until the Job is done
+        /// Sample code to pull job final status until the Job is done
         /// </summary>
         /// <param name="jobSubmitionResult"></param>
         /// <returns></returns>

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -96,8 +97,14 @@ namespace Org.Apache.REEF.Examples.HelloREEF
 
             var result = _reefClient.SubmitAndGetJobStatus(helloJobRequest);
             LogApplicationReport();
+
+            //// This is to test Kill Job Application
+            //// KillJobApplication(result.AppId);
+
+            LogApplicationReport(result.AppId);
+
             var state = PullFinalJobStatus(result);
-            Logger.Log(Level.Info, "Application state : {0}.", state);
+            Logger.Log(Level.Info, "Application final state : {0}.", state);
         }
 
         /// <summary>
@@ -114,14 +121,36 @@ namespace Org.Apache.REEF.Examples.HelloREEF
         }
 
         /// <summary>
+        /// Get application report and log for given appId
+        /// </summary>
+        private void LogApplicationReport(string appId)
+        {
+            Logger.Log(Level.Info, "Getting Application report...");
+            var apps = _reefClient.GetApplicationReports().Result;
+            Logger.Log(Level.Info, "Got Application report: {0}", apps.Count);
+            IApplicationReport report;
+            apps.TryGetValue(appId, out report);
+            if (report != null)
+            {
+                Logger.Log(Level.Info, "Application report -- AppId {0}: {1}.", appId, report.ToString());
+            }
+        }
+
+        /// <summary>
         /// Kill Job Application.
         /// </summary>
-        /// <param name="appId"></param>
+        /// <param name="appId">Application id to kill</param>
         private void KillJobApplication(string appId)
         {
-            Logger.Log(Level.Info, "killing Application {0} ...", appId);
-            var state = _reefClient.KillJobApplication(appId);
-            Logger.Log(Level.Info, "Application killed with state: ", state);
+            try
+            {
+                var state = _reefClient.KillJobApplication(appId);
+                Logger.Log(Level.Info, "Application killed with state: ", state);
+            }
+            catch (Exception e)
+            {
+                Logger.Log(Level.Error, "Fail to kill Application with exception:", e);
+            }
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloTask.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloTask.cs
@@ -16,7 +16,6 @@
 // under the License.
 
 using System;
-using System.Threading;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
 


### PR DESCRIPTION
* Add API in IYarnREEFClient
* Implement in YarnClient and YarnREEFClient
* The  code is from #1352 and implemented on top of the latest interface change

JIRA: [REEF-1838](https://issues.apache.org/jira/browse/REEF-1838)
This closes #