### PR TITLE
[REEF-1014] Expose hard Evaluator preemption on YARN

### DIFF
--- a/lang/common/proto/reef_service_protos.proto
+++ b/lang/common/proto/reef_service_protos.proto
@@ -32,6 +32,7 @@ enum State {
     SUSPEND = 3;
     FAILED = 4;
     KILLED = 5;
+    PREEMPTED = 6;
 }
 
 message RuntimeErrorProto {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
@@ -29,6 +29,7 @@ import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.CompletedEvaluator;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.driver.evaluator.PreemptedEvaluator;
 import org.apache.reef.driver.parameters.*;
 import org.apache.reef.driver.task.*;
 import org.apache.reef.runtime.common.driver.DriverRuntimeConfiguration;
@@ -111,6 +112,11 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
    * Event handler for failed evaluators. Defaults to job failure if not bound.
    */
   public static final OptionalImpl<EventHandler<FailedEvaluator>> ON_EVALUATOR_FAILED = new OptionalImpl<>();
+
+  /**
+   * Event handler for preempted evaluators. Defaults to ON_EVALUATOR_FAILED if not bound.
+   */
+  public static final OptionalImpl<EventHandler<PreemptedEvaluator>> ON_EVALUATOR_PREEMPTED = new OptionalImpl<>();
 
   // ***** TASK HANDLER BINDINGS:
 
@@ -230,6 +236,7 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
       .bindSetEntry(EvaluatorAllocatedHandlers.class, ON_EVALUATOR_ALLOCATED)
       .bindSetEntry(EvaluatorCompletedHandlers.class, ON_EVALUATOR_COMPLETED)
       .bindSetEntry(EvaluatorFailedHandlers.class, ON_EVALUATOR_FAILED)
+      .bindSetEntry(EvaluatorPreemptedHandlers.class, ON_EVALUATOR_PREEMPTED)
 
           // Task handlers
       .bindSetEntry(TaskRunningHandlers.class, ON_TASK_RUNNING)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverServiceConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverServiceConfiguration.java
@@ -28,6 +28,7 @@ import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.CompletedEvaluator;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.driver.evaluator.PreemptedEvaluator;
 import org.apache.reef.driver.parameters.*;
 import org.apache.reef.driver.restart.DriverRestarted;
 import org.apache.reef.driver.task.*;
@@ -102,6 +103,12 @@ public final class DriverServiceConfiguration extends ConfigurationModuleBuilder
    */
   public static final OptionalImpl<EventHandler<FailedEvaluator>> ON_EVALUATOR_FAILED = new OptionalImpl<>();
 
+  /**
+   * Event handler for preempted evaluators. Defaults to ON_EVALUATOR_FAILED if not bound.
+   */
+  public static final OptionalImpl<EventHandler<PreemptedEvaluator>> ON_EVALUATOR_PREEMPTED = new OptionalImpl<>();
+
+
   // ***** TASK HANDLER BINDINGS:
 
   /**
@@ -173,6 +180,7 @@ public final class DriverServiceConfiguration extends ConfigurationModuleBuilder
       .bindSetEntry(ServiceEvaluatorAllocatedHandlers.class, ON_EVALUATOR_ALLOCATED)
       .bindSetEntry(ServiceEvaluatorCompletedHandlers.class, ON_EVALUATOR_COMPLETED)
       .bindSetEntry(ServiceEvaluatorFailedHandlers.class, ON_EVALUATOR_FAILED)
+      .bindSetEntry(ServiceEvaluatorPreemptedHandlers.class, ON_EVALUATOR_PREEMPTED)
 
           // Task handlers
       .bindSetEntry(ServiceTaskRunningHandlers.class, ON_TASK_RUNNING)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/PreemptedEvaluator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/PreemptedEvaluator.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.evaluator;
+
+import org.apache.reef.annotations.Provided;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Public;
+
+/**
+ * Represents an Evaluator that was preempted.
+ * It has the same interface as FailedEvaluator, on the basis that preemption is just a type of failure.
+ *
+ * If no EventHandler<PreemptedEvaluator> is registered by the user,
+ * PreemptedEvaluator will be translated into FailedEvaluator and EventHandler<FailedEvaluator> will be invoked.
+ * Refer to DefaultEvaluatorPreemptionHandler for more information.
+ */
+@DriverSide
+@Public
+@Provided
+public interface PreemptedEvaluator extends FailedEvaluator {
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorPreemptedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorPreemptedHandlers.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.parameters;
+
+import org.apache.reef.driver.evaluator.PreemptedEvaluator;
+import org.apache.reef.runtime.common.driver.defaults.DefaultEvaluatorPreemptionHandler;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.wake.EventHandler;
+
+import java.util.Set;
+
+/**
+ * Called when a preemption occurs on a running evaluator.
+ */
+@NamedParameter(doc = "Called when a preemption occurs on a running evaluator.",
+    default_classes = DefaultEvaluatorPreemptionHandler.class)
+public final class EvaluatorPreemptedHandlers implements Name<Set<EventHandler<PreemptedEvaluator>>> {
+  private EvaluatorPreemptedHandlers() {
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceEvaluatorPreemptedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceEvaluatorPreemptedHandlers.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.parameters;
+
+import org.apache.reef.driver.evaluator.PreemptedEvaluator;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.wake.EventHandler;
+
+import java.util.Set;
+
+/**
+ * Called when a preemption occurs on a running evaluator.
+ */
+@NamedParameter(doc = "Called when a preemption occurs on a running evaluator.")
+public final class ServiceEvaluatorPreemptedHandlers implements Name<Set<EventHandler<PreemptedEvaluator>>> {
+  private ServiceEvaluatorPreemptedHandlers() {
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/EvaluatorPreemptedException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/EvaluatorPreemptedException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.exception;
+
+/**
+ * Reported as part of a PreemptedEvaluator when the resource manager preempted the Evaluator.
+ */
+public final class EvaluatorPreemptedException extends EvaluatorException {
+
+  public EvaluatorPreemptedException(final String evaluatorId, final String message) {
+    super(evaluatorId, message);
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverSingletons.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverSingletons.java
@@ -27,6 +27,7 @@ import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.CompletedEvaluator;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.driver.evaluator.PreemptedEvaluator;
 import org.apache.reef.driver.parameters.*;
 import org.apache.reef.driver.task.*;
 import org.apache.reef.proto.ClientRuntimeProtocol;
@@ -61,6 +62,8 @@ final class DriverSingletons {
       @Parameter(EvaluatorAllocatedHandlers.class)
       final Set<EventHandler<AllocatedEvaluator>> evaluatorAllocatedEventHandlers,
       @Parameter(EvaluatorFailedHandlers.class) final Set<EventHandler<FailedEvaluator>> evaluatorFailedHandlers,
+      @Parameter(EvaluatorPreemptedHandlers.class)
+      final Set<EventHandler<PreemptedEvaluator>> evaluatorPreemptedHandlers,
       @Parameter(EvaluatorCompletedHandlers.class)
       final Set<EventHandler<CompletedEvaluator>> evaluatorCompletedHandlers,
 
@@ -87,6 +90,8 @@ final class DriverSingletons {
       final Set<EventHandler<FailedEvaluator>> serviceEvaluatorFailedHandlers,
       @Parameter(ServiceEvaluatorCompletedHandlers.class)
       final Set<EventHandler<CompletedEvaluator>> serviceEvaluatorCompletedHandlers,
+      @Parameter(ServiceEvaluatorPreemptedHandlers.class)
+      final Set<EventHandler<PreemptedEvaluator>> serviceEvaluatorPreemptedHandlers,
 
       // Client event handler
       @Parameter(DriverRuntimeConfigurationOptions.JobControlHandler.class)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultEvaluatorPreemptionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultEvaluatorPreemptionHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.driver.defaults;
+
+import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.driver.evaluator.PreemptedEvaluator;
+import org.apache.reef.driver.parameters.EvaluatorFailedHandlers;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.EventHandler;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+/**
+ * Default event handler used for PreemptedEvaluator: It invokes the registered FailedEvaluator handlers.
+ */
+public final class DefaultEvaluatorPreemptionHandler implements EventHandler<PreemptedEvaluator> {
+  private final Set<EventHandler<FailedEvaluator>> evaluatorFailedHandlers;
+
+  @Inject
+  public DefaultEvaluatorPreemptionHandler(@Parameter(EvaluatorFailedHandlers.class)
+                                           final Set<EventHandler<FailedEvaluator>> evaluatorFailedHandlers) {
+    this.evaluatorFailedHandlers = evaluatorFailedHandlers;
+  }
+
+  @Override
+  public void onNext(final PreemptedEvaluator preemptedEvaluator) {
+    for (final EventHandler<FailedEvaluator> handler : evaluatorFailedHandlers) {
+      handler.onNext(preemptedEvaluator);
+    }
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorState.java
@@ -48,7 +48,10 @@ enum EvaluatorState {
   FAILED,
 
   /** Unclean shutdown. */
-  KILLED;
+  KILLED,
+
+  /** Preemption. */
+  PREEMPTED;
 
   /**
    * Check if evaluator is in the initial state (ALLOCATED).
@@ -91,11 +94,11 @@ enum EvaluatorState {
   }
 
   /**
-   * Check if the evaluator is stopped. That is, in one of the DONE, FAILED, or KILLED states.
+   * Check if the evaluator is stopped. That is, in one of the DONE, FAILED, PREEMPTED or KILLED states.
    * @return true if evaluator completed, false if it is still available or in the process of being shut down.
    */
   public final boolean isCompleted() {
-    return this == DONE || this == FAILED || this == KILLED;
+    return this == DONE || this == FAILED || this == KILLED || this == PREEMPTED;
   }
 
   /**
@@ -128,6 +131,7 @@ enum EvaluatorState {
       case CLOSING:
       case DONE:
       case FAILED:
+      case PREEMPTED:
       case KILLED:
         return true;
       default:
@@ -140,6 +144,7 @@ enum EvaluatorState {
       case CLOSING:
       case DONE:
       case FAILED:
+      case PREEMPTED:
       case KILLED:
         return true;
       default:
@@ -151,6 +156,7 @@ enum EvaluatorState {
       case CLOSING:
       case DONE:
       case FAILED:
+      case PREEMPTED:
       case KILLED:
         return true;
       default:
@@ -161,6 +167,7 @@ enum EvaluatorState {
       switch(toState) {
       case DONE:
       case FAILED:
+      case PREEMPTED:
       case KILLED:
         return true;
       default:
@@ -169,6 +176,7 @@ enum EvaluatorState {
 
     case DONE:
     case FAILED:
+    case PREEMPTED:
     case KILLED:
       return false;
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
@@ -120,7 +120,7 @@ final class EvaluatorStatusManager {
   }
 
   /**
-   * Check if the evaluator is stopped. That is, in one of the DONE, FAILED, or KILLED states.
+   * Check if the evaluator is stopped. That is, in one of the DONE, FAILED or KILLED states.
    * @return true if evaluator completed, false if it is still available or in the process of being shut down.
    * @deprecated TODO[JIRA REEF-1560] Use isCompleted() method instead. Remove after version 0.16
    */
@@ -130,7 +130,7 @@ final class EvaluatorStatusManager {
   }
 
   /**
-   * Check if the evaluator is stopped. That is, in one of the DONE, FAILED, or KILLED states.
+   * Check if the evaluator is stopped. That is, in one of the DONE, FAILED, PREEMPTED or KILLED states.
    * @return true if evaluator completed, false if it is still available or in the process of being shut down.
    */
   boolean isCompleted() {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/PreemptedEvaluatorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/PreemptedEvaluatorImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.driver.evaluator;
+
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.driver.context.FailedContext;
+import org.apache.reef.driver.evaluator.PreemptedEvaluator;
+import org.apache.reef.driver.task.FailedTask;
+import org.apache.reef.exception.EvaluatorException;
+import org.apache.reef.util.Optional;
+
+import java.util.List;
+
+@DriverSide
+@Private
+final class PreemptedEvaluatorImpl implements PreemptedEvaluator {
+
+  final String id;
+  private final EvaluatorException ex;
+  private final List<FailedContext> ctx;
+  private final Optional<FailedTask> task;
+
+  PreemptedEvaluatorImpl(final EvaluatorException ex,
+                         final List<FailedContext> ctx,
+                         final Optional<FailedTask> task,
+                         final String id) {
+    this.ex = ex;
+    this.ctx = ctx;
+    this.task = task;
+    this.id = id;
+  }
+
+  @Override
+  public EvaluatorException getEvaluatorException() {
+    return this.ex;
+  }
+
+  @Override
+  public List<FailedContext> getFailedContextList() {
+    return this.ctx;
+  }
+
+  @Override
+  public Optional<FailedTask> getFailedTask() {
+    return this.task;
+  }
+
+  @Override
+  public String getId() {
+    return this.id;
+  }
+
+  @Override
+  public String toString() {
+    return "PreemptedEvaluator{" +
+        "id='" + id + '\'' +
+        '}';
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/pojos/State.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/pojos/State.java
@@ -35,6 +35,7 @@ public enum State {
   SUSPEND,
   DONE,
   FAILED,
+  PREEMPTED,
   KILLED;
 
   /**
@@ -54,6 +55,8 @@ public enum State {
       return DONE;
     case FAILED:
       return FAILED;
+    case PREEMPTED:
+      return PREEMPTED;
     case KILLED:
       return KILLED;
     default:
@@ -81,6 +84,7 @@ public enum State {
       case SUSPEND:
       case DONE:
       case FAILED:
+      case PREEMPTED:
       case KILLED:
         return true;
       default:
@@ -92,6 +96,7 @@ public enum State {
       case SUSPEND:
       case DONE:
       case FAILED:
+      case PREEMPTED:
       case KILLED:
         return true;
       default:
@@ -102,6 +107,7 @@ public enum State {
       switch (toState) {
       case RUNNING:
       case FAILED:
+      case PREEMPTED:
       case KILLED:
         return true;
       default:
@@ -130,11 +136,11 @@ public enum State {
   }
 
   /**
-   * Check if the container is stopped. That is, in one of the DONE, FAILED, or KILLED states.
+   * Check if the container is stopped. That is, in one of the DONE, FAILED, PREEMPTED or KILLED states.
    * @return true if the container is completed, false if it is still available or suspended.
    */
   public final boolean isCompleted() {
-    return this == DONE || this == FAILED || this == KILLED;
+    return this == DONE || this == FAILED || this == PREEMPTED || this == KILLED;
   }
 
   /**

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -453,11 +453,18 @@ final class YarnContainerManager implements AMRMClientAsync.CallbackHandler, NMC
       case COMPLETE:
         LOG.log(Level.FINE, "Container completed: status {0}", value.getExitStatus());
         switch (value.getExitStatus()) {
-        case 0:
+        case ContainerExitStatus.SUCCESS:
           status.setState(State.DONE);
           break;
-        case 143:
+        case ContainerExitStatus.KILLED_BY_RESOURCEMANAGER:
+        case ContainerExitStatus.KILLED_EXCEEDED_PMEM:
+        case ContainerExitStatus.KILLED_EXCEEDED_VMEM:
+        case ContainerExitStatus.KILLED_AFTER_APP_COMPLETION:
+        case ContainerExitStatus.KILLED_BY_APPMASTER:
           status.setState(State.KILLED);
+          break;
+        case ContainerExitStatus.PREEMPTED:
+          status.setState(State.PREEMPTED);
           break;
         default:
           status.setState(State.FAILED);

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/YarnPreemptionTask.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/YarnPreemptionTask.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.yarnpreemption;
+
+import org.apache.reef.task.Task;
+
+import javax.inject.Inject;
+import java.util.concurrent.CountDownLatch;
+
+final class YarnPreemptionTask implements Task{
+
+  private final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+  @Inject
+  YarnPreemptionTask() {
+  }
+
+  @Override
+  public byte[] call(final byte[] memento) throws Exception {
+    countDownLatch.await();
+    return new byte[0];
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/YarnPreemptionTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/YarnPreemptionTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.yarnpreemption;
+
+import org.apache.reef.client.DriverConfiguration;
+import org.apache.reef.client.DriverLauncher;
+import org.apache.reef.client.LauncherStatus;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tests.TestEnvironment;
+import org.apache.reef.tests.TestEnvironmentFactory;
+import org.apache.reef.util.EnvironmentUtils;
+import org.junit.*;
+
+/**
+ * Tests whether REEF can handle PreemptedEvaluator when a YARN container is preempted.
+ */
+public class YarnPreemptionTest {
+  private final TestEnvironment testEnvironment = TestEnvironmentFactory.getNewTestEnvironment();
+
+  @Before
+  public void setUp() throws Exception {
+    this.testEnvironment.setUp();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    this.testEnvironment.tearDown();
+  }
+
+  private void runYarnPreemptionTest() throws InjectionException, InterruptedException {
+    final Configuration runtimeConfiguration = this.testEnvironment.getRuntimeConfiguration();
+
+    Thread preempteeThread = new Thread() {
+      public void run() {
+
+        final Configuration testConfigurationB = YarnPreemptionTestConfiguration.CONF
+            .set(YarnPreemptionTestConfiguration.JOB_QUEUE, "B")
+            .build();
+
+        final Configuration driverConfiguration = DriverConfiguration.CONF
+            .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(this.getClass()))
+            .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_YarnPreemptionTest_Preemptee")
+            .set(DriverConfiguration.ON_DRIVER_STARTED, YarnPreemptionTestPreempteeDriver.StartHandler.class)
+            .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED,
+                YarnPreemptionTestPreempteeDriver.EvaluatorAllocatedHandler.class)
+            .set(DriverConfiguration.ON_EVALUATOR_PREEMPTED,
+                YarnPreemptionTestPreempteeDriver.EvaluatorPreemptedHandler.class)
+            .set(DriverConfiguration.ON_EVALUATOR_FAILED,
+                YarnPreemptionTestPreempteeDriver.EvaluatorFailedHandler.class)
+            .build();
+
+
+        final Configuration mergedDriverConfiguration = Tang.Factory.getTang()
+            .newConfigurationBuilder(driverConfiguration, testConfigurationB).build();
+
+        try {
+          final LauncherStatus state = DriverLauncher.getLauncher(runtimeConfiguration)
+              .run(mergedDriverConfiguration, testEnvironment.getTestTimeout());
+          Assert.assertTrue("Job B (preemptee) state after execution: " + state, state.isDone());
+
+        } catch (InjectionException e) {
+          e.printStackTrace();
+        }
+      }
+    };
+
+    Thread preemptorThread = new Thread() {
+      public void run() {
+
+        try {
+          Thread.sleep(6000);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+
+        final Configuration testConfigurationA = YarnPreemptionTestConfiguration.CONF
+            .set(YarnPreemptionTestConfiguration.JOB_QUEUE, "A")
+            .build();
+
+        final Configuration driverConfiguration = DriverConfiguration.CONF
+            .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(this.getClass()))
+            .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_YarnPreemptionTest_Preemptor")
+            .set(DriverConfiguration.ON_DRIVER_STARTED, YarnPreemptionTestPreemptorDriver.StartHandler.class)
+            .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED,
+                YarnPreemptionTestPreemptorDriver.EvaluatorAllocatedHandler.class)
+            .build();
+
+        final Configuration mergedDriverConfiguration = Tang.Factory.getTang()
+            .newConfigurationBuilder(driverConfiguration, testConfigurationA).build();
+
+        try {
+          final LauncherStatus state = DriverLauncher.getLauncher(runtimeConfiguration)
+              .run(mergedDriverConfiguration, testEnvironment.getTestTimeout());
+          Assert.assertTrue("Job A (preemptor) state after execution: " + state, state.isSuccess());
+        } catch (InjectionException e) {
+          e.printStackTrace();
+        }
+
+      }
+    };
+
+    preempteeThread.start();
+    preemptorThread.start();
+
+    preempteeThread.join();
+    preemptorThread.join();
+  }
+
+  @Test
+  public void testYarnPreemption() throws InjectionException, InterruptedException {
+    Assume.assumeTrue("This test requires a YARN Resource Manager to connect to",
+        Boolean.parseBoolean(System.getenv("REEF_TEST_YARN")));
+    runYarnPreemptionTest();
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/YarnPreemptionTestConfiguration.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/YarnPreemptionTestConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.yarnpreemption;
+
+import org.apache.reef.runtime.yarn.client.parameters.JobQueue;
+import org.apache.reef.tang.formats.ConfigurationModule;
+import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
+import org.apache.reef.tang.formats.RequiredParameter;
+
+/**
+ * Configuration for YarnPreemptionTest.
+ */
+public final class YarnPreemptionTestConfiguration extends ConfigurationModuleBuilder {
+
+  public static final RequiredParameter<String> JOB_QUEUE = new RequiredParameter<>();
+  public static final ConfigurationModule CONF = new YarnPreemptionTestConfiguration()
+      .bindNamedParameter(JobQueue.class, JOB_QUEUE)
+      .build();
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/YarnPreemptionTestPreempteeDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/YarnPreemptionTestPreempteeDriver.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.yarnpreemption;
+
+import org.apache.reef.driver.evaluator.*;
+import org.apache.reef.driver.task.TaskConfiguration;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.annotations.Unit;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.StartTime;
+import org.junit.Assert;
+
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Unit
+final class YarnPreemptionTestPreempteeDriver {
+
+  private static final Logger LOG = Logger.getLogger(YarnPreemptionTestPreempteeDriver.class.getName());
+
+  private final EvaluatorRequestor evaluatorRequestor;
+  private boolean isPreempted;
+
+  @Inject
+  private YarnPreemptionTestPreempteeDriver(final EvaluatorRequestor evaluatorRequestor) {
+    this.evaluatorRequestor = evaluatorRequestor;
+    this.isPreempted = false;
+  }
+
+  final class StartHandler implements EventHandler<StartTime> {
+    @Override
+    public void onNext(final StartTime value) {
+      LOG.log(Level.INFO, "Submit an EvaluatorRequest to be preempted");
+      YarnPreemptionTestPreempteeDriver.this.evaluatorRequestor.submit(EvaluatorRequest.newBuilder()
+          .setNumber(1)
+          .setMemory(64)
+          .setNumberOfCores(6)
+          .build());
+    }
+  }
+
+  final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
+
+    @Override
+    public void onNext(final AllocatedEvaluator allocatedEvaluator) {
+      LOG.log(Level.INFO, "Start YarnPreemptionTask to AllocatedEvaluator: {0}", allocatedEvaluator);
+      final Configuration taskConfiguration = TaskConfiguration.CONF
+          .set(TaskConfiguration.TASK, YarnPreemptionTask.class)
+          .set(TaskConfiguration.IDENTIFIER, "YarnPreemptionTask")
+          .build();
+      allocatedEvaluator.submitTask(taskConfiguration);
+    }
+  }
+
+  final class EvaluatorPreemptedHandler implements EventHandler<PreemptedEvaluator> {
+    @Override
+    public void onNext(final PreemptedEvaluator value) {
+      LOG.log(Level.INFO, "Evaluator is preempted!");
+      isPreempted = true;
+    }
+  }
+
+  final class EvaluatorFailedHandler implements EventHandler<FailedEvaluator> {
+
+    @Override
+    public void onNext(final FailedEvaluator value) {
+      LOG.log(Level.INFO, "Evaluator is failed!");
+      Assert.assertTrue("Preempt flag: " + isPreempted, isPreempted);
+    }
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/YarnPreemptionTestPreemptorDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/YarnPreemptionTestPreemptorDriver.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.yarnpreemption;
+
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.evaluator.EvaluatorRequest;
+import org.apache.reef.driver.evaluator.EvaluatorRequestor;
+import org.apache.reef.driver.task.TaskConfiguration;
+import org.apache.reef.examples.hello.HelloTask;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.annotations.Unit;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.StartTime;
+
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Unit
+final class YarnPreemptionTestPreemptorDriver {
+
+  private static final Logger LOG = Logger.getLogger(YarnPreemptionTestPreemptorDriver.class.getName());
+
+  private final EvaluatorRequestor evaluatorRequestor;
+
+  @Inject
+  private YarnPreemptionTestPreemptorDriver(final EvaluatorRequestor evaluatorRequestor) {
+    this.evaluatorRequestor = evaluatorRequestor;
+  }
+
+  final class StartHandler implements EventHandler<StartTime> {
+    @Override
+    public void onNext(final StartTime value) {
+      LOG.log(Level.INFO, "Submit a preemptor EvaluatorRequest.");
+      YarnPreemptionTestPreemptorDriver.this.evaluatorRequestor.submit(EvaluatorRequest.newBuilder()
+          .setNumber(1)
+          .setMemory(64)
+          .setNumberOfCores(6)
+          .build());
+    }
+  }
+
+  final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
+    @Override
+    public void onNext(final AllocatedEvaluator allocatedEvaluator) {
+      LOG.log(Level.INFO, "Submitting HelloREEF task to AllocatedEvaluator: {0}", allocatedEvaluator);
+      final Configuration taskConfiguration = TaskConfiguration.CONF
+          .set(TaskConfiguration.IDENTIFIER, "HelloREEFTask")
+          .set(TaskConfiguration.TASK, HelloTask.class)
+          .build();
+      allocatedEvaluator.submitTask(taskConfiguration);
+    }
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/yarnpreemption/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Test reef.io.watcher.
+ */
+package org.apache.reef.tests.yarnpreemption;


### PR DESCRIPTION
This addressed the issue by
  * Expose to REEF users hard Evaluator preemption on YARN.

  For test, you have to enable preemption and configure 2 queues in YARN,
  queue A with 80% and queue B with 20% of total resources.
  Use following command for test.
  runyarntests.sh org.apache.reef.tests.yarnpreemption.YarnPreemptionTest

JIRA:
  [REEF-1014](https://issues.apache.org/jira/browse/REEF-1014)

Pull Request:
  This closes #