### PR TITLE
[REEF-1902] Use external executor and Runnable in MultiAsyncToSync

### DIFF
--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/MultiAsyncToSync.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/MultiAsyncToSync.java
@@ -19,10 +19,8 @@ package org.apache.reef.util;
 
 import org.apache.reef.util.exception.InvalidIdentifierException;
 
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import java.util.concurrent.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -37,12 +35,15 @@ import java.util.logging.Logger;
  * caller is released with a call to {@code release()}.
  */
 public final class MultiAsyncToSync {
+
   private static final Logger LOG = Logger.getLogger(MultiAsyncToSync.class.getName());
 
   private final ConcurrentLinkedQueue<ComplexCondition> freeQueue = new ConcurrentLinkedQueue<>();
   private final ConcurrentHashMap<Long, ComplexCondition> sleeperMap = new ConcurrentHashMap<>();
+
   private final long timeoutPeriod;
   private final TimeUnit timeoutUnits;
+  private final ExecutorService executor;
 
   /**
    * Initialize a multiple asynchronous to synchronous object with a specified timeout value.
@@ -50,47 +51,65 @@ public final class MultiAsyncToSync {
    *                      parameter before the condition automatically times out.
    * @param timeoutUnits The unit of time for the timeoutPeriod parameter.
    */
+  @Inject
   public MultiAsyncToSync(final long timeoutPeriod, final TimeUnit timeoutUnits) {
+    this(timeoutPeriod, timeoutUnits, null);
+  }
+
+  /**
+   * Initialize a multiple asynchronous to synchronous object with a specified timeout value.
+   * @param timeoutPeriod The length of time in units given by the the timeoutUnits
+   *                      parameter before the condition automatically times out.
+   * @param timeoutUnits The unit of time for the timeoutPeriod parameter.
+   * @param executor An executor service used to run async processors in the block method. Can be null.
+   */
+  public MultiAsyncToSync(final long timeoutPeriod, final TimeUnit timeoutUnits, final ExecutorService executor) {
     this.timeoutPeriod = timeoutPeriod;
     this.timeoutUnits = timeoutUnits;
+    this.executor = executor;
   }
 
   /**
    * Put the caller to sleep on a specific release identifier.
    * @param identifier The identifier required to awake the caller via the {@code release()} method.
-   * @param asyncProcessor A {@code FutureTask} object which returns {@code TAsync} that initiates the asynchronous
+   * @param asyncProcessor A {@code Runnable} object that initiates the asynchronous
    *                       processing associated with the call. This will occur inside the condition lock
    *                       to prevent the processing from generating the signal before the calling thread blocks.
    *                       Error conditions should be handled by throwing an exception which the caller
    *                       will catch. The caller can retrieve the results of the processing by calling
    *                       {@code asyndProcessor.get()}.
-   * @param <TAsync> The return type of the {@code asyncProcessor};
    * @return A boolean value that indicates whether or not a timeout or error occurred.
    * @throws InterruptedException The thread was interrupted while waiting on a condition.
    * @throws InvalidIdentifierException The identifier parameter is invalid.
    */
-  public <TAsync> boolean block(final long identifier, final FutureTask<TAsync> asyncProcessor)
+  public boolean block(final long identifier, final Runnable asyncProcessor)
         throws InterruptedException, InvalidIdentifierException {
-    final boolean timeoutOccurred;
+
     final ComplexCondition call = allocate();
     if (call.isHeldByCurrentThread()) {
       throw new RuntimeException("release() must not be called on same thread as block() to prevent deadlock");
     }
+
     try {
       call.lock();
       // Add the call identifier to the sleeper map so release() can identify this instantiation.
       addSleeper(identifier, call);
       // Invoke the caller's asynchronous processing while holding the lock
       // so a wakeup cannot occur before the caller sleeps.
-      asyncProcessor.run();
+      if (executor == null) {
+        asyncProcessor.run();
+      } else {
+        executor.execute(asyncProcessor);
+      }
       // Put the caller to sleep until the ack comes back. Note: we atomically
       // give up the look as the caller sleeps and atomically reacquire the
       // the lock as we wake up.
       LOG.log(Level.FINER, "Putting caller to sleep on identifier [{0}]", identifier);
-      timeoutOccurred = !call.await();
+      final boolean timeoutOccurred = !call.await();
       if (timeoutOccurred) {
-        LOG.log(Level.SEVERE, "Call timed out on identifier [{0}]", identifier);
+        LOG.log(Level.WARNING, "Call timed out on identifier [{0}]", identifier);
       }
+      return timeoutOccurred;
     } finally {
       // Whether or not the call completed successfully, always remove
       // the call from the sleeper map, release the lock and cleanup.
@@ -101,7 +120,6 @@ public final class MultiAsyncToSync {
         call.unlock();
       }
     }
-    return timeoutOccurred;
   }
 
   /**

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/MultiAsyncToSync.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/MultiAsyncToSync.java
@@ -19,7 +19,6 @@ package org.apache.reef.util;
 
 import org.apache.reef.util.exception.InvalidIdentifierException;
 
-import javax.inject.Inject;
 import java.util.concurrent.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,7 +50,6 @@ public final class MultiAsyncToSync {
    *                      parameter before the condition automatically times out.
    * @param timeoutUnits The unit of time for the timeoutPeriod parameter.
    */
-  @Inject
   public MultiAsyncToSync(final long timeoutPeriod, final TimeUnit timeoutUnits) {
     this(timeoutPeriod, timeoutUnits, null);
   }


### PR DESCRIPTION
Summary of changes:
   * add a new `MultiAsyncToSync` constructor that takes an ExecutorService
   * make `MultiAsyncToSync` take `Runnable` instead of its subclass `FutureTask`
   * Use finer logging levels whenever possible
   * refactor the unit tests in `MultiAsyncToSyncTest`
   * minor fixes and refactorings in `MultiAsyncToSync` and `MultiAsyncToSyncTest`

JIRA: [REEF-1902](https://issues.apache.org/jira/browse/REEF-1902)