### PR TITLE
[REEF-1899] Remove use of `Exceptions` in O.A.R.Client

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Common/JavaClientLauncher.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/JavaClientLauncher.cs
@@ -24,7 +24,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Org.Apache.REEF.Client.API.Exceptions;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Client.Common
@@ -136,14 +135,12 @@ namespace Org.Apache.REEF.Client.Common
             if (string.IsNullOrWhiteSpace(javaHomePath))
             {
                 // TODO: Attempt to find java via the registry.
-                Exceptions.Throw(
-                    new JavaNotFoundException("JAVA_HOME isn't set. Please install Java and make set JAVA_HOME"), Logger);
+                throw new JavaNotFoundException("JAVA_HOME isn't set. Please install Java and make set JAVA_HOME");
             }
 
             if (!Directory.Exists(javaHomePath))
             {
-                Exceptions.Throw(
-                    new JavaNotFoundException("JAVA_HOME references a folder that doesn't exist.", javaHomePath), Logger);
+                throw new JavaNotFoundException("JAVA_HOME references a folder that doesn't exist.", javaHomePath);
             }
 
             var javaBinPath = Path.Combine(javaHomePath, "bin");
@@ -157,10 +154,8 @@ namespace Org.Apache.REEF.Client.Common
             var javaPath = Path.Combine(javaBinPath, "java.exe");
             if (!File.Exists(javaPath))
             {
-                Exceptions.Throw(
-                    new JavaNotFoundException(
-                        "Could not find java.exe on this machine. Is Java installed and JAVA_HOME set?", javaPath),
-                    Logger);
+                throw new JavaNotFoundException(
+                    "Could not find java.exe on this machine. Is Java installed and JAVA_HOME set?", javaPath);
             }
             return javaPath;
         }
@@ -179,8 +174,8 @@ namespace Org.Apache.REEF.Client.Common
 
             if (files.Count == 0)
             {
-                Exceptions.Throw(new ClasspathException(
-                    "Unable to assemble classpath. Make sure the REEF JAR is in the current working directory."), Logger);
+                throw new ClasspathException(
+                    "Unable to assemble classpath. Make sure the REEF JAR is in the current working directory.");
             }
 
             var classpathEntries = new List<string>(_additionalClasspathEntries).Concat(files);

--- a/lang/cs/Org.Apache.REEF.Client/Common/ResourceArchiveFileGenerator.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/ResourceArchiveFileGenerator.cs
@@ -20,7 +20,6 @@ using System.IO;
 using System.IO.Compression;
 using Org.Apache.REEF.Common.Files;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Client.Common
@@ -45,12 +44,12 @@ namespace Org.Apache.REEF.Client.Common
             string reefFolder = Path.Combine(folderPath, _reefFileNames.GetReefFolderName());
             if (!Directory.Exists(reefFolder))
             {
-                Exceptions.Throw(new DirectoryNotFoundException("Cannot find directory " + reefFolder), Log);
+                throw new DirectoryNotFoundException("Cannot find directory " + reefFolder);
             }
 
             if (File.Exists(archivePath))
             {
-                Exceptions.Throw(new InvalidOperationException("Archive file already exists " + archivePath), Log);
+                throw new InvalidOperationException("Archive file already exists " + archivePath);
             }
 
             ZipFile.CreateFromDirectory(reefFolder, archivePath);

--- a/lang/cs/Org.Apache.REEF.Client/YARN/LegacyJobResourceUploader.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/LegacyJobResourceUploader.cs
@@ -22,7 +22,6 @@ using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Client.YARN.RestClient.DataModel;
 using Org.Apache.REEF.Common.Files;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Client.Yarn
@@ -83,9 +82,7 @@ namespace Org.Apache.REEF.Client.Yarn
         {
             if (!_file.Exists(filePath))
             {
-                Exceptions.Throw(
-                    new FileNotFoundException("Could not find resource file " + filePath),
-                    Log);
+                throw new FileNotFoundException("Could not find resource file " + filePath);
             }
 
             var detailsOutputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -116,9 +113,7 @@ namespace Org.Apache.REEF.Client.Yarn
         {
             if (!_file.Exists(resourceDetailsOutputPath))
             {
-                Exceptions.Throw(
-                    new FileNotFoundException("Could not find resource details file " + resourceDetailsOutputPath),
-                    Log);
+                throw new FileNotFoundException("Could not find resource details file " + resourceDetailsOutputPath);
             }
 
             // Single line file, easier to deal with sync read

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/FileSystemJobResourceUploader.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/FileSystemJobResourceUploader.cs
@@ -24,7 +24,6 @@ using Org.Apache.REEF.Client.YARN.RestClient.DataModel;
 using Org.Apache.REEF.Common.Files;
 using Org.Apache.REEF.IO.FileSystem;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Client.YARN.RestClient
@@ -85,9 +84,7 @@ namespace Org.Apache.REEF.Client.YARN.RestClient
         {
             if (!_file.Exists(filePath))
             {
-                Exceptions.Throw(
-                    new FileNotFoundException("Could not find resource file " + filePath),
-                    Log);
+                throw new FileNotFoundException("Could not find resource file " + filePath);
             }
 
             var destinationPath = driverUploadPath + Path.GetFileName(filePath);

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YarnCommandLineEnvironment.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YarnCommandLineEnvironment.cs
@@ -22,7 +22,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Client.Yarn
@@ -57,18 +56,14 @@ namespace Org.Apache.REEF.Client.Yarn
             var path = Environment.GetEnvironmentVariable("HADOOP_HOME");
             if (string.IsNullOrWhiteSpace(path))
             {
-                var ex = new FileNotFoundException("HADOOP_HOME isn't set.");
-                Exceptions.Throw(ex, Logger);
-                throw ex;
+                throw new FileNotFoundException("HADOOP_HOME isn't set.");
             }
 
             var fullPath = Path.GetFullPath(path);
 
             if (!Directory.Exists(fullPath))
             {
-                var ex = new FileNotFoundException("HADOOP_HOME points to [" + fullPath + "] which doesn't exist.");
-                Exceptions.Throw(ex, Logger);
-                throw ex;
+                throw new FileNotFoundException("HADOOP_HOME points to [" + fullPath + "] which doesn't exist.");
             }
             return fullPath;
         }
@@ -82,9 +77,7 @@ namespace Org.Apache.REEF.Client.Yarn
             var result = Path.Combine(GetHadoopHomePath(), "bin", "yarn.cmd");
             if (!File.Exists(result))
             {
-                var ex = new FileNotFoundException("Couldn't find yarn.cmd", result);
-                Exceptions.Throw(ex, Logger);
-                throw ex;
+                throw new FileNotFoundException("Couldn't find yarn.cmd", result);
             }
             return result;
         }
@@ -120,15 +113,12 @@ namespace Org.Apache.REEF.Client.Yarn
 
                 if (process.ExitCode != 0)
                 {
-                    var ex = new Exception("YARN process exited with non-zero error code.");
-                    Exceptions.Throw(ex, Logger);
+                    throw new Exception("YARN process exited with non-zero error code.");
                 }
             }
             else
             {
-                var ex = new Exception("YARN process didn't start.");
-                Exceptions.Throw(ex, Logger);
-                throw ex;
+                throw new Exception("YARN process didn't start.");
             }
             return output.ToString();
         }


### PR DESCRIPTION
This removes all use of the `Exceptions` class in O.A.R.Client

JIRA:
  [REEF-1899](https://issues.apache.org/jira/browse/REEF-1899)