### PR TITLE
[REEF-1898] REEF Runtime Mock

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -307,5 +307,12 @@ public final class EvaluatorRequest {
       return new EvaluatorRequest(this.n, this.megaBytes, this.cores, this.nodeNames,
                                   this.rackNames, this.runtimeName, this.relaxLocality);
     }
+
+    /**
+     * Short-circuit submission method for subclass implementations.
+     */
+    public void submit() {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
@@ -129,6 +129,7 @@ public final class EvaluatorRequestorImpl implements EvaluatorRequestor {
    * {@link EvaluatorRequest}s are built using this builder.
    */
   public final class Builder extends EvaluatorRequest.Builder<Builder> {
+    @Override
     public synchronized void submit() {
       EvaluatorRequestorImpl.this.submit(this.build());
     }

--- a/lang/java/reef-runtime-mock/pom.xml
+++ b/lang/java/reef-runtime-mock/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.reef</groupId>
+        <artifactId>reef-project</artifactId>
+        <version>0.17.0-SNAPSHOT</version>
+        <relativePath>../../..</relativePath>
+    </parent>
+
+    <properties>
+        <rootPath>${basedir}/../../..</rootPath>
+    </properties>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>reef-runtime-mock</artifactId>
+    <name>REEF Runtime Mock</name>
+    <description>REEF Mockup Library for testing application control flow logic.</description>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <configuration>
+                        <configLocation>lang/java/reef-common/src/main/resources/checkstyle-strict.xml</configLocation>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>reef-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/AutoCompletable.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/AutoCompletable.java
@@ -19,9 +19,12 @@
 
 package org.apache.reef.mock;
 
+import org.apache.reef.annotations.Unstable;
+
 /**
  * Indicates that a process request should auto complete.
  */
+@Unstable
 public interface AutoCompletable {
 
   /**

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/AutoCompletable.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/AutoCompletable.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,29 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.evaluator;
 
-import org.apache.reef.annotations.Provided;
-import org.apache.reef.annotations.audience.DriverSide;
-import org.apache.reef.annotations.audience.Public;
+package org.apache.reef.mock;
 
 /**
- * Interface through which Evaluators can be requested.
+ * Indicates that a process request should auto complete.
  */
-@Public
-@DriverSide
-@Provided
-public interface EvaluatorRequestor {
+public interface AutoCompletable {
 
   /**
-   * Submit the request for new evaluator.
-   * The response will surface in the AllocatedEvaluator message handler.
+   * @return true if should auto complete
    */
-  void submit(final EvaluatorRequest req);
+  boolean doAutoComplete();
 
   /**
-   * Get a new Builder for the evaluator with fluid interface.
-   * @return Builder for the evaluator
+   * Set auto complete.
+   * @param value to set
    */
-  EvaluatorRequest.Builder newRequest();
+  void setAutoComplete(final boolean value);
+
+  /**
+   * @return auto complete process request
+   */
+  ProcessRequest getCompletionProcessRequest();
 }

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/DefaultTaskReturnValueProvider.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/DefaultTaskReturnValueProvider.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
 /**
  * A default task return value provider.
  */
-public class DefaultTaskReturnValueProvider implements MockTaskReturnValueProvider {
+final class DefaultTaskReturnValueProvider implements MockTaskReturnValueProvider {
 
   @Inject
   DefaultTaskReturnValueProvider() {

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/DefaultTaskReturnValueProvider.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/DefaultTaskReturnValueProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.apache.reef.mock;
+
+import org.apache.reef.mock.runtime.MockRunningTask;
+
+import javax.inject.Inject;
+
+/**
+ * A default task return value provider.
+ */
+public class DefaultTaskReturnValueProvider implements MockTaskReturnValueProvider {
+
+  @Inject
+  DefaultTaskReturnValueProvider() {
+
+  }
+
+  @Override
+  public byte[] getReturnValue(final MockRunningTask task) {
+    return new byte[0];
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockClock.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockClock.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock;
+
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.Clock;
+import org.apache.reef.wake.time.Time;
+import org.apache.reef.wake.time.event.Alarm;
+import org.apache.reef.wake.time.runtime.event.ClientAlarm;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * The MockClock can be used to drive alarms set by the client application.
+ */
+public class MockClock implements Clock {
+
+  private final MockRuntime runtime;
+
+  private final List<Alarm> alarmList = new ArrayList<>();
+
+  private long currentTime = 0;
+
+  @Inject
+  MockClock(final MockRuntime runtime) {
+    this.runtime = runtime;
+  }
+
+  public void advanceClock(final int offset) {
+    this.currentTime += offset;
+    final Iterator<Alarm> iter = this.alarmList.iterator();
+    while (iter.hasNext()) {
+      final Alarm alarm = iter.next();
+      if (alarm.getTimestamp() <= this.currentTime) {
+        alarm.run();
+        iter.remove();
+      }
+    }
+  }
+
+  public long getCurrentTime() {
+    return this.currentTime;
+  }
+
+  @Override
+  public Time scheduleAlarm(final int offset, final EventHandler<Alarm> handler) {
+    final Alarm alarm = new ClientAlarm(this.currentTime + offset, handler);
+    alarmList.add(alarm);
+    return alarm;
+  }
+
+  @Override
+  public void close() {
+    this.runtime.stop();
+  }
+
+  @Override
+  public void stop() {
+    close();
+  }
+
+  @Override
+  public void stop(final Throwable exception) {
+    close();
+  }
+
+  @Override
+  public boolean isIdle() {
+    return this.alarmList.size() > 0;
+  }
+
+  @Override
+  public boolean isClosed() {
+    return false;
+  }
+
+  @Override
+  public void run() {
+    this.runtime.start();
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockClock.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockClock.java
@@ -19,6 +19,7 @@
 
 package org.apache.reef.mock;
 
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.time.Clock;
 import org.apache.reef.wake.time.Time;
@@ -33,7 +34,8 @@ import java.util.List;
 /**
  * The MockClock can be used to drive alarms set by the client application.
  */
-public class MockClock implements Clock {
+@Private
+public final class MockClock implements Clock {
 
   private final MockRuntime runtime;
 
@@ -41,11 +43,17 @@ public class MockClock implements Clock {
 
   private long currentTime = 0;
 
+  private boolean closed = false;
+
   @Inject
   MockClock(final MockRuntime runtime) {
     this.runtime = runtime;
   }
 
+  /**
+   * Advances the clock by the offset amount.
+   * @param offset amount to advance clock
+   */
   public void advanceClock(final int offset) {
     this.currentTime += offset;
     final Iterator<Alarm> iter = this.alarmList.iterator();
@@ -58,6 +66,9 @@ public class MockClock implements Clock {
     }
   }
 
+  /**
+   * @return the current mock clock time
+   */
   public long getCurrentTime() {
     return this.currentTime;
   }
@@ -71,7 +82,10 @@ public class MockClock implements Clock {
 
   @Override
   public void close() {
-    this.runtime.stop();
+    if (!closed) {
+      this.runtime.stop();
+      this.closed = true;
+    }
   }
 
   @Override
@@ -91,7 +105,7 @@ public class MockClock implements Clock {
 
   @Override
   public boolean isClosed() {
-    return false;
+    return this.closed;
   }
 
   @Override

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockConfiguration.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockConfiguration.java
@@ -128,14 +128,19 @@ public class MockConfiguration extends ConfigurationModuleBuilder {
    */
   public static final OptionalImpl<JobMessageObserver> ON_JOB_MESSAGE = new OptionalImpl<>();
 
+  /**
+   *  An implementation of a task return value provider.
+   */
+  public static final OptionalImpl<MockTaskReturnValueProvider> TASK_RETURN_VALUE_PROVIDER = new OptionalImpl<>();
+
   public static final ConfigurationModule CONF = new MockConfiguration()
       .bindImplementation(EvaluatorRequestor.class, MockEvaluatorRequestor.class) // requesting evaluators
       .bindImplementation(MockRuntime.class, MockRuntimeDriver.class)
       .bindImplementation(MockFailure.class, MockRuntimeDriver.class)
       .bindImplementation(Clock.class, MockClock.class)
+      .bindImplementation(MockTaskReturnValueProvider.class, TASK_RETURN_VALUE_PROVIDER)
 
       // client handlers
-
       .bindImplementation(JobMessageObserver.class, ON_JOB_MESSAGE) // sending message to job client
 
       // Driver start/stop handlers

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockConfiguration.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockConfiguration.java
@@ -131,6 +131,8 @@ public class MockConfiguration extends ConfigurationModuleBuilder {
   public static final ConfigurationModule CONF = new MockConfiguration()
       .bindImplementation(EvaluatorRequestor.class, MockEvaluatorRequestor.class) // requesting evaluators
       .bindImplementation(MockRuntime.class, MockRuntimeDriver.class)
+      .bindImplementation(MockFailure.class, MockRuntimeDriver.class)
+      .bindImplementation(Clock.class, MockClock.class)
 
       // client handlers
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockConfiguration.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockConfiguration.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.mock;
+
+import org.apache.reef.driver.client.JobMessageObserver;
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.context.ClosedContext;
+import org.apache.reef.driver.context.ContextMessage;
+import org.apache.reef.driver.context.FailedContext;
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.evaluator.CompletedEvaluator;
+import org.apache.reef.driver.evaluator.EvaluatorRequestor;
+import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.driver.parameters.*;
+import org.apache.reef.driver.task.*;
+import org.apache.reef.mock.runtime.MockEvaluatorRequestor;
+import org.apache.reef.mock.runtime.MockRuntimeDriver;
+import org.apache.reef.tang.formats.ConfigurationModule;
+import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
+import org.apache.reef.tang.formats.OptionalImpl;
+import org.apache.reef.tang.formats.RequiredImpl;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.Clock;
+import org.apache.reef.wake.time.event.StartTime;
+import org.apache.reef.wake.time.event.StopTime;
+
+/**
+ * Configure a mock runtime.
+ */
+public class MockConfiguration extends ConfigurationModuleBuilder {
+
+  /**
+   * The event handler invoked right after the driver boots up.
+   */
+  public static final RequiredImpl<EventHandler<StartTime>> ON_DRIVER_STARTED = new RequiredImpl<>();
+
+  /**
+   * The event handler invoked right before the driver shuts down. Defaults to ignore.
+   */
+  public static final OptionalImpl<EventHandler<StopTime>> ON_DRIVER_STOP = new OptionalImpl<>();
+
+  // ***** EVALUATOR HANDLER BINDINGS:
+
+  /**
+   * Event handler for allocated evaluators. Defaults to returning the evaluator if not bound.
+   */
+  public static final OptionalImpl<EventHandler<AllocatedEvaluator>> ON_EVALUATOR_ALLOCATED = new OptionalImpl<>();
+
+  /**
+   * Event handler for completed evaluators. Defaults to logging if not bound.
+   */
+  public static final OptionalImpl<EventHandler<CompletedEvaluator>> ON_EVALUATOR_COMPLETED = new OptionalImpl<>();
+
+  /**
+   * Event handler for failed evaluators. Defaults to job failure if not bound.
+   */
+  public static final OptionalImpl<EventHandler<FailedEvaluator>> ON_EVALUATOR_FAILED = new OptionalImpl<>();
+
+  // ***** TASK HANDLER BINDINGS:
+
+  /**
+   * Event handler for task messages. Defaults to logging if not bound.
+   */
+  public static final OptionalImpl<EventHandler<TaskMessage>> ON_TASK_MESSAGE = new OptionalImpl<>();
+
+  /**
+   * Event handler for completed tasks. Defaults to closing the context the task ran on if not bound.
+   */
+  public static final OptionalImpl<EventHandler<CompletedTask>> ON_TASK_COMPLETED = new OptionalImpl<>();
+
+  /**
+   * Event handler for failed tasks. Defaults to job failure if not bound.
+   */
+  public static final OptionalImpl<EventHandler<FailedTask>> ON_TASK_FAILED = new OptionalImpl<>();
+
+  /**
+   * Event handler for running tasks. Defaults to logging if not bound.
+   */
+  public static final OptionalImpl<EventHandler<RunningTask>> ON_TASK_RUNNING = new OptionalImpl<>();
+
+  /**
+   * Event handler for suspended tasks. Defaults to job failure if not bound. Rationale: many jobs don't support
+   * task suspension. Hence, this parameter should be optional. The only sane default is to crash the job, then.
+   */
+  public static final OptionalImpl<EventHandler<SuspendedTask>> ON_TASK_SUSPENDED = new OptionalImpl<>();
+
+  // ***** CONTEXT HANDLER BINDINGS:
+
+  /**
+   * Event handler for active context. Defaults to closing the context if not bound.
+   */
+  public static final OptionalImpl<EventHandler<ActiveContext>> ON_CONTEXT_ACTIVE = new OptionalImpl<>();
+
+  /**
+   * Event handler for closed context. Defaults to logging if not bound.
+   */
+  public static final OptionalImpl<EventHandler<ClosedContext>> ON_CONTEXT_CLOSED = new OptionalImpl<>();
+
+  /**
+   * Event handler for closed context. Defaults to job failure if not bound.
+   */
+  public static final OptionalImpl<EventHandler<FailedContext>> ON_CONTEXT_FAILED = new OptionalImpl<>();
+
+  /**
+   * Event handler for context messages. Defaults to logging if not bound.
+   */
+  public static final OptionalImpl<EventHandler<ContextMessage>> ON_CONTEXT_MESSAGE = new OptionalImpl<>();
+
+
+  /**
+   * Receiver of messages sent by the Driver to the client.
+   */
+  public static final OptionalImpl<JobMessageObserver> ON_JOB_MESSAGE = new OptionalImpl<>();
+
+  public static final ConfigurationModule CONF = new MockConfiguration()
+      .bindImplementation(EvaluatorRequestor.class, MockEvaluatorRequestor.class) // requesting evaluators
+      .bindImplementation(MockRuntime.class, MockRuntimeDriver.class)
+
+      // client handlers
+
+      .bindImplementation(JobMessageObserver.class, ON_JOB_MESSAGE) // sending message to job client
+
+      // Driver start/stop handlers
+      .bindSetEntry(DriverStartHandler.class, ON_DRIVER_STARTED)
+      .bindSetEntry(Clock.StopHandler.class, ON_DRIVER_STOP)
+
+      // Evaluator handlers
+      .bindSetEntry(EvaluatorAllocatedHandlers.class, ON_EVALUATOR_ALLOCATED)
+      .bindSetEntry(EvaluatorCompletedHandlers.class, ON_EVALUATOR_COMPLETED)
+      .bindSetEntry(EvaluatorFailedHandlers.class, ON_EVALUATOR_FAILED)
+
+      // Task handlers
+      .bindSetEntry(TaskRunningHandlers.class, ON_TASK_RUNNING)
+      .bindSetEntry(TaskFailedHandlers.class, ON_TASK_FAILED)
+      .bindSetEntry(TaskMessageHandlers.class, ON_TASK_MESSAGE)
+      .bindSetEntry(TaskCompletedHandlers.class, ON_TASK_COMPLETED)
+      .bindSetEntry(TaskSuspendedHandlers.class, ON_TASK_SUSPENDED)
+
+      // Context handlers
+      .bindSetEntry(ContextActiveHandlers.class, ON_CONTEXT_ACTIVE)
+      .bindSetEntry(ContextClosedHandlers.class, ON_CONTEXT_CLOSED)
+      .bindSetEntry(ContextMessageHandlers.class, ON_CONTEXT_MESSAGE)
+      .bindSetEntry(ContextFailedHandlers.class, ON_CONTEXT_FAILED)
+
+      .build();
+
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockConfiguration.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockConfiguration.java
@@ -29,6 +29,7 @@ import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.driver.parameters.*;
 import org.apache.reef.driver.task.*;
+import org.apache.reef.mock.runtime.MockClock;
 import org.apache.reef.mock.runtime.MockEvaluatorRequestor;
 import org.apache.reef.mock.runtime.MockRuntimeDriver;
 import org.apache.reef.tang.formats.ConfigurationModule;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockConfiguration.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockConfiguration.java
@@ -18,6 +18,7 @@
  */
 package org.apache.reef.mock;
 
+import org.apache.reef.annotations.Unstable;
 import org.apache.reef.driver.client.JobMessageObserver;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ClosedContext;
@@ -44,6 +45,7 @@ import org.apache.reef.wake.time.event.StopTime;
 /**
  * Configure a mock runtime.
  */
+@Unstable
 public class MockConfiguration extends ConfigurationModuleBuilder {
 
   /**

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockFailure.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockFailure.java
@@ -19,6 +19,7 @@
  */
 package org.apache.reef.mock;
 
+import org.apache.reef.annotations.Unstable;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.task.RunningTask;
@@ -28,6 +29,7 @@ import java.util.Collection;
 /**
  * Used to fail running REEF entities i.e., Evaluators, Contexts, Tasks.
  */
+@Unstable
 public interface MockFailure {
 
   /**

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockFailure.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockFailure.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.apache.reef.mock;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.task.RunningTask;
+
+import java.util.Collection;
+
+/**
+ * Used to fail running REEF entities i.e., Evaluators, Contexts, Tasks.
+ */
+public interface MockFailure {
+
+  /**
+   * @return current Collection of allocated evaluators.
+   */
+  Collection<AllocatedEvaluator> getCurrentAllocatedEvaluators();
+
+  /**
+   * Fail an allocated evaluator.
+   * @param evaluator to be failed
+   */
+  void fail(final AllocatedEvaluator evaluator);
+
+  /**
+   * @return current Collection of active contexts
+   */
+  Collection<ActiveContext> getCurrentActiveContexts();
+
+  /**
+   * Fail an ActiveContext.
+   * @param context to be failed
+   */
+  void fail(final ActiveContext context);
+
+  /**
+   * @return current Collection of running tasks
+   */
+  Collection<RunningTask> getCurrentRunningTasks();
+
+  /**
+   * Fail a running task.
+   * @param task to be failed
+   */
+  void fail(final RunningTask task);
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockRuntime.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockRuntime.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock;
+
+/**
+ * Mock API used to drive the evaluation of ProcessRequest
+ * events, which are triggered by the Application driver.
+ * Clients used this to determine whether a particular ProcessRequest
+ * event should succeed or fail.
+ */
+public interface MockRuntime extends MockFailure {
+
+  /**
+   * Initiate the start time event to the application driver.
+   */
+  void start();
+
+  /**
+   * Initiate the stop time event to the application driver.
+   */
+  void stop();
+
+  /**
+   * @return true if there is an outstanding ProcessRequest
+   */
+  boolean hasProcessRequest();
+
+  /**
+   * The client (caller) is responsible for determining what
+   * to do with a ProcessRequest event. There are three options:
+   * 1. Pass to the succeed method, which signals success to the driver.
+   * 2. Pass to the fail method, signaling failure to the driver.
+   * 3. Drop it on the floor (e.g., network failure).
+   *
+   * @return the next ProcessRequest object to be processed.
+   */
+  ProcessRequest getNextProcessRequest();
+
+  /**
+   * The driver will be informed that the operation corresponding
+   * to the ProcessRequest succeeded, and will be given any relevant
+   * data structures e.g., AllocatedEvaluator, RunningTask, etc.
+   *
+   * @param request to be processed successfully
+   */
+  void succeed(final ProcessRequest request);
+
+  /**
+   * The driver will be informed that the operation corresponding
+   * to the PRocessRequest failed, and will be given any relevant
+   * data structures e.g., FailedEvaluator, FailedTask, etc.
+   *
+   * @param request to be failed.
+   */
+  void fail(final ProcessRequest request);
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockRuntime.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockRuntime.java
@@ -19,12 +19,15 @@
 
 package org.apache.reef.mock;
 
+import org.apache.reef.annotations.Unstable;
+
 /**
  * Mock API used to drive the evaluation of ProcessRequest
  * events, which are triggered by the Application driver.
  * Clients used this to determine whether a particular ProcessRequest
  * event should succeed or fail.
  */
+@Unstable
 public interface MockRuntime extends MockFailure {
 
   /**

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockTaskReturnValueProvider.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockTaskReturnValueProvider.java
@@ -20,6 +20,7 @@
 
 package org.apache.reef.mock;
 
+import org.apache.reef.annotations.Unstable;
 import org.apache.reef.driver.task.CompletedTask;
 import org.apache.reef.mock.runtime.MockRunningTask;
 import org.apache.reef.tang.annotations.DefaultImplementation;
@@ -30,6 +31,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
  * task execution. This return value will be returned by
  * the {@link CompletedTask#get()}} method.
  */
+@Unstable
 @DefaultImplementation(DefaultTaskReturnValueProvider.class)
 public interface MockTaskReturnValueProvider {
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockTaskReturnValueProvider.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/MockTaskReturnValueProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.apache.reef.mock;
+
+import org.apache.reef.driver.task.CompletedTask;
+import org.apache.reef.mock.runtime.MockRunningTask;
+import org.apache.reef.tang.annotations.DefaultImplementation;
+
+/**
+ * Clients bind an implementation of this interface, which
+ * will be used to create a mock return value for a mock
+ * task execution. This return value will be returned by
+ * the {@link CompletedTask#get()}} method.
+ */
+@DefaultImplementation(DefaultTaskReturnValueProvider.class)
+public interface MockTaskReturnValueProvider {
+
+  /**
+   * Provide a valid return value for the {@link CompletedTask#get()} method.
+   * @param task that is to be provided with a return value
+   * @return {@link org.apache.reef.task.Task#call(byte[])} return value
+   */
+  byte[] getReturnValue(final MockRunningTask task);
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/ProcessRequest.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/ProcessRequest.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock;
 
+import org.apache.reef.annotations.Unstable;
+
 /**
  * A ProcessRequest refers to an outstanding event that is
  * waiting to be processed by the REEF mock runtime. Clients
@@ -29,6 +31,7 @@ package org.apache.reef.mock;
  * 3. dropping the processing request (i.e., loosing it)
  * These decisions are conveyed through the {MockRuntime} API.
  */
+@Unstable
 public interface ProcessRequest extends AutoCompletable {
   /**
    * process request type.

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/ProcessRequest.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/ProcessRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock;
+
+/**
+ * A ProcessRequest refers to an outstanding event that is
+ * waiting to be processed by the REEF mock runtime. Clients
+ * are responsible for deciding how a ProcessRequest should be
+ * handled, by either:
+ * 1. successfully processing the request
+ * 2. unsucessfully processing the request
+ * 3. dropping the processing request (i.e., loosing it)
+ * These decisions are conveyed through the {MockRuntime} API.
+ */
+public interface ProcessRequest extends AutoCompletable {
+  /**
+   * process request type.
+   */
+  enum Type {
+    ALLOCATE_EVALUATOR,
+    CLOSE_EVALUATOR,
+    CREATE_CONTEXT,
+    CLOSE_CONTEXT,
+    CREATE_TASK,
+    SUSPEND_TASK,
+    CLOSE_TASK,
+    COMPLETE_TASK,
+    CREATE_CONTEXT_AND_TASK,
+    SEND_MESSAGE_DRIVER_TO_TASK,
+    SEND_MESSAGE_DRIVER_TO_CONTEXT
+  }
+
+  Type getType();
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/package-info.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/package-info.java
@@ -18,6 +18,23 @@
  *
  */
 /**
- * mock runtime API.
+ * Mock runtime API.
+ *
+ * Mock runtime is meant to mimic the semantics of the REEF runtime and
+ * allow:
+ *  1. Applications to driver the forward progress of processing REEF events.
+ *     See {@link org.apache.reef.mock.MockRuntime} API
+ *  2. Control the advancement of the Clock and Alarm callbacks.
+ *     See {@link org.apache.reef.mock.MockClock}
+ *  3. Inject failures into the REEF applications.
+ *     See {@link org.apache.reef.mock.MockFailure}
+ *
+ * Use {@link org.apache.reef.mock.MockConfiguration} to bind your REEF
+ * driver application event handlers.
+ *
+ * Use {@link org.apache.reef.mock.MockRuntime#start()} to trigger the
+ * driver start event and {@link org.apache.reef.mock.MockRuntime#stop()}}
+ * or {@link org.apache.reef.mock.MockClock#close()} to trigger the driver
+ * stop event.
  */
 package org.apache.reef.mock;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/package-info.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/package-info.java
@@ -25,7 +25,7 @@
  *  1. Applications to driver the forward progress of processing REEF events.
  *     See {@link org.apache.reef.mock.MockRuntime} API
  *  2. Control the advancement of the Clock and Alarm callbacks.
- *     See {@link org.apache.reef.mock.MockClock}
+ *     See {@link org.apache.reef.mock.runtime.MockClock}
  *  3. Inject failures into the REEF applications.
  *     See {@link org.apache.reef.mock.MockFailure}
  *
@@ -34,7 +34,7 @@
  *
  * Use {@link org.apache.reef.mock.MockRuntime#start()} to trigger the
  * driver start event and {@link org.apache.reef.mock.MockRuntime#stop()}}
- * or {@link org.apache.reef.mock.MockClock#close()} to trigger the driver
+ * or {@link org.apache.reef.mock.runtime.MockClock#close()} to trigger the driver
  * stop event.
  */
 package org.apache.reef.mock;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/package-info.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+/**
+ * mock runtime API.
+ */
+package org.apache.reef.mock;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/AllocateEvaluator.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/AllocateEvaluator.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.mock.ProcessRequest;
 import org.apache.reef.mock.runtime.MockAllocatedEvalautor;
@@ -27,6 +29,8 @@ import org.apache.reef.mock.runtime.MockFailedEvaluator;
 /**
  * Allocate Evaluator process request.
  */
+@Unstable
+@Private
 public final class AllocateEvaluator implements
     ProcessRequestInternal<MockAllocatedEvalautor, FailedEvaluator> {
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/AllocateEvaluator.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/AllocateEvaluator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.request;
+
+import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.mock.ProcessRequest;
+import org.apache.reef.mock.runtime.MockAllocatedEvalautor;
+import org.apache.reef.mock.runtime.MockFailedEvaluator;
+
+/**
+ * Allocate Evaluator process request.
+ */
+public final class AllocateEvaluator implements
+    ProcessRequestInternal<MockAllocatedEvalautor, FailedEvaluator> {
+
+  private final MockAllocatedEvalautor evaluator;
+
+  public AllocateEvaluator(final MockAllocatedEvalautor evaluator) {
+    this.evaluator = evaluator;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.ALLOCATE_EVALUATOR;
+  }
+
+  @Override
+  public MockAllocatedEvalautor getSuccessEvent() {
+    return this.evaluator;
+  }
+
+  @Override
+  public FailedEvaluator getFailureEvent() {
+    return new MockFailedEvaluator(evaluator.getId());
+  }
+
+  @Override
+  public boolean doAutoComplete() {
+    return false;
+  }
+
+  @Override
+  public void setAutoComplete(final boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ProcessRequest getCompletionProcessRequest() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseContext.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ClosedContext;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.mock.AutoCompletable;
@@ -30,7 +32,9 @@ import org.apache.reef.mock.runtime.MockFailedContext;
 /**
  * close context process request.
  */
-public class CloseContext implements
+@Unstable
+@Private
+public final class CloseContext implements
     ProcessRequestInternal<ClosedContext, FailedContext>,
     AutoCompletable {
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseContext.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.request;
+
+import org.apache.reef.driver.context.ClosedContext;
+import org.apache.reef.driver.context.FailedContext;
+import org.apache.reef.mock.AutoCompletable;
+import org.apache.reef.mock.ProcessRequest;
+import org.apache.reef.mock.runtime.MockActiveContext;
+import org.apache.reef.mock.runtime.MockClosedContext;
+import org.apache.reef.mock.runtime.MockFailedContext;
+
+/**
+ * close context process request.
+ */
+public class CloseContext implements
+    ProcessRequestInternal<ClosedContext, FailedContext>,
+    AutoCompletable {
+
+  private final MockActiveContext context;
+
+  public CloseContext(final MockActiveContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.CLOSE_CONTEXT;
+  }
+
+  @Override
+  public MockClosedContext getSuccessEvent() {
+    return new MockClosedContext(this.context);
+  }
+
+  @Override
+  public FailedContext getFailureEvent() {
+    return new MockFailedContext(this.context);
+  }
+
+  @Override
+  public boolean doAutoComplete() {
+    return !this.context.getParentContext().isPresent();
+  }
+
+  @Override
+  public void setAutoComplete(final boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ProcessRequest getCompletionProcessRequest() {
+    return new CloseEvaluator(this.context.getEvaluator());
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseEvaluator.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseEvaluator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.request;
+
+import org.apache.reef.driver.evaluator.CompletedEvaluator;
+import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.mock.ProcessRequest;
+import org.apache.reef.mock.runtime.MockAllocatedEvalautor;
+import org.apache.reef.mock.runtime.MockFailedEvaluator;
+
+/**
+ * close evaluator request.
+ */
+public final class CloseEvaluator implements ProcessRequestInternal<CompletedEvaluator, FailedEvaluator> {
+
+  private final MockAllocatedEvalautor evaluator;
+
+  public CloseEvaluator(final MockAllocatedEvalautor evaluator) {
+    this.evaluator = evaluator;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.CLOSE_EVALUATOR;
+  }
+
+  @Override
+  public CompletedEvaluator getSuccessEvent() {
+    return new CompletedEvaluator() {
+      @Override
+      public String getId() {
+        return evaluator.getId();
+      }
+    };
+  }
+
+  @Override
+  public FailedEvaluator getFailureEvent() {
+    // TODO[initialize remaining failed contstructer fields]
+    return new MockFailedEvaluator(evaluator.getId());
+  }
+
+  @Override
+  public boolean doAutoComplete() {
+    return false;
+  }
+
+  @Override
+  public void setAutoComplete(final boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ProcessRequest getCompletionProcessRequest() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseEvaluator.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseEvaluator.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.evaluator.CompletedEvaluator;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.mock.ProcessRequest;
@@ -28,6 +30,8 @@ import org.apache.reef.mock.runtime.MockFailedEvaluator;
 /**
  * close evaluator request.
  */
+@Unstable
+@Private
 public final class CloseEvaluator implements ProcessRequestInternal<CompletedEvaluator, FailedEvaluator> {
 
   private final MockAllocatedEvalautor evaluator;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseTask.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.task.CompletedTask;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.mock.MockTaskReturnValueProvider;
@@ -30,7 +32,9 @@ import org.apache.reef.util.Optional;
 /**
  * close task process request.
  */
-public class CloseTask implements ProcessRequestInternal<CompletedTask, FailedTask> {
+@Unstable
+@Private
+public final class CloseTask implements ProcessRequestInternal<CompletedTask, FailedTask> {
 
   private final MockRunningTask task;
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseTask.java
@@ -21,6 +21,7 @@ package org.apache.reef.mock.request;
 
 import org.apache.reef.driver.task.CompletedTask;
 import org.apache.reef.driver.task.FailedTask;
+import org.apache.reef.mock.MockTaskReturnValueProvider;
 import org.apache.reef.mock.ProcessRequest;
 import org.apache.reef.mock.runtime.MockCompletedTask;
 import org.apache.reef.mock.runtime.MockRunningTask;
@@ -33,11 +34,13 @@ public class CloseTask implements ProcessRequestInternal<CompletedTask, FailedTa
 
   private final MockRunningTask task;
 
-  private final Optional<byte[]> returnValue;
+  private final MockTaskReturnValueProvider taskReturnValueProvider;
 
-  public CloseTask(final MockRunningTask task, final Optional<byte[]> returnValue) {
+  public CloseTask(
+      final MockRunningTask task,
+      final MockTaskReturnValueProvider taskReturnValueProvider) {
     this.task = task;
-    this.returnValue = returnValue;
+    this.taskReturnValueProvider = taskReturnValueProvider;
   }
 
   public MockRunningTask getTask() {
@@ -51,7 +54,7 @@ public class CloseTask implements ProcessRequestInternal<CompletedTask, FailedTa
 
   @Override
   public MockCompletedTask getSuccessEvent() {
-    return new MockCompletedTask(this.task, this.returnValue);
+    return new MockCompletedTask(this.task, this.taskReturnValueProvider.getReturnValue(task));
   }
 
   @Override

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CloseTask.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.request;
+
+import org.apache.reef.driver.task.CompletedTask;
+import org.apache.reef.driver.task.FailedTask;
+import org.apache.reef.mock.ProcessRequest;
+import org.apache.reef.mock.runtime.MockCompletedTask;
+import org.apache.reef.mock.runtime.MockRunningTask;
+import org.apache.reef.util.Optional;
+
+/**
+ * close task process request.
+ */
+public class CloseTask implements ProcessRequestInternal<CompletedTask, FailedTask> {
+
+  private final MockRunningTask task;
+
+  private final Optional<byte[]> returnValue;
+
+  public CloseTask(final MockRunningTask task, final Optional<byte[]> returnValue) {
+    this.task = task;
+    this.returnValue = returnValue;
+  }
+
+  public MockRunningTask getTask() {
+    return task;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.CLOSE_TASK;
+  }
+
+  @Override
+  public MockCompletedTask getSuccessEvent() {
+    return new MockCompletedTask(this.task, this.returnValue);
+  }
+
+  @Override
+  public FailedTask getFailureEvent() {
+    return new FailedTask(
+      task.getId(),
+      "mock",
+      Optional.<String>empty(),
+      Optional.<Throwable>empty(),
+      Optional.<byte[]>empty(),
+      Optional.of(this.task.getActiveContext()));
+  }
+
+  @Override
+  public boolean doAutoComplete() {
+    return false;
+  }
+
+  @Override
+  public void setAutoComplete(final boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ProcessRequest getCompletionProcessRequest() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CompleteTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CompleteTask.java
@@ -21,10 +21,10 @@ package org.apache.reef.mock.request;
 
 import org.apache.reef.driver.task.CompletedTask;
 import org.apache.reef.driver.task.FailedTask;
+import org.apache.reef.mock.MockTaskReturnValueProvider;
 import org.apache.reef.mock.ProcessRequest;
 import org.apache.reef.mock.runtime.MockCompletedTask;
 import org.apache.reef.mock.runtime.MockRunningTask;
-import org.apache.reef.util.Optional;
 
 /**
  * close task process request.
@@ -33,10 +33,13 @@ public class CompleteTask implements ProcessRequestInternal<CompletedTask, Faile
 
   private final MockRunningTask task;
 
-  private Optional<byte[]> returnValue = Optional.empty();
+  private final MockTaskReturnValueProvider returnValueProvider;
 
-  public CompleteTask(final MockRunningTask task) {
+  public CompleteTask(
+      final MockRunningTask task,
+      final MockTaskReturnValueProvider returnValueProvider) {
     this.task = task;
+    this.returnValueProvider = returnValueProvider;
   }
 
   public MockRunningTask getTask() {
@@ -48,13 +51,9 @@ public class CompleteTask implements ProcessRequestInternal<CompletedTask, Faile
     return Type.COMPLETE_TASK;
   }
 
-  public void setReturnValue(final byte[] value) {
-    this.returnValue = Optional.of(value);
-  }
-
   @Override
   public CompletedTask getSuccessEvent() {
-    return new MockCompletedTask(this.task, this.returnValue);
+    return new MockCompletedTask(this.task, this.returnValueProvider.getReturnValue(task));
   }
 
   @Override

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CompleteTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CompleteTask.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.task.CompletedTask;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.mock.MockTaskReturnValueProvider;
@@ -29,7 +31,9 @@ import org.apache.reef.mock.runtime.MockRunningTask;
 /**
  * close task process request.
  */
-public class CompleteTask implements ProcessRequestInternal<CompletedTask, FailedTask> {
+@Unstable
+@Private
+public final class CompleteTask implements ProcessRequestInternal<CompletedTask, FailedTask> {
 
   private final MockRunningTask task;
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CompleteTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CompleteTask.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.request;
+
+import org.apache.reef.driver.task.CompletedTask;
+import org.apache.reef.driver.task.FailedTask;
+import org.apache.reef.mock.ProcessRequest;
+import org.apache.reef.mock.runtime.MockCompletedTask;
+import org.apache.reef.mock.runtime.MockRunningTask;
+import org.apache.reef.util.Optional;
+
+/**
+ * close task process request.
+ */
+public class CompleteTask implements ProcessRequestInternal<CompletedTask, FailedTask> {
+
+  private final MockRunningTask task;
+
+  private Optional<byte[]> returnValue = Optional.empty();
+
+  public CompleteTask(final MockRunningTask task) {
+    this.task = task;
+  }
+
+  public MockRunningTask getTask() {
+    return task;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.COMPLETE_TASK;
+  }
+
+  public void setReturnValue(final byte[] value) {
+    this.returnValue = Optional.of(value);
+  }
+
+  @Override
+  public CompletedTask getSuccessEvent() {
+    return new MockCompletedTask(this.task, this.returnValue);
+  }
+
+  @Override
+  public FailedTask getFailureEvent() {
+    return null;
+  }
+
+  @Override
+  public boolean doAutoComplete() {
+    return false;
+  }
+
+  @Override
+  public void setAutoComplete(final boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ProcessRequest getCompletionProcessRequest() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContext.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.mock.AutoCompletable;
 import org.apache.reef.mock.ProcessRequest;
@@ -28,7 +30,9 @@ import org.apache.reef.mock.runtime.MockFailedContext;
 /**
  * create context process request.
  */
-public class CreateContext implements
+@Unstable
+@Private
+public final class CreateContext implements
     ProcessRequestInternal<MockActiveContext, FailedContext>,
     AutoCompletable {
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContext.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.request;
+
+import org.apache.reef.driver.context.FailedContext;
+import org.apache.reef.mock.AutoCompletable;
+import org.apache.reef.mock.ProcessRequest;
+import org.apache.reef.mock.runtime.MockActiveContext;
+import org.apache.reef.mock.runtime.MockFailedContext;
+
+/**
+ * create context process request.
+ */
+public class CreateContext implements
+    ProcessRequestInternal<MockActiveContext, FailedContext>,
+    AutoCompletable {
+
+  private final MockActiveContext context;
+
+  private boolean autoComplete = false;
+
+  public CreateContext(final MockActiveContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.CREATE_CONTEXT;
+  }
+
+  @Override
+  public MockActiveContext getSuccessEvent() {
+    return this.context;
+  }
+
+  @Override
+  public FailedContext getFailureEvent() {
+    return new MockFailedContext(this.context);
+  }
+
+  @Override
+  public boolean doAutoComplete() {
+    return this.autoComplete;
+  }
+
+  @Override
+  public void setAutoComplete(final boolean value) {
+    this.autoComplete = value;
+  }
+
+  @Override
+  public ProcessRequest getCompletionProcessRequest() {
+    return new CloseContext(this.context);
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContextAndTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContextAndTask.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.request;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.task.FailedTask;
+import org.apache.reef.io.Tuple;
+import org.apache.reef.mock.AutoCompletable;
+import org.apache.reef.mock.ProcessRequest;
+import org.apache.reef.mock.runtime.MockActiveContext;
+import org.apache.reef.mock.runtime.MockFailedContext;
+import org.apache.reef.mock.runtime.MockRunningTask;
+import org.apache.reef.util.Optional;
+
+/**
+ * create context and task process request.
+ */
+public class CreateContextAndTask implements
+    ProcessRequestInternal<Tuple<MockActiveContext, MockRunningTask>, Tuple<MockFailedContext, FailedTask>>,
+    AutoCompletable {
+
+  private final MockActiveContext context;
+
+  private final MockRunningTask task;
+
+  private boolean autoComplete = true;
+
+  public CreateContextAndTask(
+      final MockActiveContext context,
+      final MockRunningTask task) {
+    this.context = context;
+    this.task = task;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.CREATE_CONTEXT_AND_TASK;
+  }
+
+  @Override
+  public Tuple<MockActiveContext, MockRunningTask> getSuccessEvent() {
+    return new Tuple<>(this.context, this.task);
+  }
+
+  @Override
+  public Tuple<MockFailedContext, FailedTask> getFailureEvent() {
+    return new Tuple<>(
+        new MockFailedContext(this.context),
+        new FailedTask(
+            this.task.getId(),
+            "mock",
+            Optional.<String>empty(),
+            Optional.<Throwable>empty(),
+            Optional.<byte[]>empty(),
+            Optional.of((ActiveContext)this.context)));
+  }
+
+  @Override
+  public boolean doAutoComplete() {
+    return this.autoComplete;
+  }
+
+  @Override
+  public void setAutoComplete(final boolean value) {
+    this.autoComplete = value;
+  }
+
+  @Override
+  public ProcessRequest getCompletionProcessRequest() {
+    return new CompleteTask(this.task);
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContextAndTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContextAndTask.java
@@ -33,7 +33,7 @@ import org.apache.reef.util.Optional;
 /**
  * create context and task process request.
  */
-public class CreateContextAndTask implements
+public final class CreateContextAndTask implements
     ProcessRequestInternal<Tuple<MockActiveContext, MockRunningTask>, Tuple<MockFailedContext, FailedTask>>,
     AutoCompletable {
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContextAndTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContextAndTask.java
@@ -23,6 +23,7 @@ import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.io.Tuple;
 import org.apache.reef.mock.AutoCompletable;
+import org.apache.reef.mock.MockTaskReturnValueProvider;
 import org.apache.reef.mock.ProcessRequest;
 import org.apache.reef.mock.runtime.MockActiveContext;
 import org.apache.reef.mock.runtime.MockFailedContext;
@@ -40,13 +41,17 @@ public class CreateContextAndTask implements
 
   private final MockRunningTask task;
 
+  private final MockTaskReturnValueProvider taskReturnValueProvider;
+
   private boolean autoComplete = true;
 
   public CreateContextAndTask(
       final MockActiveContext context,
-      final MockRunningTask task) {
+      final MockRunningTask task,
+      final MockTaskReturnValueProvider taskReturnValueProvider) {
     this.context = context;
     this.task = task;
+    this.taskReturnValueProvider = taskReturnValueProvider;
   }
 
   @Override
@@ -84,6 +89,6 @@ public class CreateContextAndTask implements
 
   @Override
   public ProcessRequest getCompletionProcessRequest() {
-    return new CompleteTask(this.task);
+    return new CompleteTask(this.task, this.taskReturnValueProvider);
   }
 }

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContextAndTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateContextAndTask.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.io.Tuple;
@@ -33,6 +35,8 @@ import org.apache.reef.util.Optional;
 /**
  * create context and task process request.
  */
+@Unstable
+@Private
 public final class CreateContextAndTask implements
     ProcessRequestInternal<Tuple<MockActiveContext, MockRunningTask>, Tuple<MockFailedContext, FailedTask>>,
     AutoCompletable {

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateTask.java
@@ -22,6 +22,7 @@ package org.apache.reef.mock.request;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.mock.AutoCompletable;
+import org.apache.reef.mock.MockTaskReturnValueProvider;
 import org.apache.reef.mock.ProcessRequest;
 import org.apache.reef.mock.runtime.MockRunningTask;
 import org.apache.reef.util.Optional;
@@ -35,10 +36,15 @@ public class CreateTask implements
 
   private final MockRunningTask task;
 
+  private final MockTaskReturnValueProvider returnValueProvider;
+
   private boolean autoComplete = true;
 
-  public CreateTask(final MockRunningTask task) {
+  public CreateTask(
+      final MockRunningTask task,
+      final MockTaskReturnValueProvider returnValueProvider) {
     this.task = task;
+    this.returnValueProvider = returnValueProvider;
   }
 
   @Override
@@ -53,7 +59,7 @@ public class CreateTask implements
 
   @Override
   public ProcessRequest getCompletionProcessRequest() {
-    return new CompleteTask(this.task);
+    return new CompleteTask(this.task, this.returnValueProvider);
   }
 
   @Override

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateTask.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.mock.AutoCompletable;
@@ -30,6 +32,8 @@ import org.apache.reef.util.Optional;
 /**
  * create task process request.
  */
+@Unstable
+@Private
 public final class CreateTask implements
     ProcessRequestInternal<RunningTask, FailedTask>,
     AutoCompletable {

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateTask.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.request;
+
+import org.apache.reef.driver.task.FailedTask;
+import org.apache.reef.driver.task.RunningTask;
+import org.apache.reef.mock.AutoCompletable;
+import org.apache.reef.mock.ProcessRequest;
+import org.apache.reef.mock.runtime.MockRunningTask;
+import org.apache.reef.util.Optional;
+
+/**
+ * create task process request.
+ */
+public class CreateTask implements
+    ProcessRequestInternal<RunningTask, FailedTask>,
+    AutoCompletable {
+
+  private final MockRunningTask task;
+
+  private boolean autoComplete = true;
+
+  public CreateTask(final MockRunningTask task) {
+    this.task = task;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.CREATE_TASK;
+  }
+
+  @Override
+  public boolean doAutoComplete() {
+    return this.autoComplete;
+  }
+
+  @Override
+  public ProcessRequest getCompletionProcessRequest() {
+    return new CompleteTask(this.task);
+  }
+
+  @Override
+  public void setAutoComplete(final boolean value) {
+    this.autoComplete = value;
+  }
+
+  @Override
+  public MockRunningTask getSuccessEvent() {
+    return this.task;
+  }
+
+  @Override
+  public FailedTask getFailureEvent() {
+    return new FailedTask(
+        this.task.getId(),
+        "mock",
+        Optional.<String>empty(),
+        Optional.<Throwable>empty(),
+        Optional.<byte[]>empty(),
+        Optional.of(this.task.getActiveContext()));
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/CreateTask.java
@@ -30,7 +30,7 @@ import org.apache.reef.util.Optional;
 /**
  * create task process request.
  */
-public class CreateTask implements
+public final class CreateTask implements
     ProcessRequestInternal<RunningTask, FailedTask>,
     AutoCompletable {
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/ProcessRequestInternal.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/ProcessRequestInternal.java
@@ -19,6 +19,7 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.mock.ProcessRequest;
 
@@ -27,6 +28,7 @@ import org.apache.reef.mock.ProcessRequest;
  * @param <S> successful event
  * @param <F> failure event
  */
+@Unstable
 @Private
 public interface ProcessRequestInternal<S, F> extends ProcessRequest {
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/ProcessRequestInternal.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/ProcessRequestInternal.java
@@ -19,6 +19,7 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.mock.ProcessRequest;
 
 /**
@@ -26,9 +27,16 @@ import org.apache.reef.mock.ProcessRequest;
  * @param <S> successful event
  * @param <F> failure event
  */
+@Private
 public interface ProcessRequestInternal<S, F> extends ProcessRequest {
 
+  /**
+   * @return the outcome of a successful processing of this request
+   */
   S getSuccessEvent();
 
+  /**
+   * @return the outcome of an unsuccessful processing of this request
+   */
   F getFailureEvent();
 }

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/ProcessRequestInternal.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/ProcessRequestInternal.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,29 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.evaluator;
 
-import org.apache.reef.annotations.Provided;
-import org.apache.reef.annotations.audience.DriverSide;
-import org.apache.reef.annotations.audience.Public;
+package org.apache.reef.mock.request;
+
+import org.apache.reef.mock.ProcessRequest;
 
 /**
- * Interface through which Evaluators can be requested.
+ * internal process request API.
+ * @param <S> successful event
+ * @param <F> failure event
  */
-@Public
-@DriverSide
-@Provided
-public interface EvaluatorRequestor {
+public interface ProcessRequestInternal<S, F> extends ProcessRequest {
 
-  /**
-   * Submit the request for new evaluator.
-   * The response will surface in the AllocatedEvaluator message handler.
-   */
-  void submit(final EvaluatorRequest req);
+  S getSuccessEvent();
 
-  /**
-   * Get a new Builder for the evaluator with fluid interface.
-   * @return Builder for the evaluator
-   */
-  EvaluatorRequest.Builder newRequest();
+  F getFailureEvent();
 }

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SendMessageDriverToContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SendMessageDriverToContext.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.request;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.mock.ProcessRequest;
+
+/**
+ * send message from driver to context process request.
+ */
+public class SendMessageDriverToContext implements
+    ProcessRequestInternal<Object, Object> {
+
+  private final ActiveContext context;
+
+  private final byte[] message;
+
+  public SendMessageDriverToContext(final ActiveContext context, final byte[] message) {
+    this.context = context;
+    this.message = message;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.SEND_MESSAGE_DRIVER_TO_CONTEXT;
+  }
+
+  public ActiveContext getContext() {
+    return this.context;
+  }
+
+  public byte[] getMessage() {
+    return this.message;
+  }
+
+  @Override
+  public Object getSuccessEvent() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Object getFailureEvent() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean doAutoComplete() {
+    return false;
+  }
+
+  @Override
+  public void setAutoComplete(final boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ProcessRequest getCompletionProcessRequest() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SendMessageDriverToContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SendMessageDriverToContext.java
@@ -19,13 +19,17 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.mock.ProcessRequest;
 
 /**
  * send message from driver to context process request.
  */
-public class SendMessageDriverToContext implements
+@Unstable
+@Private
+public final class SendMessageDriverToContext implements
     ProcessRequestInternal<Object, Object> {
 
   private final ActiveContext context;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SendMessageDriverToTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SendMessageDriverToTask.java
@@ -19,13 +19,17 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.mock.ProcessRequest;
 
 /**
  * send message from driver to task process request.
  */
-public class SendMessageDriverToTask implements
+@Unstable
+@Private
+public final class SendMessageDriverToTask implements
     ProcessRequestInternal<Object, Object> {
 
   private RunningTask task;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SendMessageDriverToTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SendMessageDriverToTask.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.request;
+
+import org.apache.reef.driver.task.RunningTask;
+import org.apache.reef.mock.ProcessRequest;
+
+/**
+ * send message from driver to task process request.
+ */
+public class SendMessageDriverToTask implements
+    ProcessRequestInternal<Object, Object> {
+
+  private RunningTask task;
+
+  private final byte[] message;
+
+  public SendMessageDriverToTask(final RunningTask task, final byte[] message) {
+    this.task = task;
+    this.message = message;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.SEND_MESSAGE_DRIVER_TO_TASK;
+  }
+
+  public RunningTask getTask() {
+    return task;
+  }
+
+  public byte[] getMessage() {
+    return message;
+  }
+
+  @Override
+  public Object getSuccessEvent() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Object getFailureEvent() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean doAutoComplete() {
+    return false;
+  }
+
+  @Override
+  public void setAutoComplete(final boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ProcessRequest getCompletionProcessRequest() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SuspendTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SuspendTask.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.request;
+
+import org.apache.reef.driver.task.FailedTask;
+import org.apache.reef.driver.task.SuspendedTask;
+import org.apache.reef.mock.ProcessRequest;
+import org.apache.reef.mock.runtime.MockRunningTask;
+import org.apache.reef.mock.runtime.MockSuspendedTask;
+import org.apache.reef.util.Optional;
+
+/**
+ * suspend task process request.
+ */
+public class SuspendTask implements ProcessRequestInternal<SuspendedTask, FailedTask> {
+
+  private final MockRunningTask task;
+
+  private final Optional<byte[]> message;
+
+  public SuspendTask(final MockRunningTask task, final Optional<byte[]> message) {
+    this.task = task;
+    this.message = message;
+  }
+
+  public MockRunningTask getTask() {
+    return task;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.SUSPEND_TASK;
+  }
+
+  public Optional<byte[]> getMessage() {
+    return message;
+  }
+
+  @Override
+  public MockSuspendedTask getSuccessEvent() {
+    return new MockSuspendedTask(this.task);
+  }
+
+  @Override
+  public FailedTask getFailureEvent() {
+    return new FailedTask(
+        this.task.getId(),
+        "mock",
+        Optional.<String>empty(),
+        Optional.<Throwable>empty(),
+        Optional.<byte[]>empty(),
+        Optional.of(this.task.getActiveContext()));
+  }
+
+  @Override
+  public boolean doAutoComplete() {
+    return false;
+  }
+
+  @Override
+  public void setAutoComplete(final boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ProcessRequest getCompletionProcessRequest() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SuspendTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/SuspendTask.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.request;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.driver.task.SuspendedTask;
 import org.apache.reef.mock.ProcessRequest;
@@ -29,7 +31,9 @@ import org.apache.reef.util.Optional;
 /**
  * suspend task process request.
  */
-public class SuspendTask implements ProcessRequestInternal<SuspendedTask, FailedTask> {
+@Unstable
+@Private
+public final class SuspendTask implements ProcessRequestInternal<SuspendedTask, FailedTask> {
 
   private final MockRunningTask task;
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/package-info.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/request/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+/**
+ * process request implementations.
+ */
+package org.apache.reef.mock.request;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockActiveContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockActiveContext.java
@@ -85,7 +85,7 @@ public final class MockActiveContext implements ActiveContext {
   public void submitTask(final Configuration taskConf) {
     final String taskID = MockUtils.getValue(taskConf, TaskConfigurationOptions.Identifier.class);
     final MockRunningTask task = new MockRunningTask(this.mockRuntimeDriver, taskID, this);
-    this.mockRuntimeDriver.add(new CreateTask(task));
+    this.mockRuntimeDriver.add(new CreateTask(task, this.mockRuntimeDriver.getTaskReturnValueProvider()));
   }
 
   @Override

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockActiveContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockActiveContext.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
+import org.apache.reef.driver.task.TaskConfigurationOptions;
+import org.apache.reef.evaluator.context.parameters.ContextIdentifier;
+import org.apache.reef.mock.request.CloseContext;
+import org.apache.reef.mock.request.CreateContext;
+import org.apache.reef.mock.request.CreateTask;
+import org.apache.reef.mock.request.SendMessageDriverToContext;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.util.Optional;
+
+/**
+ * mock active context.
+ */
+public final class MockActiveContext implements ActiveContext {
+
+  private final MockRuntimeDriver mockRuntimeDriver;
+
+  private final MockAllocatedEvalautor evaluator;
+
+  private final Optional<MockActiveContext> parentContext;
+
+  private final String contextID;
+
+  MockActiveContext(
+      final MockRuntimeDriver mockRuntimeDriver,
+      final MockAllocatedEvalautor evalautor,
+      final Optional<MockActiveContext> parentContext,
+      final String contextID) {
+    this.mockRuntimeDriver = mockRuntimeDriver;
+    this.evaluator = evalautor;
+    this.parentContext = parentContext;
+    this.contextID = contextID;
+  }
+
+  @Override
+  public int hashCode() {
+    final String id = this.getEvaluatorId() + ":" + contextID;
+    return id.hashCode();
+  }
+
+  public boolean equals(final Object that) {
+    if (that instanceof MockActiveContext) {
+      return this.getEvaluatorId().equals(((MockActiveContext)that).getEvaluatorId()) &&
+          this.contextID.equals(((MockActiveContext)that).contextID);
+    }
+    return false;
+  }
+
+  public MockAllocatedEvalautor getEvaluator() {
+    return this.evaluator;
+  }
+
+  public Optional<MockActiveContext> getParentContext() {
+    return this.parentContext;
+  }
+
+  @Override
+  public void close() {
+    this.mockRuntimeDriver.add(new CloseContext(this));
+  }
+
+  @Override
+  public void submitTask(final Configuration taskConf) {
+    final String taskID = MockUtils.getValue(taskConf, TaskConfigurationOptions.Identifier.class);
+    final MockRunningTask task = new MockRunningTask(this.mockRuntimeDriver, taskID, this);
+    this.mockRuntimeDriver.add(new CreateTask(task));
+  }
+
+  @Override
+  public void submitContext(final Configuration contextConfiguration) {
+    final String childContextID = MockUtils.getValue(contextConfiguration, ContextIdentifier.class);
+    final MockActiveContext context = new MockActiveContext(
+        this.mockRuntimeDriver,
+        this.evaluator,
+        Optional.of(this),
+        childContextID);
+    this.mockRuntimeDriver.add(new CreateContext(context));
+  }
+
+  @Override
+  public void submitContextAndService(
+      final Configuration contextConfiguration,
+      final Configuration serviceConfiguration) {
+    submitContext(contextConfiguration);
+  }
+
+  @Override
+  public void sendMessage(final byte[] message) {
+    this.mockRuntimeDriver.add(new SendMessageDriverToContext(this, message));
+  }
+
+  @Override
+  public String getEvaluatorId() {
+    return this.evaluator.getId();
+  }
+
+  @Override
+  public Optional<String> getParentId() {
+    return this.parentContext.isPresent() ?
+        Optional.of(this.parentContext.get().getId()) :
+        Optional.<String>empty();
+  }
+
+  @Override
+  public EvaluatorDescriptor getEvaluatorDescriptor() {
+    return this.evaluator.getEvaluatorDescriptor();
+  }
+
+  @Override
+  public String getId() {
+    return this.contextID;
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockActiveContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockActiveContext.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
 import org.apache.reef.driver.task.TaskConfigurationOptions;
@@ -33,6 +35,8 @@ import org.apache.reef.util.Optional;
 /**
  * mock active context.
  */
+@Unstable
+@Private
 public final class MockActiveContext implements ActiveContext {
 
   private final MockRuntimeDriver mockRuntimeDriver;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockAllocatedEvalautor.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockAllocatedEvalautor.java
@@ -123,7 +123,11 @@ public final class MockAllocatedEvalautor implements AllocatedEvaluator {
         Optional.of(this.rootContext),
         contextID);
     final MockRunningTask mockTask = new MockRunningTask(this.mockRuntimeDriver, taskID, mockContext);
-    this.mockRuntimeDriver.add(new CreateContextAndTask(mockContext, mockTask));
+    this.mockRuntimeDriver.add(
+        new CreateContextAndTask(
+            mockContext,
+            mockTask,
+            this.mockRuntimeDriver.getTaskReturnValueProvider()));
   }
 
   @Override

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockAllocatedEvalautor.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockAllocatedEvalautor.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
+import org.apache.reef.driver.evaluator.EvaluatorProcess;
+import org.apache.reef.driver.task.TaskConfigurationOptions;
+import org.apache.reef.evaluator.context.parameters.ContextIdentifier;
+import org.apache.reef.mock.request.CloseEvaluator;
+import org.apache.reef.mock.request.CreateContextAndTask;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.util.Optional;
+
+import java.io.File;
+
+/**
+ * mock allocated evaluator.
+ */
+public final class MockAllocatedEvalautor implements AllocatedEvaluator {
+  public static final String ROOT_CONTEXT_IDENTIFIER_PREFIX = "ROOT.CONTEXT.";
+
+  private final MockRuntimeDriver mockRuntimeDriver;
+
+  private final String identifier;
+
+  private final EvaluatorDescriptor evaluatorDescriptor;
+
+  private final MockActiveContext rootContext;
+
+  private boolean closed = false;
+
+  MockAllocatedEvalautor(
+      final MockRuntimeDriver mockRuntimeDriver,
+      final String identifier,
+      final EvaluatorDescriptor evaluatorDescriptor) {
+    this.mockRuntimeDriver = mockRuntimeDriver;
+    this.identifier = identifier;
+    this.evaluatorDescriptor = evaluatorDescriptor;
+    this.rootContext = new MockActiveContext(
+        mockRuntimeDriver,
+        this,
+        Optional.<MockActiveContext>empty(),
+        ROOT_CONTEXT_IDENTIFIER_PREFIX + identifier);
+  }
+
+  public MockActiveContext getRootContext() {
+    return this.rootContext;
+  }
+
+  @Override
+  public void addFile(final File file) {
+    // ignore
+  }
+
+  @Override
+  public void addLibrary(final File file) {
+    // ignore
+  }
+
+  @Override
+  public EvaluatorDescriptor getEvaluatorDescriptor() {
+    return this.evaluatorDescriptor;
+  }
+
+  @Override
+  public void setProcess(final EvaluatorProcess process) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void close() {
+    if (!this.closed) {
+      this.mockRuntimeDriver.add(new CloseEvaluator(this));
+    } else {
+      throw new IllegalStateException("evaluator already closed");
+    }
+  }
+
+  @Override
+  public void submitTask(final Configuration taskConfiguration) {
+    this.rootContext.submitTask(taskConfiguration);
+  }
+
+  @Override
+  public void submitContext(final Configuration contextConfiguration) {
+    this.rootContext.submitContext(contextConfiguration);
+  }
+
+  @Override
+  public void submitContextAndService(
+      final Configuration contextConfiguration,
+      final Configuration serviceConfiguration) {
+    this.rootContext.submitContextAndService(contextConfiguration, serviceConfiguration);
+  }
+
+  @Override
+  public void submitContextAndTask(
+      final Configuration contextConfiguration,
+      final Configuration taskConfiguration) {
+    final String contextID = MockUtils.getValue(contextConfiguration, ContextIdentifier.class);
+    final String taskID = MockUtils.getValue(taskConfiguration, TaskConfigurationOptions.Identifier.class);
+    final MockActiveContext mockContext = new MockActiveContext(
+        this.mockRuntimeDriver,
+        this,
+        Optional.of(this.rootContext),
+        contextID);
+    final MockRunningTask mockTask = new MockRunningTask(this.mockRuntimeDriver, taskID, mockContext);
+    this.mockRuntimeDriver.add(new CreateContextAndTask(mockContext, mockTask));
+  }
+
+  @Override
+  public void submitContextAndServiceAndTask(
+      final Configuration contextConfiguration,
+      final Configuration serviceConfiguration,
+      final Configuration taskConfiguration) {
+    submitContextAndTask(contextConfiguration, taskConfiguration);
+  }
+
+  @Override
+  public String getId() {
+    return this.identifier;
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockAllocatedEvalautor.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockAllocatedEvalautor.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
 import org.apache.reef.driver.evaluator.EvaluatorProcess;
@@ -34,6 +36,8 @@ import java.io.File;
 /**
  * mock allocated evaluator.
  */
+@Unstable
+@Private
 public final class MockAllocatedEvalautor implements AllocatedEvaluator {
   public static final String ROOT_CONTEXT_IDENTIFIER_PREFIX = "ROOT.CONTEXT.";
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockClock.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockClock.java
@@ -2,24 +2,27 @@
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
+ *  regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
  */
 
-package org.apache.reef.mock;
+package org.apache.reef.mock.runtime;
 
 import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.mock.MockRuntime;
+import org.apache.reef.tang.InjectionFuture;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.time.Clock;
 import org.apache.reef.wake.time.Time;
@@ -37,7 +40,7 @@ import java.util.List;
 @Private
 public final class MockClock implements Clock {
 
-  private final MockRuntime runtime;
+  private final InjectionFuture<MockRuntime> runtime;
 
   private final List<Alarm> alarmList = new ArrayList<>();
 
@@ -46,7 +49,7 @@ public final class MockClock implements Clock {
   private boolean closed = false;
 
   @Inject
-  MockClock(final MockRuntime runtime) {
+  MockClock(final InjectionFuture<MockRuntime> runtime) {
     this.runtime = runtime;
   }
 
@@ -83,7 +86,7 @@ public final class MockClock implements Clock {
   @Override
   public void close() {
     if (!closed) {
-      this.runtime.stop();
+      this.runtime.get().stop();
       this.closed = true;
     }
   }
@@ -100,7 +103,7 @@ public final class MockClock implements Clock {
 
   @Override
   public boolean isIdle() {
-    return this.alarmList.size() > 0;
+    return this.alarmList.size() == 0;
   }
 
   @Override
@@ -110,6 +113,6 @@ public final class MockClock implements Clock {
 
   @Override
   public void run() {
-    this.runtime.start();
+    this.runtime.get().start();
   }
 }

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockClock.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockClock.java
@@ -20,6 +20,7 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.mock.MockRuntime;
 import org.apache.reef.tang.InjectionFuture;
@@ -37,6 +38,7 @@ import java.util.List;
 /**
  * The MockClock can be used to drive alarms set by the client application.
  */
+@Unstable
 @Private
 public final class MockClock implements Clock {
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockClosedContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockClosedContext.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.context.ClosedContext;
+import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
+import org.apache.reef.util.Optional;
+
+/**
+ * mock closed context.
+ */
+public class MockClosedContext implements ClosedContext {
+
+  private final MockActiveContext mockActiveContext;
+
+  public MockClosedContext(final MockActiveContext activeContext) {
+    this.mockActiveContext = activeContext;
+  }
+
+  public MockActiveContext getMockActiveContext() {
+    return this.mockActiveContext;
+  }
+
+  @Override
+  public ActiveContext getParentContext() {
+    return this.mockActiveContext.getParentContext().isPresent() ?
+      this.mockActiveContext.getParentContext().get() : null;
+  }
+
+  @Override
+  public String getId() {
+    return this.mockActiveContext.getId();
+  }
+
+  @Override
+  public String getEvaluatorId() {
+    return this.mockActiveContext.getEvaluatorId();
+  }
+
+  @Override
+  public Optional<String> getParentId() {
+    return this.mockActiveContext.getParentId();
+  }
+
+  @Override
+  public EvaluatorDescriptor getEvaluatorDescriptor() {
+    return this.mockActiveContext.getEvaluatorDescriptor();
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockClosedContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockClosedContext.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ClosedContext;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
@@ -27,7 +29,9 @@ import org.apache.reef.util.Optional;
 /**
  * mock closed context.
  */
-public class MockClosedContext implements ClosedContext {
+@Unstable
+@Private
+public final class MockClosedContext implements ClosedContext {
 
   private final MockActiveContext mockActiveContext;
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockCompletedTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockCompletedTask.java
@@ -21,7 +21,6 @@ package org.apache.reef.mock.runtime;
 
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.task.CompletedTask;
-import org.apache.reef.util.Optional;
 
 /**
  * mock completed task.
@@ -30,9 +29,9 @@ public class MockCompletedTask implements CompletedTask {
 
   private final MockRunningTask task;
 
-  private final Optional<byte[]> returnValue;
+  private final byte[] returnValue;
 
-  public MockCompletedTask(final MockRunningTask task, final Optional<byte[]> returnValue) {
+  public MockCompletedTask(final MockRunningTask task, final byte[] returnValue) {
     this.task = task;
     this.returnValue = returnValue;
   }
@@ -49,6 +48,6 @@ public class MockCompletedTask implements CompletedTask {
 
   @Override
   public byte[] get() {
-    return this.returnValue.isPresent() ? this.returnValue.get() : new byte[0];
+    return this.returnValue;
   }
 }

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockCompletedTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockCompletedTask.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.task.CompletedTask;
+import org.apache.reef.util.Optional;
+
+/**
+ * mock completed task.
+ */
+public class MockCompletedTask implements CompletedTask {
+
+  private final MockRunningTask task;
+
+  private final Optional<byte[]> returnValue;
+
+  public MockCompletedTask(final MockRunningTask task, final Optional<byte[]> returnValue) {
+    this.task = task;
+    this.returnValue = returnValue;
+  }
+
+  @Override
+  public ActiveContext getActiveContext() {
+    return this.task.getActiveContext();
+  }
+
+  @Override
+  public String getId() {
+    return this.task.getId();
+  }
+
+  @Override
+  public byte[] get() {
+    return this.returnValue.isPresent() ? this.returnValue.get() : new byte[0];
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockCompletedTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockCompletedTask.java
@@ -19,13 +19,17 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.task.CompletedTask;
 
 /**
  * mock completed task.
  */
-public class MockCompletedTask implements CompletedTask {
+@Unstable
+@Private
+public final class MockCompletedTask implements CompletedTask {
 
   private final MockRunningTask task;
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockEvaluatorDescriptor.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockEvaluatorDescriptor.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.catalog.NodeDescriptor;
+import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
+import org.apache.reef.driver.evaluator.EvaluatorProcess;
+
+/**
+ * mock evaluator descriptor.
+ */
+public final class MockEvaluatorDescriptor implements EvaluatorDescriptor {
+  private final NodeDescriptor nodeDescriptor;
+
+  MockEvaluatorDescriptor(final NodeDescriptor nodeDescriptor) {
+    this.nodeDescriptor = nodeDescriptor;
+  }
+
+  @Override
+  public NodeDescriptor getNodeDescriptor() {
+    return this.nodeDescriptor;
+  }
+
+  @Override
+  public EvaluatorProcess getProcess() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getMemory() {
+    return 0;
+  }
+
+  @Override
+  public int getNumberOfCores() {
+    return 1;
+  }
+
+  @Override
+  public String getRuntimeName() {
+    return "mock";
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockEvaluatorDescriptor.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockEvaluatorDescriptor.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.catalog.NodeDescriptor;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
 import org.apache.reef.driver.evaluator.EvaluatorProcess;
@@ -26,6 +28,8 @@ import org.apache.reef.driver.evaluator.EvaluatorProcess;
 /**
  * mock evaluator descriptor.
  */
+@Unstable
+@Private
 public final class MockEvaluatorDescriptor implements EvaluatorDescriptor {
   private final NodeDescriptor nodeDescriptor;
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockEvaluatorRequestor.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockEvaluatorRequestor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.catalog.NodeDescriptor;
+import org.apache.reef.driver.evaluator.EvaluatorRequest;
+import org.apache.reef.driver.evaluator.EvaluatorRequestor;
+import org.apache.reef.mock.request.AllocateEvaluator;
+import org.apache.reef.tang.InjectionFuture;
+
+import javax.inject.Inject;
+import java.util.UUID;
+
+/**
+ * mock evaluator requestor.
+ */
+public final class MockEvaluatorRequestor implements EvaluatorRequestor {
+
+  private final InjectionFuture<MockRuntimeDriver> mockRuntimeDriver;
+
+  @Inject
+  MockEvaluatorRequestor(final InjectionFuture<MockRuntimeDriver> mockRuntimeDriver) {
+    this.mockRuntimeDriver = mockRuntimeDriver;
+  }
+
+  @Override
+  public void submit(final EvaluatorRequest req) {
+    final NodeDescriptor nodeDescriptor = new MockNodeDescriptor();
+    final MockEvaluatorDescriptor evaluatorDescriptor = new MockEvaluatorDescriptor(nodeDescriptor);
+    for (int i = 0; i < req.getNumber(); i++) {
+      final MockAllocatedEvalautor mockEvaluator = new MockAllocatedEvalautor(
+          this.mockRuntimeDriver.get(), UUID.randomUUID().toString(), evaluatorDescriptor);
+      this.mockRuntimeDriver.get().add(new AllocateEvaluator(mockEvaluator));
+    }
+  }
+
+  @Override
+  public Builder newRequest() {
+    return new Builder();
+  }
+
+
+  /**
+   * {@link EvaluatorRequest.Builder} extended with a new submit method.
+   * {@link EvaluatorRequest}s are built using this builder.
+   */
+  public final class Builder extends EvaluatorRequest.Builder<Builder> {
+    @Override
+    public void submit() {
+      MockEvaluatorRequestor.this.submit(this.build());
+    }
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockEvaluatorRequestor.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockEvaluatorRequestor.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.catalog.NodeDescriptor;
 import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
@@ -31,6 +33,8 @@ import java.util.UUID;
 /**
  * mock evaluator requestor.
  */
+@Unstable
+@Private
 public final class MockEvaluatorRequestor implements EvaluatorRequestor {
 
   private final InjectionFuture<MockRuntimeDriver> mockRuntimeDriver;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockFailedContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockFailedContext.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
@@ -27,7 +29,9 @@ import org.apache.reef.util.Optional;
 /**
  * mock failed context.
  */
-public class MockFailedContext implements FailedContext {
+@Unstable
+@Private
+public final class MockFailedContext implements FailedContext {
 
   private final MockActiveContext context;
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockFailedContext.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockFailedContext.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.context.FailedContext;
+import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
+import org.apache.reef.util.Optional;
+
+/**
+ * mock failed context.
+ */
+public class MockFailedContext implements FailedContext {
+
+  private final MockActiveContext context;
+
+  public MockFailedContext(final MockActiveContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public Optional<ActiveContext> getParentContext() {
+    return this.context.getParentContext().isPresent() ?
+        Optional.of((ActiveContext)this.context.getParentContext().get()) :
+        Optional.<ActiveContext>empty();
+  }
+
+  @Override
+  public String getMessage() {
+    return "mock";
+  }
+
+  @Override
+  public Optional<String> getDescription() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Throwable> getReason() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<byte[]> getData() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Throwable asError() {
+    return new Exception("mock");
+  }
+
+  @Override
+  public String getEvaluatorId() {
+    return this.context.getEvaluatorId();
+  }
+
+  @Override
+  public Optional<String> getParentId() {
+    return this.context.getParentId();
+  }
+
+  @Override
+  public EvaluatorDescriptor getEvaluatorDescriptor() {
+    return this.context.getEvaluatorDescriptor();
+  }
+
+  @Override
+  public String getId() {
+    return this.context.getId();
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockFailedEvaluator.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockFailedEvaluator.java
@@ -18,6 +18,8 @@
  */
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.driver.task.FailedTask;
@@ -30,7 +32,9 @@ import java.util.List;
 /**
  * mock failed evaluator.
  */
-public class MockFailedEvaluator implements FailedEvaluator {
+@Unstable
+@Private
+public final class MockFailedEvaluator implements FailedEvaluator {
 
   private final String evaluatorID;
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockFailedEvaluator.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockFailedEvaluator.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.context.FailedContext;
+import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.driver.task.FailedTask;
+import org.apache.reef.exception.EvaluatorException;
+import org.apache.reef.util.Optional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * mock failed evaluator.
+ */
+public class MockFailedEvaluator implements FailedEvaluator {
+
+  private final String evaluatorID;
+
+  private final List<FailedContext> failedContextList;
+
+  private final Optional<FailedTask> failedTask;
+
+  public MockFailedEvaluator(
+      final String evaluatorID,
+      final List<FailedContext> failedContextList,
+      final Optional<FailedTask> failedTask) {
+    this.evaluatorID = evaluatorID;
+    this.failedContextList = failedContextList;
+    this.failedTask = failedTask;
+  }
+
+  public MockFailedEvaluator(final String evaluatorID) {
+    this.evaluatorID = evaluatorID;
+    this.failedContextList = new ArrayList<>();
+    this.failedTask = Optional.empty();
+  }
+
+  @Override
+  public EvaluatorException getEvaluatorException() {
+    return null;
+  }
+
+  @Override
+  public List<FailedContext> getFailedContextList() {
+    return this.failedContextList;
+  }
+
+  @Override
+  public Optional<FailedTask> getFailedTask() {
+    return this.failedTask;
+  }
+
+  @Override
+  public String getId() {
+    return this.evaluatorID;
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockNodeDescriptor.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockNodeDescriptor.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.catalog.NodeDescriptor;
 import org.apache.reef.driver.catalog.RackDescriptor;
 
@@ -29,7 +31,9 @@ import java.util.List;
 /**
  * mock node descriptor.
  */
-public class MockNodeDescriptor implements NodeDescriptor {
+@Unstable
+@Private
+public final class MockNodeDescriptor implements NodeDescriptor {
   @Override
   public InetSocketAddress getInetSocketAddress() {
     throw new UnsupportedOperationException();

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockNodeDescriptor.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockNodeDescriptor.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.catalog.NodeDescriptor;
+import org.apache.reef.driver.catalog.RackDescriptor;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * mock node descriptor.
+ */
+public class MockNodeDescriptor implements NodeDescriptor {
+  @Override
+  public InetSocketAddress getInetSocketAddress() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public RackDescriptor getRackDescriptor() {
+    return new RackDescriptor() {
+      @Override
+      public List<NodeDescriptor> getNodes() {
+        final List<NodeDescriptor> nodes = new ArrayList<>();
+        nodes.add(MockNodeDescriptor.this);
+        return nodes;
+      }
+
+      @Override
+      public String getName() {
+        return "mock";
+      }
+    };
+  }
+
+  @Override
+  public String getName() {
+    return "mock";
+  }
+
+  @Override
+  public String getId() {
+    return "mock";
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRunningTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRunningTask.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.task.RunningTask;
+import org.apache.reef.mock.request.CloseTask;
+import org.apache.reef.mock.request.SendMessageDriverToTask;
+import org.apache.reef.mock.request.SuspendTask;
+import org.apache.reef.runtime.common.driver.task.TaskRepresenter;
+import org.apache.reef.util.Optional;
+
+/**
+ * mock running task.
+ */
+public class MockRunningTask implements RunningTask {
+
+  private final MockRuntimeDriver mockRuntimeDriver;
+
+  private final String taskID;
+
+  private final ActiveContext context;
+
+  MockRunningTask(
+      final MockRuntimeDriver mockRuntimeDriver,
+      final String taskID,
+      final ActiveContext context) {
+    this.mockRuntimeDriver = mockRuntimeDriver;
+    this.taskID = taskID;
+    this.context = context;
+  }
+
+  public String evaluatorID() {
+    return this.context.getEvaluatorId();
+  }
+
+  @Override
+  public ActiveContext getActiveContext() {
+    return this.context;
+  }
+
+  @Override
+  public void send(final byte[] message) {
+    this.mockRuntimeDriver.add(new SendMessageDriverToTask(this, message));
+  }
+
+  @Override
+  public void suspend(final byte[] message) {
+    this.mockRuntimeDriver.add(new SuspendTask(this, Optional.of(message)));
+  }
+
+  @Override
+  public void suspend() {
+    this.mockRuntimeDriver.add(new SuspendTask(this, Optional.<byte[]>empty()));
+  }
+
+  @Override
+  public void close(final byte[] message) {
+    this.mockRuntimeDriver.add(new CloseTask(this, Optional.of(message)));
+  }
+
+  @Override
+  public void close() {
+    this.mockRuntimeDriver.add(new CloseTask(this, Optional.<byte[]>empty()));
+  }
+
+  @Override
+  public TaskRepresenter getTaskRepresenter() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getId() {
+    return this.taskID;
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRunningTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRunningTask.java
@@ -73,12 +73,12 @@ public class MockRunningTask implements RunningTask {
 
   @Override
   public void close(final byte[] message) {
-    this.mockRuntimeDriver.add(new CloseTask(this, Optional.of(message)));
+    this.mockRuntimeDriver.add(new CloseTask(this, this.mockRuntimeDriver.getTaskReturnValueProvider()));
   }
 
   @Override
   public void close() {
-    this.mockRuntimeDriver.add(new CloseTask(this, Optional.<byte[]>empty()));
+    this.mockRuntimeDriver.add(new CloseTask(this, this.mockRuntimeDriver.getTaskReturnValueProvider()));
   }
 
   @Override

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRunningTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRunningTask.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.mock.request.CloseTask;
@@ -30,7 +32,9 @@ import org.apache.reef.util.Optional;
 /**
  * mock running task.
  */
-public class MockRunningTask implements RunningTask {
+@Unstable
+@Private
+public final class MockRunningTask implements RunningTask {
 
   private final MockRuntimeDriver mockRuntimeDriver;
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRuntimeDriver.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRuntimeDriver.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ContextMessage;
 import org.apache.reef.driver.context.FailedContext;
@@ -46,6 +48,8 @@ import java.util.*;
 /**
  * mock runtime driver.
  */
+@Unstable
+@Private
 public final class MockRuntimeDriver implements MockRuntime {
 
   private final InjectionFuture<MockClock> clock;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRuntimeDriver.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRuntimeDriver.java
@@ -20,7 +20,6 @@
 package org.apache.reef.mock.runtime;
 
 import org.apache.reef.driver.context.ActiveContext;
-import org.apache.reef.driver.context.ClosedContext;
 import org.apache.reef.driver.context.ContextMessage;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRuntimeDriver.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRuntimeDriver.java
@@ -30,6 +30,7 @@ import org.apache.reef.driver.task.*;
 import org.apache.reef.io.Tuple;
 import org.apache.reef.mock.MockClock;
 import org.apache.reef.mock.MockRuntime;
+import org.apache.reef.mock.MockTaskReturnValueProvider;
 import org.apache.reef.mock.ProcessRequest;
 import org.apache.reef.mock.request.*;
 import org.apache.reef.tang.InjectionFuture;
@@ -86,9 +87,12 @@ public final class MockRuntimeDriver implements MockRuntime {
 
   private final Map<String, MockRunningTask> runningTasks = new HashMap<>();
 
+  private final MockTaskReturnValueProvider taskReturnValueProvider;
+
   @Inject
   MockRuntimeDriver(
       final InjectionFuture<MockClock> clock,
+      final MockTaskReturnValueProvider taskReturnValueProvider,
       @Parameter(DriverStartHandler.class) final Set<EventHandler<StartTime>> driverStartHandlers,
       @Parameter(Clock.StopHandler.class) final Set<EventHandler<StopTime>> driverStopHandlers,
       @Parameter(EvaluatorAllocatedHandlers.class) final Set<EventHandler<AllocatedEvaluator>>
@@ -106,6 +110,7 @@ public final class MockRuntimeDriver implements MockRuntime {
       @Parameter(ContextMessageHandlers.class) final Set<EventHandler<ContextMessage>> contextMessageHandlers,
       @Parameter(ContextFailedHandlers.class) final Set<EventHandler<FailedContext>> contextFailedHandlers) {
     this.clock = clock;
+    this.taskReturnValueProvider = taskReturnValueProvider;
     this.driverStartHandlers = driverStartHandlers;
     this.driverStopHandlers = driverStopHandlers;
     this.allocatedEvaluatorHandlers = allocatedEvaluatorHandlers;
@@ -339,6 +344,9 @@ public final class MockRuntimeDriver implements MockRuntime {
     }
   }
 
+  MockTaskReturnValueProvider getTaskReturnValueProvider() {
+    return this.taskReturnValueProvider;
+  }
   /**
    * Used by mock REEF entities (e.g., AllocatedEvaluator, RunningTask) to inject
    * process requests from initiated actions e.g., RunningTask.close().

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRuntimeDriver.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRuntimeDriver.java
@@ -368,6 +368,9 @@ public final class MockRuntimeDriver implements MockRuntime {
       throw new IllegalStateException("closing context that is not on the top of the stack");
     }
     contexts.remove(context.getMockActiveContext());
+    if (contexts.size() == 0) {
+      add(new CloseEvaluator(this.allocatedEvaluatorMap.get(context.getEvaluatorId())));
+    }
   }
 
   private void validateAndCreate(final MockRunningTask task) {

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRuntimeDriver.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockRuntimeDriver.java
@@ -1,0 +1,403 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.context.ContextMessage;
+import org.apache.reef.driver.context.FailedContext;
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.evaluator.CompletedEvaluator;
+import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.driver.parameters.*;
+import org.apache.reef.driver.task.*;
+import org.apache.reef.io.Tuple;
+import org.apache.reef.mock.MockClock;
+import org.apache.reef.mock.MockRuntime;
+import org.apache.reef.mock.ProcessRequest;
+import org.apache.reef.mock.request.*;
+import org.apache.reef.tang.InjectionFuture;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.util.Optional;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.Clock;
+import org.apache.reef.wake.time.event.StartTime;
+import org.apache.reef.wake.time.event.StopTime;
+
+import javax.inject.Inject;
+import java.util.*;
+
+/**
+ * mock runtime driver.
+ */
+public final class MockRuntimeDriver implements MockRuntime {
+
+  private final InjectionFuture<MockClock> clock;
+
+  private final List<ProcessRequest> processRequestQueue = new ArrayList<>();
+
+  private final Set<EventHandler<StartTime>> driverStartHandlers;
+
+  private final Set<EventHandler<StopTime>> driverStopHandlers;
+
+  private final Set<EventHandler<AllocatedEvaluator>> allocatedEvaluatorHandlers;
+
+  private final Set<EventHandler<CompletedEvaluator>> completedEvaluatorHandlers;
+
+  private final Set<EventHandler<FailedEvaluator>> failedEvaluatorHandlers;
+
+  private final Set<EventHandler<TaskRunningHandlers>> taskRunningHandlers;
+
+  private final Set<EventHandler<FailedTask>> taskFailedHandlers;
+
+  private final Set<EventHandler<TaskMessage>> taskMessageHandlers;
+
+  private final Set<EventHandler<CompletedTask>> taskCompletedHandlers;
+
+  private final Set<EventHandler<SuspendedTask>> taskSuspendedHandlers;
+
+  private final Set<EventHandler<ActiveContext>> contextActiveHandlers;
+
+  private final Set<EventHandler<CloseContext>> contextClosedHandlers;
+
+  private final Set<EventHandler<ContextMessage>> contextMessageHandlers;
+
+  private final Set<EventHandler<FailedContext>> contextFailedHandlers;
+
+  private final Map<String, MockAllocatedEvalautor> allocatedEvaluatorMap = new HashMap<>();
+
+  private final Map<String, List<MockActiveContext>> allocatedContextsMap = new HashMap<>();
+
+  private final Map<String, MockRunningTask> runningTasks = new HashMap<>();
+
+  @Inject
+  MockRuntimeDriver(
+      final InjectionFuture<MockClock> clock,
+      @Parameter(DriverStartHandler.class) final Set<EventHandler<StartTime>> driverStartHandlers,
+      @Parameter(Clock.StopHandler.class) final Set<EventHandler<StopTime>> driverStopHandlers,
+      @Parameter(EvaluatorAllocatedHandlers.class) final Set<EventHandler<AllocatedEvaluator>>
+          allocatedEvaluatorHandlers,
+      @Parameter(EvaluatorCompletedHandlers.class) final Set<EventHandler<CompletedEvaluator>>
+          completedEvaluatorHandlers,
+      @Parameter(EvaluatorFailedHandlers.class) final Set<EventHandler<FailedEvaluator>> failedEvaluatorHandlers,
+      @Parameter(TaskRunningHandlers.class) final Set<EventHandler<TaskRunningHandlers>> taskRunningHandlers,
+      @Parameter(TaskFailedHandlers.class) final Set<EventHandler<FailedTask>> taskFailedHandlers,
+      @Parameter(TaskMessageHandlers.class) final Set<EventHandler<TaskMessage>> taskMessageHandlers,
+      @Parameter(TaskCompletedHandlers.class) final Set<EventHandler<CompletedTask>> taskCompletedHandlers,
+      @Parameter(TaskSuspendedHandlers.class) final Set<EventHandler<SuspendedTask>> taskSuspendedHandlers,
+      @Parameter(ContextActiveHandlers.class) final Set<EventHandler<ActiveContext>> contextActiveHandlers,
+      @Parameter(ContextClosedHandlers.class) final Set<EventHandler<CloseContext>> contextClosedHandlers,
+      @Parameter(ContextMessageHandlers.class) final Set<EventHandler<ContextMessage>> contextMessageHandlers,
+      @Parameter(ContextFailedHandlers.class) final Set<EventHandler<FailedContext>> contextFailedHandlers) {
+    this.clock = clock;
+    this.driverStartHandlers = driverStartHandlers;
+    this.driverStopHandlers = driverStopHandlers;
+    this.allocatedEvaluatorHandlers = allocatedEvaluatorHandlers;
+    this.completedEvaluatorHandlers = completedEvaluatorHandlers;
+    this.failedEvaluatorHandlers = failedEvaluatorHandlers;
+    this.taskRunningHandlers = taskRunningHandlers;
+    this.taskFailedHandlers = taskFailedHandlers;
+    this.taskMessageHandlers = taskMessageHandlers;
+    this.taskCompletedHandlers = taskCompletedHandlers;
+    this.taskSuspendedHandlers = taskSuspendedHandlers;
+    this.contextActiveHandlers = contextActiveHandlers;
+    this.contextClosedHandlers = contextClosedHandlers;
+    this.contextMessageHandlers = contextMessageHandlers;
+    this.contextFailedHandlers = contextFailedHandlers;
+  }
+
+  @Override
+  public Collection<AllocatedEvaluator> getCurrentAllocatedEvaluators() {
+    return new ArrayList<AllocatedEvaluator>(this.allocatedEvaluatorMap.values());
+  }
+
+  @Override
+  public void fail(final AllocatedEvaluator evaluator) {
+    if (this.allocatedEvaluatorMap.containsKey(evaluator.getId())) {
+      FailedTask failedTask =  null;
+      if (this.runningTasks.containsKey(evaluator.getId())) {
+        final RunningTask task = this.runningTasks.remove(evaluator.getId());
+        failedTask = new FailedTask(
+            task.getId(),
+            "mock",
+            Optional.<String>empty(),
+            Optional.<Throwable>empty(),
+            Optional.<byte[]>empty(),
+            Optional.<ActiveContext>of(task.getActiveContext()));
+      }
+      final List<FailedContext> failedContexts = new ArrayList<>();
+      for (final MockActiveContext context : this.allocatedContextsMap.get(evaluator.getId())) {
+        failedContexts.add(new MockFailedContext(context));
+      }
+      this.allocatedContextsMap.remove(evaluator.getId());
+
+      post(this.failedEvaluatorHandlers, new MockFailedEvaluator(
+          evaluator.getId(), failedContexts,
+          failedTask == null ? Optional.<FailedTask>empty() : Optional.of(failedTask)));
+    } else {
+      throw new IllegalStateException("unknown evaluator " + evaluator);
+    }
+  }
+
+  @Override
+  public Collection<ActiveContext> getCurrentActiveContexts() {
+    final List<ActiveContext> currentActiveContexts = new ArrayList<>();
+    for (final List<MockActiveContext> contexts : this.allocatedContextsMap.values()) {
+      currentActiveContexts.addAll(contexts);
+    }
+    return currentActiveContexts;
+  }
+
+  @Override
+  public void fail(final ActiveContext context) {
+    final MockAllocatedEvalautor evaluator = ((MockActiveContext) context).getEvaluator();
+    post(this.contextFailedHandlers, new MockFailedContext((MockActiveContext) context));
+    if (!((MockActiveContext) context).getParentContext().isPresent()) {
+      // root context failure shuts evalautor down
+      fail(evaluator);
+    } else {
+      this.allocatedContextsMap.get(evaluator.getId()).remove(context);
+    }
+  }
+
+  @Override
+  public Collection<RunningTask> getCurrentRunningTasks() {
+    return new ArrayList<RunningTask>(this.runningTasks.values());
+  }
+
+  @Override
+  public void fail(final RunningTask task) {
+    final String evaluatorID = task.getActiveContext().getEvaluatorId();
+    if (this.runningTasks.containsKey(evaluatorID) &&
+        this.runningTasks.get(evaluatorID).equals(task)) {
+      this.runningTasks.remove(evaluatorID);
+      post(taskFailedHandlers, new FailedTask(
+          task.getId(),
+          "mock",
+          Optional.<String>empty(),
+          Optional.<Throwable>empty(),
+          Optional.<byte[]>empty(),
+          Optional.of(task.getActiveContext())));
+    } else {
+      throw new IllegalStateException("unknown running task " + task);
+    }
+  }
+
+  @Override
+  public void start() {
+    post(this.driverStartHandlers, new StartTime(this.clock.get().getCurrentTime()));
+  }
+
+  @Override
+  public void stop() {
+    post(this.driverStopHandlers, new StopTime(this.clock.get().getCurrentTime()));
+  }
+
+  @Override
+  public boolean hasProcessRequest() {
+    return this.processRequestQueue.size() > 0;
+  }
+
+  @Override
+  public ProcessRequest getNextProcessRequest() {
+    if (this.processRequestQueue.size() > 0) {
+      return this.processRequestQueue.remove(0);
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public void succeed(final ProcessRequest pr) {
+    final ProcessRequestInternal request = (ProcessRequestInternal) pr;
+    switch (request.getType()) {
+    case ALLOCATE_EVALUATOR:
+      final MockAllocatedEvalautor allocatedEvalautor = ((AllocateEvaluator)request).getSuccessEvent();
+      validateAndCreate(allocatedEvalautor);
+      post(this.allocatedEvaluatorHandlers, allocatedEvalautor);
+      post(this.contextActiveHandlers, allocatedEvalautor.getRootContext());
+      break;
+    case CLOSE_EVALUATOR:
+      final CompletedEvaluator closedEvaluator = ((CloseEvaluator)request).getSuccessEvent();
+      validateAndClose(closedEvaluator);
+      post(this.completedEvaluatorHandlers, closedEvaluator);
+      break;
+    case CREATE_CONTEXT:
+      final MockActiveContext createContext = ((CreateContext) request).getSuccessEvent();
+      validateAndCreate(createContext);
+      post(this.contextActiveHandlers, createContext);
+      break;
+    case CLOSE_CONTEXT:
+      final MockClosedContext closeContext = ((CloseContext) request).getSuccessEvent();
+      validateAndClose(closeContext);
+      post(this.contextClosedHandlers, closeContext);
+      break;
+    case CREATE_TASK:
+      final MockRunningTask createTask = ((CreateTask)request).getSuccessEvent();
+      validateAndCreate(createTask);
+      post(this.taskRunningHandlers, request.getSuccessEvent());
+      break;
+    case SUSPEND_TASK:
+      final MockRunningTask suspendedTask = ((SuspendTask)request).getTask();
+      validateAndClose(suspendedTask);
+      post(this.taskSuspendedHandlers, request.getSuccessEvent());
+      break;
+    case CLOSE_TASK:
+    case COMPLETE_TASK:
+      final MockRunningTask completedTask = ((CompleteTask)request).getTask();
+      validateAndClose(completedTask);
+      post(this.taskCompletedHandlers, request.getSuccessEvent());
+      break;
+    case CREATE_CONTEXT_AND_TASK:
+      final CreateContextAndTask createContextTask = (CreateContextAndTask) request;
+      final Tuple<MockActiveContext, MockRunningTask> events = createContextTask.getSuccessEvent();
+      validateAndCreate(events.getKey());
+      post(this.contextActiveHandlers, events.getKey());
+      validateAndCreate(events.getValue());
+      post(this.taskRunningHandlers, events.getValue());
+      break;
+    case SEND_MESSAGE_DRIVER_TO_TASK:
+      // ignore
+      break;
+    case SEND_MESSAGE_DRIVER_TO_CONTEXT:
+      // ignore
+      break;
+    default:
+      throw new IllegalStateException("unknown type");
+    }
+
+    if (request.doAutoComplete()) {
+      add(request.getCompletionProcessRequest());
+    }
+  }
+
+  @Override
+  public void fail(final ProcessRequest pr) {
+    final ProcessRequestInternal request = (ProcessRequestInternal) pr;
+    switch (request.getType()) {
+    case ALLOCATE_EVALUATOR:
+      post(this.failedEvaluatorHandlers, request.getFailureEvent());
+      break;
+    case CLOSE_EVALUATOR:
+      final CompletedEvaluator evaluator = ((CloseEvaluator)request).getSuccessEvent();
+      validateAndClose(evaluator);
+      post(this.failedEvaluatorHandlers, request.getFailureEvent());
+      break;
+    case CREATE_CONTEXT:
+      post(this.contextFailedHandlers, request.getFailureEvent());
+      break;
+    case CLOSE_CONTEXT:
+      validateAndClose(((CloseContext)request).getSuccessEvent());
+      post(this.contextFailedHandlers, request.getFailureEvent());
+      break;
+    case CREATE_TASK:
+      post(this.taskFailedHandlers, request.getFailureEvent());
+      break;
+    case SUSPEND_TASK:
+      validateAndClose(((SuspendTask)request).getTask());
+      post(this.taskFailedHandlers, request.getFailureEvent());
+      break;
+    case CLOSE_TASK:
+    case COMPLETE_TASK:
+      validateAndClose(((CloseTask)request).getTask());
+      post(this.taskFailedHandlers, request.getFailureEvent());
+      break;
+    case CREATE_CONTEXT_AND_TASK:
+      final CreateContextAndTask createContextTask = (CreateContextAndTask) request;
+      final Tuple<MockFailedContext, FailedTask> events = createContextTask.getFailureEvent();
+      post(this.taskFailedHandlers, events.getValue());
+      post(this.contextFailedHandlers, events.getKey());
+      break;
+    case SEND_MESSAGE_DRIVER_TO_TASK:
+      // ignore
+      break;
+    case SEND_MESSAGE_DRIVER_TO_CONTEXT:
+      // ignore
+      break;
+    default:
+      throw new IllegalStateException("unknown type");
+    }
+  }
+
+  /**
+   * Used by mock REEF entities (e.g., AllocatedEvaluator, RunningTask) to inject
+   * process requests from initiated actions e.g., RunningTask.close().
+   * @param request to inject
+   */
+  void add(final ProcessRequest request) {
+    this.processRequestQueue.add(request);
+  }
+
+  private <T> void post(final Set<EventHandler<T>> handlers, final Object event) {
+    for (final EventHandler<T> handler : handlers) {
+      handler.onNext((T) event);
+    }
+  }
+
+  private void validateAndCreate(final MockActiveContext context) {
+    if (!this.allocatedEvaluatorMap.containsKey(context.getEvaluatorId())) {
+      throw new IllegalStateException("unknown evaluator id " + context.getEvaluatorId());
+    } else if (!this.allocatedContextsMap.containsKey(context.getEvaluatorId())) {
+      this.allocatedContextsMap.put(context.getEvaluatorId(), new ArrayList<MockActiveContext>());
+    }
+    this.allocatedContextsMap.get(context.getEvaluatorId()).add(context);
+  }
+
+  private void validateAndClose(final MockClosedContext context) {
+    if (!this.allocatedContextsMap.containsKey(context.getEvaluatorId())) {
+      throw new IllegalStateException("unknown evaluator id " + context.getEvaluatorId());
+    }
+    final List<MockActiveContext> contexts = this.allocatedContextsMap.get(context.getEvaluatorId());
+    if (!contexts.get(contexts.size() - 1).equals(context.getMockActiveContext())) {
+      throw new IllegalStateException("closing context that is not on the top of the stack");
+    }
+    contexts.remove(context.getMockActiveContext());
+  }
+
+  private void validateAndCreate(final MockRunningTask task) {
+    if (this.runningTasks.containsKey(task.evaluatorID())) {
+      throw new IllegalStateException("task already running on evaluator " +
+          task.evaluatorID());
+    }
+    this.runningTasks.put(task.evaluatorID(), task);
+  }
+
+  private void validateAndClose(final MockRunningTask task) {
+    if (!this.runningTasks.containsKey(task.getActiveContext().getEvaluatorId())) {
+      throw new IllegalStateException("no task running on evaluator");
+    }
+    this.runningTasks.remove(task.getActiveContext().getEvaluatorId());
+  }
+
+  private void validateAndCreate(final MockAllocatedEvalautor evalutor) {
+    if (this.allocatedEvaluatorMap.containsKey(evalutor.getId())) {
+      throw new IllegalStateException("evaluator id " + evalutor.getId() + " already exists");
+    }
+    this.allocatedEvaluatorMap.put(evalutor.getId(), evalutor);
+    this.allocatedContextsMap.put(evalutor.getId(), new ArrayList<MockActiveContext>());
+    this.allocatedContextsMap.get(evalutor.getId()).add(evalutor.getRootContext());
+  }
+
+  private void validateAndClose(final CompletedEvaluator evalautor) {
+    if (!this.allocatedEvaluatorMap.containsKey(evalautor.getId())) {
+      throw new IllegalStateException("unknown evaluator id " + evalautor.getId());
+    }
+    this.allocatedEvaluatorMap.remove(evalautor.getId());
+  }
+}

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockSuspendedTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockSuspendedTask.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,29 +16,35 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.evaluator;
 
-import org.apache.reef.annotations.Provided;
-import org.apache.reef.annotations.audience.DriverSide;
-import org.apache.reef.annotations.audience.Public;
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.task.SuspendedTask;
 
 /**
- * Interface through which Evaluators can be requested.
+ * mock suspended task.
  */
-@Public
-@DriverSide
-@Provided
-public interface EvaluatorRequestor {
+public class MockSuspendedTask implements SuspendedTask {
 
-  /**
-   * Submit the request for new evaluator.
-   * The response will surface in the AllocatedEvaluator message handler.
-   */
-  void submit(final EvaluatorRequest req);
+  private final MockRunningTask task;
 
-  /**
-   * Get a new Builder for the evaluator with fluid interface.
-   * @return Builder for the evaluator
-   */
-  EvaluatorRequest.Builder newRequest();
+  public MockSuspendedTask(final MockRunningTask task) {
+    this.task = task;
+  }
+
+  @Override
+  public ActiveContext getActiveContext() {
+    return this.task.getActiveContext();
+  }
+
+  @Override
+  public byte[] get() {
+    return new byte[0];
+  }
+
+  @Override
+  public String getId() {
+    return this.task.getId();
+  }
 }

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockSuspendedTask.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockSuspendedTask.java
@@ -19,13 +19,17 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.task.SuspendedTask;
 
 /**
  * mock suspended task.
  */
-public class MockSuspendedTask implements SuspendedTask {
+@Unstable
+@Private
+public final class MockSuspendedTask implements SuspendedTask {
 
   private final MockRunningTask task;
 

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockUtils.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockUtils.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,29 +16,30 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.evaluator;
 
-import org.apache.reef.annotations.Provided;
-import org.apache.reef.annotations.audience.DriverSide;
-import org.apache.reef.annotations.audience.Public;
+package org.apache.reef.mock.runtime;
+
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.exceptions.InjectionException;
 
 /**
- * Interface through which Evaluators can be requested.
+ * mock utilities.
  */
-@Public
-@DriverSide
-@Provided
-public interface EvaluatorRequestor {
+public final class MockUtils {
 
-  /**
-   * Submit the request for new evaluator.
-   * The response will surface in the AllocatedEvaluator message handler.
-   */
-  void submit(final EvaluatorRequest req);
+  private MockUtils() {
 
-  /**
-   * Get a new Builder for the evaluator with fluid interface.
-   * @return Builder for the evaluator
-   */
-  EvaluatorRequest.Builder newRequest();
+  }
+
+  public static <U, T extends Name<U>> U getValue(final Configuration configuration, final Class<T> name) {
+    try {
+      final Injector injector = Tang.Factory.getTang().newInjector(configuration);
+      return injector.getNamedInstance(name);
+    } catch (InjectionException e) {
+      throw new IllegalStateException(e);
+    }
+  }
 }

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockUtils.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/MockUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.reef.mock.runtime;
 
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
@@ -28,10 +30,11 @@ import org.apache.reef.tang.exceptions.InjectionException;
 /**
  * mock utilities.
  */
-public final class MockUtils {
+@Unstable
+@Private
+final class MockUtils {
 
   private MockUtils() {
-
   }
 
   public static <U, T extends Name<U>> U getValue(final Configuration configuration, final Class<T> name) {

--- a/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/package-info.java
+++ b/lang/java/reef-runtime-mock/src/main/java/org/apache/reef/mock/runtime/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+/**
+ * mock runtime implementation.
+ */
+package org.apache.reef.mock.runtime;

--- a/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/BasicMockTests.java
+++ b/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/BasicMockTests.java
@@ -107,7 +107,7 @@ public final class BasicMockTests {
     assertEquals("complete task request", ProcessRequest.Type.COMPLETE_TASK,
         completedTask.getType());
     this.mockRuntime.succeed(completedTask);
-    assertEquals("no running tasks", 0,this.mockApplication.getRunningTasks().size());
+    assertEquals("no running tasks", 0, this.mockApplication.getRunningTasks().size());
 
     // create a sub-context
     this.mockApplication.submitContext(rootContext, "child");
@@ -185,14 +185,14 @@ public final class BasicMockTests {
 
     // fail task
     this.mockRuntime.fail(task);
-    assertEquals("task failed", 1,this.mockApplication.getFailedTasks().size());
+    assertEquals("task failed", 1, this.mockApplication.getFailedTasks().size());
 
     // fail child context
     this.mockRuntime.fail(childContext);
     assertTrue("child context failed",
         this.mockApplication.getFailedContext().iterator().next().getId().equals(childContext.getId()));
     // evaluator should still be up
-    assertEquals("check evaluator", 0,this.mockApplication.getFailedEvaluators().size());
+    assertEquals("check evaluator", 0, this.mockApplication.getFailedEvaluators().size());
 
     // fail evaluator
     this.mockRuntime.fail(evaluator);

--- a/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/BasicMockTests.java
+++ b/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/BasicMockTests.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * basic mock tests.
  */
-public final class BasicMockTests {
+final class BasicMockTests {
 
   private MockApplication mockApplication;
 

--- a/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/BasicMockTests.java
+++ b/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/BasicMockTests.java
@@ -31,6 +31,7 @@ import org.apache.reef.tang.Tang;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -76,8 +77,8 @@ public final class BasicMockTests {
     this.mockApplication.requestEvaluators(1);
     assertTrue("check for process event", this.mockRuntime.hasProcessRequest());
     final ProcessRequest allocateEvaluatorRequest = this.mockRuntime.getNextProcessRequest();
-    assertTrue("allocate evalautor request",
-        allocateEvaluatorRequest.getType() == ProcessRequest.Type.ALLOCATE_EVALUATOR);
+    assertEquals("allocate evalautor request", ProcessRequest.Type.ALLOCATE_EVALUATOR,
+        allocateEvaluatorRequest.getType());
     final AllocatedEvaluator evaluator =
         ((ProcessRequestInternal<AllocatedEvaluator, Object>)allocateEvaluatorRequest)
             .getSuccessEvent();
@@ -93,8 +94,8 @@ public final class BasicMockTests {
     this.mockApplication.submitTask(rootContext, "test-task");
     assertTrue("create task queued", this.mockRuntime.hasProcessRequest());
     final ProcessRequest createTaskRequest = this.mockRuntime.getNextProcessRequest();
-    assertTrue("create task request",
-        createTaskRequest.getType() == ProcessRequest.Type.CREATE_TASK);
+    assertEquals("create task request", ProcessRequest.Type.CREATE_TASK,
+        createTaskRequest.getType());
     final RunningTask task = (RunningTask) ((ProcessRequestInternal)createTaskRequest).getSuccessEvent();
     this.mockRuntime.succeed(createTaskRequest);
     assertTrue("task running", this.mockApplication.getRunningTasks().contains(task));
@@ -103,18 +104,18 @@ public final class BasicMockTests {
     assertTrue("check for request", this.mockRuntime.hasProcessRequest());
     final ProcessRequestInternal completedTask =
         (ProcessRequestInternal) this.mockRuntime.getNextProcessRequest();
-    assertTrue("complete task request",
-        completedTask.getType() == ProcessRequest.Type.COMPLETE_TASK);
+    assertEquals("complete task request", ProcessRequest.Type.COMPLETE_TASK,
+        completedTask.getType());
     this.mockRuntime.succeed(completedTask);
-    assertTrue("no running tasks", this.mockApplication.getRunningTasks().size() == 0);
+    assertEquals("no running tasks", 0,this.mockApplication.getRunningTasks().size());
 
     // create a sub-context
     this.mockApplication.submitContext(rootContext, "child");
     assertTrue("check for request", this.mockRuntime.hasProcessRequest());
     final ProcessRequestInternal createContextRequest =
         (ProcessRequestInternal) this.mockRuntime.getNextProcessRequest();
-    assertTrue("create context request",
-        createContextRequest.getType() == ProcessRequest.Type.CREATE_CONTEXT);
+    assertEquals("create context request", ProcessRequest.Type.CREATE_CONTEXT,
+        createContextRequest.getType());
     this.mockRuntime.succeed(createContextRequest);
     final ActiveContext context = this.mockApplication.getContext(evaluator, "child");
     assertTrue("child context", context.getParentId().get().equals(rootContext.getId()));
@@ -128,8 +129,8 @@ public final class BasicMockTests {
     assertTrue("check for process event", this.mockRuntime.hasProcessRequest());
     ProcessRequest allocateEvaluatorRequest = this.mockRuntime.getNextProcessRequest();
     this.mockRuntime.fail(allocateEvaluatorRequest);
-    assertTrue("evaluator allocation failed",
-        this.mockApplication.getFailedEvaluators().size() == 1);
+    assertEquals("evaluator allocation failed", 1,
+        this.mockApplication.getFailedEvaluators().size());
 
     this.mockApplication.requestEvaluators(1);
     allocateEvaluatorRequest = this.mockRuntime.getNextProcessRequest();
@@ -144,10 +145,10 @@ public final class BasicMockTests {
     this.mockApplication.submitTask(rootContext, "test-task");
     assertTrue("create task queued", this.mockRuntime.hasProcessRequest());
     final ProcessRequest createTaskRequest = this.mockRuntime.getNextProcessRequest();
-    assertTrue("create task request",
-        createTaskRequest.getType() == ProcessRequest.Type.CREATE_TASK);
+    assertEquals("create task request", ProcessRequest.Type.CREATE_TASK,
+        createTaskRequest.getType());
     this.mockRuntime.fail(createTaskRequest);
-    assertTrue("task running", this.mockApplication.getFailedTasks().size() == 1);
+    assertEquals("task running", 1, this.mockApplication.getFailedTasks().size());
 
     // create a sub-context
     this.mockApplication.submitContext(rootContext, "child");
@@ -155,7 +156,7 @@ public final class BasicMockTests {
     final ProcessRequestInternal createContextRequest =
         (ProcessRequestInternal) this.mockRuntime.getNextProcessRequest();
     this.mockRuntime.fail(createContextRequest);
-    assertTrue("child context", this.mockApplication.getFailedContext().size() == 1);
+    assertEquals("child context", 1, this.mockApplication.getFailedContext().size());
   }
 
   @Test
@@ -184,21 +185,21 @@ public final class BasicMockTests {
 
     // fail task
     this.mockRuntime.fail(task);
-    assertTrue("task failed", this.mockApplication.getFailedTasks().size() == 1);
+    assertEquals("task failed", 1,this.mockApplication.getFailedTasks().size());
 
     // fail child context
     this.mockRuntime.fail(childContext);
     assertTrue("child context failed",
         this.mockApplication.getFailedContext().iterator().next().getId().equals(childContext.getId()));
     // evaluator should still be up
-    assertTrue("check evaluator", this.mockApplication.getFailedEvaluators().size() == 0);
+    assertEquals("check evaluator", 0,this.mockApplication.getFailedEvaluators().size());
 
     // fail evaluator
     this.mockRuntime.fail(evaluator);
-    assertTrue("evaluator failed", this.mockApplication.getFailedEvaluators().size() == 1);
+    assertEquals("evaluator failed", 1, this.mockApplication.getFailedEvaluators().size());
 
     // both contexts should be failed
-    assertTrue("root and child contexts failed",
-        this.mockApplication.getFailedContext().size() == 2);
+    assertEquals("root and child contexts failed", 2,
+        this.mockApplication.getFailedContext().size());
   }
 }

--- a/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/BasicMockTests.java
+++ b/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/BasicMockTests.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.task.RunningTask;
+import org.apache.reef.mock.request.ProcessRequestInternal;
+import org.apache.reef.mock.runtime.MockAllocatedEvalautor;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * basic mock tests.
+ */
+public final class BasicMockTests {
+
+  private MockApplication mockApplication;
+
+  private MockRuntime mockRuntime;
+
+  private MockClock mockClock;
+
+  @Before
+  public void initialize() throws Exception {
+    final Configuration conf = MockConfiguration.CONF
+        .set(MockConfiguration.ON_DRIVER_STARTED, MockApplication.StartHandler.class)
+        .set(MockConfiguration.ON_DRIVER_STOP, MockApplication.StopHandler.class)
+        .set(MockConfiguration.ON_CONTEXT_ACTIVE, MockApplication.ActiveContextHandler.class)
+        .set(MockConfiguration.ON_CONTEXT_CLOSED, MockApplication.ContextClosedHandler.class)
+        .set(MockConfiguration.ON_CONTEXT_FAILED, MockApplication.FailedContextHandler.class)
+        .set(MockConfiguration.ON_EVALUATOR_ALLOCATED, MockApplication.AllocatedEvaluatorHandler.class)
+        .set(MockConfiguration.ON_EVALUATOR_COMPLETED, MockApplication.CompletedEvaluatorHandler.class)
+        .set(MockConfiguration.ON_EVALUATOR_FAILED, MockApplication.FailedEvaluatorHandler.class)
+        .set(MockConfiguration.ON_TASK_COMPLETED, MockApplication.CompletedTaskHandler.class)
+        .set(MockConfiguration.ON_TASK_FAILED, MockApplication.FailedTaskHandler.class)
+        .set(MockConfiguration.ON_TASK_RUNNING, MockApplication.RunningTaskHandler.class)
+        .set(MockConfiguration.ON_TASK_SUSPENDED, MockApplication.SuspendedTaskHandler.class)
+        .build();
+
+    final Injector injector = Tang.Factory.getTang().newInjector(conf);
+    this.mockApplication = injector.getInstance(MockApplication.class);
+    this.mockRuntime = injector.getInstance(MockRuntime.class);
+    this.mockClock = injector.getInstance(MockClock.class);
+
+    this.mockClock.run();
+  }
+
+  @Test
+  public void testSuccessRequests() throws Exception {
+    assertTrue("mock application received start event", this.mockApplication.isRunning());
+
+    this.mockApplication.requestEvaluators(1);
+    assertTrue("check for process event", this.mockRuntime.hasProcessRequest());
+    final ProcessRequest allocateEvaluatorRequest = this.mockRuntime.getNextProcessRequest();
+    assertTrue("allocate evalautor request",
+        allocateEvaluatorRequest.getType() == ProcessRequest.Type.ALLOCATE_EVALUATOR);
+    final AllocatedEvaluator evaluator =
+        ((ProcessRequestInternal<AllocatedEvaluator, Object>)allocateEvaluatorRequest)
+            .getSuccessEvent();
+    this.mockRuntime.succeed(allocateEvaluatorRequest);
+    assertTrue("evaluator allocation succeeded",
+        this.mockApplication.getAllocatedEvaluators().contains(evaluator));
+    final ActiveContext rootContext = this.mockApplication.getContext(evaluator,
+        MockAllocatedEvalautor.ROOT_CONTEXT_IDENTIFIER_PREFIX + evaluator.getId());
+    assertTrue("root context", rootContext != null);
+
+
+    // submit a task
+    this.mockApplication.submitTask(rootContext, "test-task");
+    assertTrue("create task queued", this.mockRuntime.hasProcessRequest());
+    final ProcessRequest createTaskRequest = this.mockRuntime.getNextProcessRequest();
+    assertTrue("create task request",
+        createTaskRequest.getType() == ProcessRequest.Type.CREATE_TASK);
+    final RunningTask task = (RunningTask) ((ProcessRequestInternal)createTaskRequest).getSuccessEvent();
+    this.mockRuntime.succeed(createTaskRequest);
+    assertTrue("task running", this.mockApplication.getRunningTasks().contains(task));
+
+    // check task auto complete
+    assertTrue("check for request", this.mockRuntime.hasProcessRequest());
+    final ProcessRequestInternal completedTask =
+        (ProcessRequestInternal) this.mockRuntime.getNextProcessRequest();
+    assertTrue("complete task request",
+        completedTask.getType() == ProcessRequest.Type.COMPLETE_TASK);
+    this.mockRuntime.succeed(completedTask);
+    assertTrue("no running tasks", this.mockApplication.getRunningTasks().size() == 0);
+
+    // create a sub-context
+    this.mockApplication.submitContext(rootContext, "child");
+    assertTrue("check for request", this.mockRuntime.hasProcessRequest());
+    final ProcessRequestInternal createContextRequest =
+        (ProcessRequestInternal) this.mockRuntime.getNextProcessRequest();
+    assertTrue("create context request",
+        createContextRequest.getType() == ProcessRequest.Type.CREATE_CONTEXT);
+    this.mockRuntime.succeed(createContextRequest);
+    final ActiveContext context = this.mockApplication.getContext(evaluator, "child");
+    assertTrue("child context", context.getParentId().get().equals(rootContext.getId()));
+  }
+
+  @Test
+  public void testFailureRequests() throws Exception {
+    assertTrue("mock application received start event", this.mockApplication.isRunning());
+
+    this.mockApplication.requestEvaluators(1);
+    assertTrue("check for process event", this.mockRuntime.hasProcessRequest());
+    ProcessRequest allocateEvaluatorRequest = this.mockRuntime.getNextProcessRequest();
+    this.mockRuntime.fail(allocateEvaluatorRequest);
+    assertTrue("evaluator allocation failed",
+        this.mockApplication.getFailedEvaluators().size() == 1);
+
+    this.mockApplication.requestEvaluators(1);
+    allocateEvaluatorRequest = this.mockRuntime.getNextProcessRequest();
+    final AllocatedEvaluator evaluator =
+        (AllocatedEvaluator)((ProcessRequestInternal)allocateEvaluatorRequest).getSuccessEvent();
+    this.mockRuntime.succeed(allocateEvaluatorRequest);
+    final ActiveContext rootContext = this.mockApplication
+        .getContext(evaluator, MockAllocatedEvalautor.ROOT_CONTEXT_IDENTIFIER_PREFIX + evaluator.getId());
+
+
+    // submit a task
+    this.mockApplication.submitTask(rootContext, "test-task");
+    assertTrue("create task queued", this.mockRuntime.hasProcessRequest());
+    final ProcessRequest createTaskRequest = this.mockRuntime.getNextProcessRequest();
+    assertTrue("create task request",
+        createTaskRequest.getType() == ProcessRequest.Type.CREATE_TASK);
+    this.mockRuntime.fail(createTaskRequest);
+    assertTrue("task running", this.mockApplication.getFailedTasks().size() == 1);
+
+    // create a sub-context
+    this.mockApplication.submitContext(rootContext, "child");
+    assertTrue("check for request", this.mockRuntime.hasProcessRequest());
+    final ProcessRequestInternal createContextRequest =
+        (ProcessRequestInternal) this.mockRuntime.getNextProcessRequest();
+    this.mockRuntime.fail(createContextRequest);
+    assertTrue("child context", this.mockApplication.getFailedContext().size() == 1);
+  }
+
+  @Test
+  public void testMockFailures() {
+    // make sure we're running
+    assertTrue("mock application received start event", this.mockApplication.isRunning());
+
+    // allocate an evaluator and get root context
+    this.mockApplication.requestEvaluators(1);
+    this.mockRuntime.succeed(this.mockRuntime.getNextProcessRequest());
+    final AllocatedEvaluator evaluator = this.mockRuntime.getCurrentAllocatedEvaluators().iterator().next();
+    final ActiveContext rootContext = this.mockApplication.getContext(evaluator,
+        MockAllocatedEvalautor.ROOT_CONTEXT_IDENTIFIER_PREFIX + evaluator.getId());
+
+    // create a child context off of root context
+    this.mockApplication.submitContext(rootContext, "child");
+    this.mockRuntime.succeed(this.mockRuntime.getNextProcessRequest());
+    final ActiveContext childContext = this.mockApplication.getContext(evaluator, "child");
+
+    // submit a task from child context
+    this.mockApplication.submitTask(childContext, "test-task");
+    final ProcessRequest createTaskRequest = this.mockRuntime.getNextProcessRequest();
+    createTaskRequest.setAutoComplete(false); // keep it running
+    this.mockRuntime.succeed(createTaskRequest);
+    final RunningTask task = this.mockRuntime.getCurrentRunningTasks().iterator().next();
+
+    // fail task
+    this.mockRuntime.fail(task);
+    assertTrue("task failed", this.mockApplication.getFailedTasks().size() == 1);
+
+    // fail child context
+    this.mockRuntime.fail(childContext);
+    assertTrue("child context failed",
+        this.mockApplication.getFailedContext().iterator().next().getId().equals(childContext.getId()));
+    // evaluator should still be up
+    assertTrue("check evaluator", this.mockApplication.getFailedEvaluators().size() == 0);
+
+    // fail evaluator
+    this.mockRuntime.fail(evaluator);
+    assertTrue("evaluator failed", this.mockApplication.getFailedEvaluators().size() == 1);
+
+    // both contexts should be failed
+    assertTrue("root and child contexts failed",
+        this.mockApplication.getFailedContext().size() == 2);
+  }
+}

--- a/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/BasicMockTests.java
+++ b/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/BasicMockTests.java
@@ -24,6 +24,7 @@ import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.mock.request.ProcessRequestInternal;
 import org.apache.reef.mock.runtime.MockAllocatedEvalautor;
+import org.apache.reef.mock.runtime.MockClock;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;

--- a/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/MockApplication.java
+++ b/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/MockApplication.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
  * mock application.
  */
 @Unit
-public class MockApplication {
+final class MockApplication {
 
   private static final Logger LOG = Logger.getLogger(MockApplication.class.getName());
 

--- a/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/MockApplication.java
+++ b/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/MockApplication.java
@@ -80,23 +80,23 @@ public class MockApplication {
   }
 
   Collection<RunningTask> getRunningTasks() {
-    return this.evaluatorIdRunningTaskMap.values();
+    return Collections.unmodifiableCollection(this.evaluatorIdRunningTaskMap.values());
   }
 
   Collection<AllocatedEvaluator> getAllocatedEvaluators() {
-    return this.evaluatorMap.values();
+    return Collections.unmodifiableCollection(this.evaluatorMap.values());
   }
 
   Collection<FailedEvaluator> getFailedEvaluators() {
-    return this.failedEvaluatorMap.values();
+    return Collections.unmodifiableCollection(this.failedEvaluatorMap.values());
   }
 
   Collection<FailedTask> getFailedTasks() {
-    return this.failedTaskSet;
+    return Collections.unmodifiableCollection(this.failedTaskSet);
   }
 
   Collection<FailedContext> getFailedContext() {
-    return this.failedContextSet;
+    return Collections.unmodifiableCollection(this.failedContextSet);
   }
 
   void requestEvaluators(final int numEvaluators) {
@@ -200,7 +200,9 @@ public class MockApplication {
         evaluatorId2ContextId2ContextMap.put(context.getEvaluatorId(), new HashMap<String, ActiveContext>());
       }
       if (evaluatorId2ContextId2ContextMap.get(context.getEvaluatorId()).containsKey(context.getId())) {
-        throw new IllegalStateException("Context already exists on evaluator with same identifier");
+        throw new IllegalStateException(
+                String.format("Context %s on evaluator %s already exists on evaluator with " +
+                        "same identifier", context.getId(), context.getEvaluatorId()));
       }
       evaluatorId2ContextId2ContextMap.get(context.getEvaluatorId()).put(context.getId(), context);
     }

--- a/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/MockApplication.java
+++ b/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/MockApplication.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.mock;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.context.ClosedContext;
+import org.apache.reef.driver.context.ContextConfiguration;
+import org.apache.reef.driver.context.FailedContext;
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.evaluator.CompletedEvaluator;
+import org.apache.reef.driver.evaluator.EvaluatorRequestor;
+import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.driver.task.*;
+import org.apache.reef.tang.annotations.Unit;
+import org.apache.reef.task.Task;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.Clock;
+import org.apache.reef.wake.time.event.StartTime;
+import org.apache.reef.wake.time.event.StopTime;
+
+import javax.inject.Inject;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * mock application.
+ */
+@Unit
+public class MockApplication {
+
+  private static final Logger LOG = Logger.getLogger(MockApplication.class.getName());
+
+  private final EvaluatorRequestor evaluatorRequestor;
+
+  private final Clock clock;
+
+  private final Map<String, Map<String, ActiveContext>> evaluatorId2ContextId2ContextMap = new HashMap<>();
+
+  private final Map<String, AllocatedEvaluator> evaluatorMap = new HashMap<>();
+
+  private final Map<String, FailedEvaluator> failedEvaluatorMap = new HashMap<>();
+
+  private final Map<String, RunningTask> evaluatorIdRunningTaskMap = new HashMap<>();
+
+  private final Set<FailedContext> failedContextSet = new HashSet<>();
+
+  private final Set<FailedTask> failedTaskSet = new HashSet<>();
+
+  private final Set<SuspendedTask> suspendedTaskSet = new HashSet<>();
+
+  private boolean running = false;
+
+  @Inject
+  MockApplication(final EvaluatorRequestor evaluatorRequestor, final Clock clock) {
+    this.evaluatorRequestor = evaluatorRequestor;
+    this.clock = clock;
+  }
+
+  ActiveContext getContext(final AllocatedEvaluator evaluator, final String identifier) {
+    return this.evaluatorId2ContextId2ContextMap.get(evaluator.getId()).get(identifier);
+  }
+
+  Collection<RunningTask> getRunningTasks() {
+    return this.evaluatorIdRunningTaskMap.values();
+  }
+
+  Collection<AllocatedEvaluator> getAllocatedEvaluators() {
+    return this.evaluatorMap.values();
+  }
+
+  Collection<FailedEvaluator> getFailedEvaluators() {
+    return this.failedEvaluatorMap.values();
+  }
+
+  Collection<FailedTask> getFailedTasks() {
+    return this.failedTaskSet;
+  }
+
+  Collection<FailedContext> getFailedContext() {
+    return this.failedContextSet;
+  }
+
+  void requestEvaluators(final int numEvaluators) {
+    LOG.log(Level.INFO, "request {0} Evaluators", numEvaluators);
+    evaluatorRequestor.newRequest()
+        .setMemory(128)
+        .setNumberOfCores(1)
+        .setNumber(numEvaluators)
+        .submit();
+  }
+
+  void submitTask(final ActiveContext context, final String identifier) {
+    context.submitTask(TaskConfiguration.CONF
+        .set(TaskConfiguration.IDENTIFIER, identifier)
+        .set(TaskConfiguration.TASK, DummyTestTask.class)
+        .build());
+  }
+
+  void submitContext(final ActiveContext context, final String identifier) {
+    context.submitContext(ContextConfiguration.CONF
+        .set(ContextConfiguration.IDENTIFIER, identifier)
+        .build());
+  }
+
+  boolean isRunning() {
+    return this.running;
+  }
+
+  boolean exists(final AllocatedEvaluator evaluator) {
+    return this.evaluatorMap.containsKey(evaluator.getId());
+  }
+
+  /**
+   * Job Driver is ready and the clock is set up: request the evaluatorMap.
+   */
+  final class StartHandler implements EventHandler<StartTime> {
+    @Override
+    public void onNext(final StartTime startTime) {
+      running = true;
+    }
+  }
+
+  /**
+   * Job Driver is is shutting down: write to the log.
+   */
+  final class StopHandler implements EventHandler<StopTime> {
+    @Override
+    public void onNext(final StopTime stopTime) {
+      running = false;
+    }
+  }
+
+  /**
+   * Receive notification that an Evaluator had been allocated,
+   * and submitTask a new Task in that Evaluator.
+   */
+  final class AllocatedEvaluatorHandler implements EventHandler<AllocatedEvaluator> {
+    @Override
+    public void onNext(final AllocatedEvaluator eval) {
+      evaluatorMap.put(eval.getId(), eval);
+    }
+  }
+
+  /**
+   * Receive notification that the Evaluator has been shut down.
+   */
+  final class CompletedEvaluatorHandler implements EventHandler<CompletedEvaluator> {
+    @Override
+    public void onNext(final CompletedEvaluator eval) {
+      evaluatorMap.remove(eval.getId());
+      evaluatorId2ContextId2ContextMap.remove(eval.getId());
+      evaluatorIdRunningTaskMap.remove(eval.getId());
+    }
+  }
+
+  final class FailedEvaluatorHandler implements EventHandler<FailedEvaluator> {
+
+    @Override
+    public void onNext(final FailedEvaluator eval) {
+      evaluatorMap.remove(eval.getId());
+      evaluatorId2ContextId2ContextMap.remove(eval.getId());
+      evaluatorIdRunningTaskMap.remove(eval.getId());
+      failedEvaluatorMap.put(eval.getId(), eval);
+      failedContextSet.addAll(eval.getFailedContextList());
+    }
+  }
+
+  /**
+   * Receive notification that the Context is active.
+   */
+  final class ActiveContextHandler implements EventHandler<ActiveContext> {
+    @Override
+    public void onNext(final ActiveContext context) {
+      if (!evaluatorId2ContextId2ContextMap.containsKey(context.getEvaluatorId())) {
+        evaluatorId2ContextId2ContextMap.put(context.getEvaluatorId(), new HashMap<String, ActiveContext>());
+      }
+      if (evaluatorId2ContextId2ContextMap.get(context.getEvaluatorId()).containsKey(context.getId())) {
+        throw new IllegalStateException("Context already exists on evaluator with same identifier");
+      }
+      evaluatorId2ContextId2ContextMap.get(context.getEvaluatorId()).put(context.getId(), context);
+    }
+  }
+
+  final class ContextClosedHandler implements EventHandler<ClosedContext> {
+    @Override
+    public void onNext(final ClosedContext value) {
+      assert evaluatorId2ContextId2ContextMap.containsKey(value.getEvaluatorId());
+      assert evaluatorId2ContextId2ContextMap.get(value.getEvaluatorId()).containsKey(value.getId());
+      evaluatorId2ContextId2ContextMap.get(value.getEvaluatorId()).remove(value.getId());
+    }
+  }
+
+  final class FailedContextHandler implements EventHandler<FailedContext> {
+    @Override
+    public void onNext(final FailedContext value) {
+      if (evaluatorId2ContextId2ContextMap.containsKey(value.getEvaluatorId()) &&
+          evaluatorId2ContextId2ContextMap.get(value.getEvaluatorId()).containsKey(value.getId())) {
+        evaluatorId2ContextId2ContextMap.get(value.getEvaluatorId()).remove(value.getEvaluatorId());
+      } else {
+        // must have failed before it succeeded
+      }
+      failedContextSet.add(value);
+    }
+  }
+
+  /**
+   * Receive notification that the Task is running.
+   */
+  final class RunningTaskHandler implements EventHandler<RunningTask> {
+    @Override
+    public void onNext(final RunningTask task) {
+      evaluatorIdRunningTaskMap.put(task.getActiveContext().getEvaluatorId(), task);
+    }
+  }
+
+  /**
+   * Receive notification that the Task has completed successfully.
+   */
+  final class CompletedTaskHandler implements EventHandler<CompletedTask> {
+    @Override
+    public void onNext(final CompletedTask task) {
+      evaluatorIdRunningTaskMap.remove(task.getActiveContext().getEvaluatorId());
+    }
+  }
+
+  final class FailedTaskHandler implements EventHandler<FailedTask> {
+    @Override
+    public void onNext(final FailedTask value) {
+      evaluatorIdRunningTaskMap.remove(value.getActiveContext().get().getEvaluatorId());
+      failedTaskSet.add(value);
+    }
+  }
+
+  final class SuspendedTaskHandler implements EventHandler<SuspendedTask> {
+    @Override
+    public void onNext(final SuspendedTask value) {
+      evaluatorIdRunningTaskMap.remove(value.getActiveContext().getEvaluatorId());
+      suspendedTaskSet.add(value);
+    }
+  }
+
+  private static final class DummyTestTask implements Task {
+    @Override
+    public byte[] call(final byte[] memento) throws Exception {
+      return new byte[0];
+    }
+  }
+}

--- a/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/MockApplication.java
+++ b/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/MockApplication.java
@@ -31,7 +31,6 @@ import org.apache.reef.driver.task.*;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.task.Task;
 import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.time.Clock;
 import org.apache.reef.wake.time.event.StartTime;
 import org.apache.reef.wake.time.event.StopTime;
 
@@ -50,8 +49,6 @@ public class MockApplication {
 
   private final EvaluatorRequestor evaluatorRequestor;
 
-  private final Clock clock;
-
   private final Map<String, Map<String, ActiveContext>> evaluatorId2ContextId2ContextMap = new HashMap<>();
 
   private final Map<String, AllocatedEvaluator> evaluatorMap = new HashMap<>();
@@ -69,9 +66,8 @@ public class MockApplication {
   private boolean running = false;
 
   @Inject
-  MockApplication(final EvaluatorRequestor evaluatorRequestor, final Clock clock) {
+  MockApplication(final EvaluatorRequestor evaluatorRequestor) {
     this.evaluatorRequestor = evaluatorRequestor;
-    this.clock = clock;
   }
 
   ActiveContext getContext(final AllocatedEvaluator evaluator, final String identifier) {

--- a/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/MockApplication.java
+++ b/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/MockApplication.java
@@ -31,6 +31,8 @@ import org.apache.reef.driver.task.*;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.task.Task;
 import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.Clock;
+import org.apache.reef.wake.time.event.Alarm;
 import org.apache.reef.wake.time.event.StartTime;
 import org.apache.reef.wake.time.event.StopTime;
 
@@ -46,6 +48,8 @@ import java.util.logging.Logger;
 public class MockApplication {
 
   private static final Logger LOG = Logger.getLogger(MockApplication.class.getName());
+
+  private final Clock clock;
 
   private final EvaluatorRequestor evaluatorRequestor;
 
@@ -66,7 +70,8 @@ public class MockApplication {
   private boolean running = false;
 
   @Inject
-  MockApplication(final EvaluatorRequestor evaluatorRequestor) {
+  MockApplication(final Clock clock, final EvaluatorRequestor evaluatorRequestor) {
+    this.clock = clock;
     this.evaluatorRequestor = evaluatorRequestor;
   }
 
@@ -130,6 +135,12 @@ public class MockApplication {
   final class StartHandler implements EventHandler<StartTime> {
     @Override
     public void onNext(final StartTime startTime) {
+      clock.scheduleAlarm(Integer.MAX_VALUE, new EventHandler<Alarm>() {
+        @Override
+        public void onNext(final Alarm value) {
+          throw new RuntimeException("should not happen");
+        }
+      });
       running = true;
     }
   }

--- a/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/package-info.java
+++ b/lang/java/reef-runtime-mock/src/test/java/org/apache/reef/mock/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+/**
+ * mock runtime tests.
+ */
+package org.apache.reef.mock;

--- a/pom.xml
+++ b/pom.xml
@@ -774,6 +774,7 @@ under the License.
         <module>lang/java/reef-runtime-local</module>
         <module>lang/java/reef-runtime-yarn</module>
         <module>lang/java/reef-runtime-mesos</module>
+        <module>lang/java/reef-runtime-mock</module>
         <module>lang/java/reef-runtime-multi</module>
         <module>lang/java/reef-runtime-standalone</module>
         <module>lang/java/reef-tang</module>


### PR DESCRIPTION
  This adds a new REEF mock runtime, which can be used to create
  regression tests for an application dirver.

JIRA:
  [REEF-1898](https://issues.apache.org/jira/browse/REEF-1898)

Pull Request:
  Closes #1390