### PR TITLE
[REEF-1883] Harmonize Protocol Buffers dependency version to 2.1.0

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.nuspec
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.nuspec
@@ -37,7 +37,7 @@ under the License.
       <dependency id="Org.Apache.REEF.Evaluator" version="$version$" />
       <dependency id="Org.Apache.REEF.Examples" version="$version$" />
       <dependency id="Rx-Core" version="2.2.5" />
-      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="protobuf-net" version="2.1.0" />
       <dependency id="TransientFaultHandling.Core" version="5.1.1209.1" />
     </dependencies>
   </metadata>

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.nuspec
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.nuspec
@@ -30,7 +30,7 @@ under the License.
     <tags>Reef Common Infrastructure</tags>
     <dependencies>
       <dependency id="Microsoft.Hadoop.Avro" version="1.5.6" />
-      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="protobuf-net" version="2.1.0" />
       <dependency id="Rx-Core" version="2.2.5" />
       <dependency id="Org.Apache.REEF.Utilities" version="$version$" />
       <dependency id="Org.Apache.REEF.Tang" version="$version$" />

--- a/lang/cs/Org.Apache.REEF.Common/packages.config
+++ b/lang/cs/Org.Apache.REEF.Common/packages.config
@@ -20,7 +20,7 @@ under the License.
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />

--- a/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.nuspec
+++ b/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.nuspec
@@ -29,7 +29,7 @@ under the License.
     <copyright>The Apache Software Foundation</copyright>
     <dependencies>
       <dependency id="Microsoft.Hadoop.Avro" version="1.5.6" />
-      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="protobuf-net" version="2.1.0" />
       <dependency id="Org.Apache.REEF.Common" version="$version$" />
       <dependency id="Org.Apache.REEF.Utilities" version="$version$" />
       <dependency id="Org.Apache.REEF.Tang" version="$version$" />

--- a/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.nuspec
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.nuspec
@@ -34,7 +34,7 @@ under the License.
       <dependency id="Org.Apache.REEF.Common" version="$version$" />
       <dependency id="Org.Apache.REEF.Driver" version="$version$" />
       <dependency id="Rx-Core" version="2.2.5" />
-      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="protobuf-net" version="2.1.0" />
     </dependencies>
   </metadata>
   <files>

--- a/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.nuspec
+++ b/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.nuspec
@@ -32,7 +32,7 @@ under the License.
       <dependency id="Org.Apache.REEF.Wake" version="$version$" />
       <dependency id="Org.Apache.REEF.Utilities" version="$version$" />
       <dependency id="Microsoft.Hadoop.Avro" version="1.5.6" />
-      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="protobuf-net" version="2.1.0" />
       <dependency id="Rx-Core" version="2.2.5" />
       <dependency id="Org.Apache.REEF.Common" version="$version$" />
       <dependency id="Org.Apache.REEF.Driver" version="$version$" />

--- a/lang/cs/Org.Apache.REEF.FatNuGet/Org.Apache.REEF.FatNuGet.nuspec
+++ b/lang/cs/Org.Apache.REEF.FatNuGet/Org.Apache.REEF.FatNuGet.nuspec
@@ -31,7 +31,7 @@ under the License.
     <dependencies>
       <dependency id="Microsoft.Hadoop.Avro" version="1.5.6" />
       <dependency id="Newtonsoft.Json" version="8.0.3" />
-      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="protobuf-net" version="2.1.0" />
       <dependency id="Rx-Core" version="2.2.5" />
     </dependencies>
   </metadata>

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/Org.Apache.REEF.IMRU.Examples.nuspec
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/Org.Apache.REEF.IMRU.Examples.nuspec
@@ -38,7 +38,7 @@ under the License.
       <dependency id="Org.Apache.REEF.IMRU" version="$version$" />
       <dependency id="Org.Apache.REEF.Examples" version="$version$" />
       <dependency id="Rx-Core" version="2.2.5" />
-      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="protobuf-net" version="2.1.0" />
     </dependencies>
   </metadata>
   <files>

--- a/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.nuspec
+++ b/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.nuspec
@@ -37,7 +37,7 @@ under the License.
       <dependency id="Org.Apache.REEF.Driver" version="$version$" />
       <dependency id="Org.Apache.REEF.Examples" version="$version$" />
       <dependency id="Rx-Core" version="2.2.5" />
-      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="protobuf-net" version="2.1.0" />
     </dependencies>
   </metadata>
   <files>

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.nuspec
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.nuspec
@@ -32,7 +32,7 @@ under the License.
       <dependency id="Org.Apache.REEF.Wake" version="$version$" />
       <dependency id="Org.Apache.REEF.Utilities" version="$version$" />
       <dependency id="Microsoft.Hadoop.Avro" version="1.5.6" />
-      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="protobuf-net" version="2.1.0" />
       <dependency id="Rx-Core" version="2.2.5" />
       <dependency id="Org.Apache.REEF.Common" version="$version$" />
       <dependency id="Org.Apache.REEF.Driver" version="$version$" />

--- a/lang/cs/Org.Apache.REEF.Tang/Org.Apache.REEF.Tang.nuspec
+++ b/lang/cs/Org.Apache.REEF.Tang/Org.Apache.REEF.Tang.nuspec
@@ -30,7 +30,7 @@ under the License.
     <tags>tang dependency injection</tags>
     <dependencies>
       <dependency id="Microsoft.Hadoop.Avro" version="1.5.6" />
-      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="protobuf-net" version="2.1.0" />
       <dependency id="Org.Apache.REEF.Utilities" version="$version$" />
     </dependencies>
   </metadata>

--- a/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.nuspec
+++ b/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.nuspec
@@ -29,7 +29,7 @@ under the License.
     <copyright>The Apache Software Foundation</copyright>
     <tags>wake event driven</tags>
     <dependencies>
-      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="protobuf-net" version="2.1.0" />
       <dependency id="Rx-Core" version="2.2.5" />
       <dependency id="TransientFaultHandling.Core" version="5.1.1209.1" />
       <dependency id="Org.Apache.REEF.Utilities" version="$version$" />


### PR DESCRIPTION
This changes all references to `protobuf-net` in the `.nuspec` files to reference version `2.1.0` of that package. We already depend on that version in the `.csproj` files.

JIRA:
  [REEF-1883](https://issues.apache.org/jira/browse/REEF-1883)