### PR TITLE
[REEF-1875] Upgrade Netty depenency to 4.1.15Final

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
@@ -147,9 +147,9 @@ public class ChunkedReadWriteHandler extends ChunkedWriteHandler {
    */
   private byte[] sizeAsByteArr(final int size) {
     final byte[] ret = new byte[INT_SIZE];
-    final ByteBuf intBuffer = Unpooled.wrappedBuffer(ret).order(Unpooled.LITTLE_ENDIAN);
+    final ByteBuf intBuffer = Unpooled.wrappedBuffer(ret);
     intBuffer.clear();
-    intBuffer.writeInt(size);
+    intBuffer.writeIntLE(size);
     intBuffer.release();
     return ret;
   }
@@ -170,8 +170,8 @@ public class ChunkedReadWriteHandler extends ChunkedWriteHandler {
       return 0;
     }
 
-    final ByteBuf intBuffer = Unpooled.wrappedBuffer(data, offset, INT_SIZE).order(Unpooled.LITTLE_ENDIAN);
-    final int ret = intBuffer.readInt();
+    final ByteBuf intBuffer = Unpooled.wrappedBuffer(data, offset, INT_SIZE);
+    final int ret = intBuffer.readIntLE();
     intBuffer.release();
 
     return ret;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
@@ -320,7 +320,7 @@ public final class NettyMessagingTransport implements Transport {
         }
         break;
       } catch (final Exception e) {
-        if (e.getClass().getSimpleName().compareTo("ConnectException") == 0) {
+        if (e.getClass().getSimpleName().compareTo("AnnotatedConnectException") == 0) {
           LOG.log(Level.WARNING, "Connection refused. Retry {0} of {1}",
               new Object[]{i + 1, this.numberOfTries});
           synchronized (flag) {

--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,7 @@ under the License.
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>4.0.21.Final</version>
+                <version>4.1.15.Final</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
* removed a deprecated method `ByteBuf.order`
* changed name of exception caught in `open` in `NettyMessagingTransport`.

JIRA:
[REEF-1875](https://issues.apache.org/jira/browse/REEF-1875)

Pull request:
This closes #1371