### PR TITLE
[REEF-1860] Enable Mesos Node Labels

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorDescriptor.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorDescriptor.java
@@ -20,6 +20,8 @@ package org.apache.reef.driver.evaluator;
 
 import org.apache.reef.driver.catalog.NodeDescriptor;
 
+import java.util.Map;
+
 /**
  * Metadata about an Evaluator.
  */
@@ -49,4 +51,9 @@ public interface EvaluatorDescriptor {
    * @return name of the runtime that was used to allocate this Evaluator
    */
   String getRuntimeName();
+
+  /**
+   * @return node labels on this Evaluator
+   */
+  Map<String, String> getNodeLabels();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -25,6 +25,8 @@ import org.apache.reef.annotations.audience.Public;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 /**
  * A request for one ore more Evaluators.
@@ -41,13 +43,14 @@ public final class EvaluatorRequest {
   private final List<String> rackNames;
   private final String runtimeName;
   private final boolean relaxLocality;
+  private final Map<String, String> nodeLabels;
 
   EvaluatorRequest(final int number,
                    final int megaBytes,
                    final int cores,
                    final List<String> nodeNames,
                    final List<String> rackNames) {
-    this(number, megaBytes, cores, nodeNames, rackNames, "");
+    this(number, megaBytes, cores, nodeNames, rackNames, "", new HashMap<String, String>(), true);
   }
 
   EvaluatorRequest(final int number,
@@ -56,9 +59,8 @@ public final class EvaluatorRequest {
                    final List<String> nodeNames,
                    final List<String> rackNames,
                    final String runtimeName) {
-    this(number, megaBytes, cores, nodeNames, rackNames, runtimeName, true);
+    this(number, megaBytes, cores, nodeNames, rackNames, runtimeName, new HashMap<String, String>(), true);
   }
-
 
   EvaluatorRequest(final int number,
                    final int megaBytes,
@@ -66,6 +68,7 @@ public final class EvaluatorRequest {
                    final List<String> nodeNames,
                    final List<String> rackNames,
                    final String runtimeName,
+                   final Map<String, String> nodeLabels,
                    final boolean relaxLocality) {
     this.number = number;
     this.megaBytes = megaBytes;
@@ -74,6 +77,7 @@ public final class EvaluatorRequest {
     this.rackNames = rackNames;
     this.runtimeName = runtimeName;
     this.relaxLocality = relaxLocality;
+    this.nodeLabels = nodeLabels;
   }
 
   /**
@@ -93,6 +97,15 @@ public final class EvaluatorRequest {
    */
   public static Builder newBuilder(final EvaluatorRequest request) {
     return new Builder(request);
+  }
+
+  /**
+   * Access the node labels requested.
+   *
+   * @return the node labels requested.
+   */
+  public Map<String, String> getNodeLabels() {
+    return this.nodeLabels;
   }
 
   /**
@@ -171,6 +184,7 @@ public final class EvaluatorRequest {
     private final List<String> rackNames = new ArrayList<>();
     private String runtimeName = "";
     private boolean relaxLocality = true; //if not set, default to true
+    private Map<String, String> nodeLabels = new HashMap<>();
 
     @Private
     public Builder() {
@@ -188,12 +202,21 @@ public final class EvaluatorRequest {
       setNumberOfCores(request.getNumberOfCores());
       setRuntimeName(request.getRuntimeName());
       setRelaxLocality(request.getRelaxLocality());
+      for (Map.Entry<String, String> elem : request.getNodeLabels().entrySet()) {
+        setNodeLabel(elem.getKey(), elem.getValue());
+      }
       for (final String nodeName : request.getNodeNames()) {
         addNodeName(nodeName);
       }
       for (final String rackName : request.getRackNames()) {
         addRackName(rackName);
       }
+    }
+
+    @SuppressWarnings("checkstyle:hiddenfield")
+    public T setNodeLabel(final String key, final String value) {
+      nodeLabels.put(key, value);
+      return (T) this;
     }
 
     /**
@@ -304,8 +327,8 @@ public final class EvaluatorRequest {
      */
     @Override
     public EvaluatorRequest build() {
-      return new EvaluatorRequest(this.n, this.megaBytes, this.cores, this.nodeNames,
-                                  this.rackNames, this.runtimeName, this.relaxLocality);
+      return new EvaluatorRequest(this.n, this.megaBytes, this.cores,
+          this.nodeNames, this.rackNames, this.runtimeName, this.nodeLabels, this.relaxLocality);
     }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
@@ -109,6 +109,7 @@ public final class EvaluatorRequestorImpl implements EvaluatorRequestor {
           .addRackNames(req.getRackNames())
           .setRelaxLocality(relaxLocality)
           .setRuntimeName(req.getRuntimeName())
+          .setNodeLabels(req.getNodeLabels())
           .build();
       this.resourceRequestHandler.onNext(request);
     }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
@@ -24,6 +24,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.util.Optional;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Event from Driver Process to Driver Runtime.
@@ -33,6 +34,11 @@ import java.util.List;
 @DriverSide
 @DefaultImplementation(ResourceRequestEventImpl.class)
 public interface ResourceRequestEvent {
+
+  /**
+   * @return The node labels.
+   */
+  Map<String, String> getNodeLabels();
 
   /**
    * @return The number of resources requested

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
@@ -23,6 +23,8 @@ import org.apache.reef.util.Optional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 /**
  * Default POJO implementation of ResourceRequestEvent.
@@ -37,6 +39,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
   private final Optional<Integer> virtualCores;
   private final Optional<Boolean> relaxLocality;
   private final String runtimeName;
+  private final Map<String, String> nodeLabels;
 
   private ResourceRequestEventImpl(final Builder builder) {
     this.resourceCount = BuilderUtils.notNull(builder.resourceCount);
@@ -47,6 +50,12 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     this.virtualCores = Optional.ofNullable(builder.virtualCores);
     this.relaxLocality = Optional.ofNullable(builder.relaxLocality);
     this.runtimeName = builder.runtimeName == null ? "" : builder.runtimeName;
+    this.nodeLabels = builder.nodeLabels == null ? new HashMap<String, String>() : builder.nodeLabels;
+  }
+
+  @Override
+  public Map<String, String> getNodeLabels() {
+    return nodeLabels;
   }
 
   @Override
@@ -105,6 +114,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     private Integer virtualCores;
     private Boolean relaxLocality;
     private String runtimeName;
+    private Map<String, String> nodeLabels;
 
     /**
      * Create a builder from an existing ResourceRequestEvent.
@@ -118,6 +128,15 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
       this.virtualCores = resourceRequestEvent.getVirtualCores().orElse(null);
       this.relaxLocality = resourceRequestEvent.getRelaxLocality().orElse(null);
       this.runtimeName = resourceRequestEvent.getRuntimeName();
+      this.nodeLabels = resourceRequestEvent.getNodeLabels();
+      return this;
+    }
+
+    /**
+     * set node labels.
+     */
+    public Builder setNodeLabels(final Map<String, String> nodeLabels) {
+      this.nodeLabels = nodeLabels;
       return this;
     }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorDescriptorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorDescriptorImpl.java
@@ -24,6 +24,10 @@ import org.apache.reef.driver.catalog.NodeDescriptor;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
 import org.apache.reef.driver.evaluator.EvaluatorProcess;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * A simple all-data implementation of EvaluatorDescriptor.
  */
@@ -36,17 +40,28 @@ final class EvaluatorDescriptorImpl implements EvaluatorDescriptor {
   private final int numberOfCores;
   private EvaluatorProcess process;
   private final String runtimeName;
+  private final Map<String, String> nodeLabels;
 
   EvaluatorDescriptorImpl(final NodeDescriptor nodeDescriptor,
                           final int megaBytes,
                           final int numberOfCores,
                           final EvaluatorProcess process,
                           final String runtimeName) {
+    this(nodeDescriptor, megaBytes, numberOfCores, process, runtimeName, new HashMap<String, String>());
+  }
+
+  EvaluatorDescriptorImpl(final NodeDescriptor nodeDescriptor,
+                          final int megaBytes,
+                          final int numberOfCores,
+                          final EvaluatorProcess process,
+                          final String runtimeName,
+                          final Map<String, String> nodeLabels) {
     this.nodeDescriptor = nodeDescriptor;
     this.megaBytes = megaBytes;
     this.numberOfCores = numberOfCores;
     this.process = process;
     this.runtimeName = runtimeName;
+    this.nodeLabels = nodeLabels;
   }
 
   @Override
@@ -79,5 +94,9 @@ final class EvaluatorDescriptorImpl implements EvaluatorDescriptor {
   @Override
   public String getRuntimeName() {
     return this.runtimeName;
+  }
+
+  public Map<String, String> getNodeLabels() {
+    return Collections.unmodifiableMap(this.nodeLabels);
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
@@ -74,7 +74,8 @@ public final class EvaluatorManagerFactory {
     }
     final EvaluatorDescriptorImpl evaluatorDescriptor = new EvaluatorDescriptorImpl(nodeDescriptor,
         resourceEvent.getResourceMemory(), resourceEvent.getVirtualCores().get(),
-        processFactory.newEvaluatorProcess(), resourceEvent.getRuntimeName());
+        processFactory.newEvaluatorProcess(), resourceEvent.getRuntimeName(),
+        resourceEvent.getNodeLabels());
 
     LOG.log(Level.FINEST, "Resource allocation: new evaluator id[{0}]", resourceEvent.getIdentifier());
     final EvaluatorManager evaluatorManager =

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceEvent.java
@@ -22,6 +22,8 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.util.Optional;
 
+import java.util.Map;
+
 /**
  * An interface capturing the characteristics of a resource event.
  */
@@ -58,4 +60,11 @@ public interface ResourceEvent {
    * @return Runtime name of the resource
    */
   String getRuntimeName();
+
+  /**
+   * @return Node labels of the resource.
+   * In YARN, key is a static constant string and value is the node label.
+   * In Mesos, these are required Attributes.
+   */
+  Map<String, String> getNodeLabels();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceEventImpl.java
@@ -21,6 +21,8 @@ package org.apache.reef.runtime.common.driver.resourcemanager;
 import org.apache.reef.util.BuilderUtils;
 import org.apache.reef.util.Optional;
 
+import java.util.Map;
+
 /**
  * Default POJO implementation of ResourceAllocationEvent and ResourceRecoverEvent.
  * Use newAllocationBuilder to construct an instance for ResourceAllocationEvent and
@@ -33,6 +35,7 @@ public final class ResourceEventImpl implements ResourceAllocationEvent, Resourc
   private final Optional<Integer> virtualCores;
   private final Optional<String> rackName;
   private final String runtimeName;
+  private final Map<String, String> nodeLabels;
 
 
   private ResourceEventImpl(final Builder builder) {
@@ -42,6 +45,7 @@ public final class ResourceEventImpl implements ResourceAllocationEvent, Resourc
     this.virtualCores = Optional.ofNullable(builder.virtualCores);
     this.rackName = Optional.ofNullable(builder.rackName);
     this.runtimeName = BuilderUtils.notNull(builder.runtimeName);
+    this.nodeLabels = builder.nodeLabels;
   }
 
   @Override
@@ -74,6 +78,11 @@ public final class ResourceEventImpl implements ResourceAllocationEvent, Resourc
     return runtimeName;
   }
 
+  @Override
+  public Map<String, String> getNodeLabels() {
+    return nodeLabels;
+  }
+
   public static Builder newAllocationBuilder() {
     return new Builder(false);
   }
@@ -94,6 +103,7 @@ public final class ResourceEventImpl implements ResourceAllocationEvent, Resourc
     private Integer virtualCores;
     private String rackName;
     private String runtimeName;
+    private Map<String, String> nodeLabels;
 
     private Builder(final boolean recovery){
       this.recovery = recovery;
@@ -146,6 +156,16 @@ public final class ResourceEventImpl implements ResourceAllocationEvent, Resourc
       this.runtimeName = runtimeName;
       return this;
     }
+
+    /**
+     * @see ResourceAllocationEvent#getNodeLabels()
+     * @param nodeLabels
+     */
+    public Builder setNodeLabels(final Map<String, String> nodeLabels) {
+      this.nodeLabels = nodeLabels;
+      return this;
+    }
+
 
     @Override
     public ResourceEventImpl build() {

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/mesosnodelabel/NodeLabelTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/mesosnodelabel/NodeLabelTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.mesosnodelabel;
+
+import org.apache.reef.client.DriverConfiguration;
+import org.apache.reef.client.DriverLauncher;
+import org.apache.reef.client.LauncherStatus;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.exceptions.BindException;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tests.TestEnvironment;
+import org.apache.reef.tests.TestEnvironmentFactory;
+import org.apache.reef.util.EnvironmentUtils;
+import org.junit.*;
+
+/**
+ * Tests whether Evaluator allocations requested with a given node label are fulfilled.
+ * Before running this test, configure Mesos to let the Mesos master sends offer with attribute "mylabel"
+ * when resources are offered from a specific Mesos agent.
+ *
+ * In the test, the NodeLabelTestDriver submits an EvaluatorRequest labeled with "mylabel:mylabel".
+ * The test passes if there comes one evaluator from the node that contains "mylabel:mylabel" attribute.
+ */
+public class NodeLabelTest {
+  private final TestEnvironment testEnvironment = TestEnvironmentFactory.getNewTestEnvironment();
+
+  @Before
+  public void setUp() throws Exception {
+    this.testEnvironment.setUp();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    this.testEnvironment.tearDown();
+  }
+
+  private LauncherStatus runNodeLabelTest() throws BindException, InjectionException {
+    final Configuration runtimeConfiguration = this.testEnvironment.getRuntimeConfiguration();
+
+    final Configuration driverConfiguration = DriverConfiguration.CONF
+        .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(NodeLabelTestDriver.class))
+        .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_REEFMesosNodeLabelTest")
+        .set(DriverConfiguration.ON_DRIVER_STARTED, NodeLabelTestDriver.StartHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, NodeLabelTestDriver.EvaluatorAllocatedHandler.class)
+        .set(DriverConfiguration.ON_DRIVER_STOP, NodeLabelTestDriver.StopHandler.class)
+        .build();
+
+    final LauncherStatus state = DriverLauncher.getLauncher(runtimeConfiguration)
+        .run(driverConfiguration, this.testEnvironment.getTestTimeout());
+    return state;
+  }
+
+
+  @Test
+  public void testNodeLabel() throws BindException, InjectionException {
+    Assume.assumeTrue("This test requires a Mesos Resource Manager to connect to",
+        Boolean.parseBoolean(System.getenv("REEF_TEST_MESOS")));
+
+    final LauncherStatus state = runNodeLabelTest();
+    Assert.assertTrue("Job state after execution: " + state, state.isSuccess());
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/mesosnodelabel/NodeLabelTestDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/mesosnodelabel/NodeLabelTestDriver.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.mesosnodelabel;
+
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.evaluator.EvaluatorRequest;
+import org.apache.reef.driver.evaluator.EvaluatorRequestor;
+import org.apache.reef.driver.task.TaskConfiguration;
+import org.apache.reef.examples.hello.HelloTask;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.annotations.Unit;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.StartTime;
+import org.apache.reef.wake.time.event.StopTime;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Unit
+final class NodeLabelTestDriver {
+  private static final Logger LOG = Logger.getLogger(NodeLabelTestDriver.class.getName());
+
+  private final EvaluatorRequestor evaluatorRequestor;
+
+  private final String nodeLabelExpression = "mylabel";
+  private int labeledContainerCount;
+  private int defaultContainerCount;
+
+  @Inject
+  NodeLabelTestDriver(final EvaluatorRequestor evaluatorRequestor) {
+    this.evaluatorRequestor = evaluatorRequestor;
+    this.labeledContainerCount = 0;
+    this.defaultContainerCount = 0;
+  }
+
+  final class StartHandler implements EventHandler<StartTime> {
+    @Override
+    public void onNext(final StartTime startTime) {
+      final EvaluatorRequest reqToMylabel = EvaluatorRequest.newBuilder()
+          .setNumber(1)
+          .setMemory(64)
+          .setNumberOfCores(1)
+          .setNodeLabel(NodeLabelTestDriver.this.nodeLabelExpression, NodeLabelTestDriver.this.nodeLabelExpression)
+          .build();
+      LOG.log(Level.INFO, "Requested Evaluator with node label: {0}", reqToMylabel.getNodeLabels());
+      NodeLabelTestDriver.this.evaluatorRequestor.submit(reqToMylabel);
+
+      final EvaluatorRequest reqToDefault = EvaluatorRequest.newBuilder()
+          .setNumber(1)
+          .setMemory(64)
+          .setNumberOfCores(1)
+          .build();
+      LOG.log(Level.INFO, "Requested Evaluator without node label");
+      NodeLabelTestDriver.this.evaluatorRequestor.submit(reqToDefault);
+    }
+  }
+
+  final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
+    @Override
+    public void onNext(final AllocatedEvaluator allocatedEvaluator) {
+      LOG.log(Level.INFO, "Evaluator Allocated: {0}", allocatedEvaluator);
+
+      final Map<String, String> attributesFromEvaluator =
+          allocatedEvaluator.getEvaluatorDescriptor().getNodeLabels();
+      LOG.log(Level.INFO, "Node Labels on this node: {0}", attributesFromEvaluator);
+
+      if (attributesFromEvaluator.isEmpty()) {
+        NodeLabelTestDriver.this.defaultContainerCount++;
+      } else if (attributesFromEvaluator.containsKey("mylabel") && attributesFromEvaluator.containsValue("mylabel")) {
+        NodeLabelTestDriver.this.labeledContainerCount++;
+      }
+
+      LOG.log(Level.INFO, "Submitting Dummy REEF task to AllocatedEvaluator: {0}", allocatedEvaluator);
+
+      final Configuration taskConfiguration = TaskConfiguration.CONF
+          .set(TaskConfiguration.TASK, HelloTask.class)
+          .set(TaskConfiguration.IDENTIFIER, "HelloTask")
+          .build();
+
+      allocatedEvaluator.submitTask(taskConfiguration);
+
+      allocatedEvaluator.close();
+    }
+  }
+
+  final class StopHandler implements EventHandler<StopTime> {
+
+    @Override
+    public void onNext(final StopTime stopTime) {
+      LOG.log(Level.INFO, "# of total default containers: {0}",
+          NodeLabelTestDriver.this.defaultContainerCount);
+      if (NodeLabelTestDriver.this.defaultContainerCount != 1) {
+        throw new RuntimeException("Asked for one default container, but got " +
+            NodeLabelTestDriver.this.defaultContainerCount + "default container.");
+      }
+
+      LOG.log(Level.INFO, "# of total labeled containers: {0}",
+          NodeLabelTestDriver.this.labeledContainerCount);
+      if (NodeLabelTestDriver.this.labeledContainerCount != 1) {
+        throw new RuntimeException("Asked for one labeled container, but got " +
+            NodeLabelTestDriver.this.labeledContainerCount + "labeled container.");
+      }
+    }
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/mesosnodelabel/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/mesosnodelabel/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Test for Mesos evaluator request with node label.
+ */
+package org.apache.reef.tests.mesosnodelabel;

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestAvroSerializerForHttp.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestAvroSerializerForHttp.java
@@ -162,6 +162,11 @@ public class TestAvroSerializerForHttp {
     public String getRuntimeName() {
       return "Local";
     }
+
+    @Override
+    public Map<String, String> getNodeLabels() {
+      return new HashMap<>();
+    }
   }
 
   static class NodeDescriptorMock implements NodeDescriptor {

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestReefEventStateManager.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestReefEventStateManager.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 
 import javax.inject.Inject;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -127,6 +128,11 @@ final class MockEvaluatorDescriptor implements EvaluatorDescriptor {
   @Override
   public String getRuntimeName() {
     return "Local";
+  }
+
+  @Override
+  public Map<String, String> getNodeLabels() {
+    return new HashMap<>();
   }
 }
 


### PR DESCRIPTION
This addressed the issue by
  * Enables REEF Runtime Mesos to use node labeling feature.

  Before running this test, configure Mesos to let the Mesos master
  sends offer with attribute "mylabel:mylabel" when resources are offered
  from a specific Mesos agent(node).

JIRA:
  [REEF-1860](https://issues.apache.org/jira/browse/REEF-1860)

Pull Request:
  This closes #