### PR TITLE
[REEF-1879] Downgrade netty dependency to 4.0.23.Final

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
@@ -61,7 +61,7 @@ public final class EvaluatorManagerFactory {
 
     if (nodeDescriptor == null) {
       final String nodeId = resourceEvent.getNodeId();
-      LOG.log(Level.WARNING, "Node {} is not in our catalog, adding it", nodeId);
+      LOG.log(Level.WARNING, "Node {0} is not in our catalog, adding it", nodeId);
       final String[] hostNameAndPort = nodeId.split(":");
       Validate.isTrue(hostNameAndPort.length == 2);
       final NodeDescriptorEvent nodeDescriptorEvent = NodeDescriptorEventImpl.newBuilder().setIdentifier(nodeId)

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
@@ -49,6 +49,7 @@ import javax.inject.Inject;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
@@ -206,7 +207,8 @@ public final class NameLookupClient implements Stage, NamingLookup {
         }
       }
 
-      final List<NameAssignment> list = resp.getNameAssignments();
+      final List<NameAssignment> list = resp == null ? Collections.<NameAssignment>emptyList()
+          : resp.getNameAssignments();
       if (list.isEmpty()) {
         throw new NamingException("Cannot find " + id + " from the name server");
       } else {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
@@ -147,9 +147,9 @@ public class ChunkedReadWriteHandler extends ChunkedWriteHandler {
    */
   private byte[] sizeAsByteArr(final int size) {
     final byte[] ret = new byte[INT_SIZE];
-    final ByteBuf intBuffer = Unpooled.wrappedBuffer(ret);
+    final ByteBuf intBuffer = Unpooled.wrappedBuffer(ret).order(Unpooled.LITTLE_ENDIAN);
     intBuffer.clear();
-    intBuffer.writeIntLE(size);
+    intBuffer.writeInt(size);
     intBuffer.release();
     return ret;
   }
@@ -170,8 +170,8 @@ public class ChunkedReadWriteHandler extends ChunkedWriteHandler {
       return 0;
     }
 
-    final ByteBuf intBuffer = Unpooled.wrappedBuffer(data, offset, INT_SIZE);
-    final int ret = intBuffer.readIntLE();
+    final ByteBuf intBuffer = Unpooled.wrappedBuffer(data, offset, INT_SIZE).order(Unpooled.LITTLE_ENDIAN);
+    final int ret = intBuffer.readInt();
     intBuffer.release();
 
     return ret;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
@@ -320,7 +320,7 @@ public final class NettyMessagingTransport implements Transport {
         }
         break;
       } catch (final Exception e) {
-        if (e.getClass().getSimpleName().compareTo("AnnotatedConnectException") == 0) {
+        if (e.getClass().getSimpleName().compareTo("ConnectException") == 0) {
           LOG.log(Level.WARNING, "Connection refused. Retry {0} of {1}",
               new Object[]{i + 1, this.numberOfTries});
           synchronized (flag) {

--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,7 @@ under the License.
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>4.1.15.Final</version>
+                <version>4.0.23.Final</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Summary of changes:

* Reverts b8cecb612feaa96a86c031df0b6f6f7306f215b2
* Modifies pom.xml to use Netty 4.0.23.Final
* Makes NameLookupClient throw NamingException on replyQueue.poll timeout, rather than NullPointerException
* Fixes a minor typo

JIRA: [REEF-1879](https://issues.apache.org/jira/browse/REEF-1879)

Closes #