### PR TITLE
[REEF-1903] Use Class.getCanonicalName() in HandlerContainer and RemoteManager

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
@@ -117,7 +117,7 @@ public final class DefaultRemoteManagerImplementation implements RemoteManager {
 
     if (LOG.isLoggable(Level.FINE)) {
       LOG.log(Level.FINE, "RemoteManager: {0} destinationIdentifier: {1} messageType: {2}",
-          new Object[] {this.name, destinationIdentifier, messageType.getName()});
+          new Object[] {this.name, destinationIdentifier, messageType.getCanonicalName()});
     }
 
     return new ProxyEventHandler<>(this.myIdentifier, destinationIdentifier,
@@ -130,12 +130,11 @@ public final class DefaultRemoteManagerImplementation implements RemoteManager {
    */
   @Override
   public <T, U extends T> AutoCloseable registerHandler(
-      final RemoteIdentifier sourceIdentifier,
-      final Class<U> messageType, final EventHandler<T> theHandler) {
+      final RemoteIdentifier sourceIdentifier, final Class<U> messageType, final EventHandler<T> theHandler) {
 
     if (LOG.isLoggable(Level.FINE)) {
-      LOG.log(Level.FINE, "RemoteManager: {0} remoteid: {1} messageType: {2} handler: {3}",
-          new Object[] {this.name, sourceIdentifier, messageType.getName(), theHandler.getClass().getName()});
+      LOG.log(Level.FINE, "RemoteManager: {0} remoteId: {1} messageType: {2} handler: {3}", new Object[] {
+          this.name, sourceIdentifier, messageType.getCanonicalName(), theHandler.getClass().getCanonicalName()});
     }
 
     return this.handlerContainer.registerHandler(sourceIdentifier, messageType, theHandler);
@@ -149,8 +148,8 @@ public final class DefaultRemoteManagerImplementation implements RemoteManager {
       final Class<U> messageType, final EventHandler<RemoteMessage<T>> theHandler) {
 
     if (LOG.isLoggable(Level.FINE)) {
-      LOG.log(Level.FINE, "RemoteManager: {0} messageType: {1} handler: {2}",
-          new Object[] {this.name, messageType.getName(), theHandler.getClass().getName()});
+      LOG.log(Level.FINE, "RemoteManager: {0} messageType: {1} handler: {2}", new Object[] {
+          this.name, messageType.getCanonicalName(), theHandler.getClass().getCanonicalName()});
     }
 
     return this.handlerContainer.registerHandler(messageType, theHandler);
@@ -235,6 +234,6 @@ public final class DefaultRemoteManagerImplementation implements RemoteManager {
 
   @Override
   public String toString() {
-    return String.format("RemoteManager: { id:%s handler:%s }", this.myIdentifier, this.handlerContainer);
+    return String.format("RemoteManager: { id: %s handler: %s }", this.myIdentifier, this.handlerContainer);
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
@@ -89,7 +89,7 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
 
     LOG.log(Level.FINER,
         "Add handler for tuple: {0},{1}",
-        new Object[] {tuple.getT1(), tuple.getT2().getName()});
+        new Object[] {tuple.getT1(), tuple.getT2().getCanonicalName()});
 
     return new SubscriptionHandler<>(tuple, this.unsubscribeTuple);
   }
@@ -106,7 +106,7 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
 
     this.msgTypeToHandlerMap.put(messageType, theHandler);
 
-    LOG.log(Level.FINER, "Add handler for class: {0}", messageType.getName());
+    LOG.log(Level.FINER, "Add handler for class: {0}", messageType.getCanonicalName());
 
     return new SubscriptionHandler<>(messageType, this.unsubscribeClass);
   }
@@ -141,7 +141,7 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
       this.msgTypeToHandlerMap.remove(token);
     } else {
       throw new RemoteRuntimeException(
-          "Unknown subscription type: " + subscription.getClass().getName());
+          "Unknown subscription type: " + subscription.getClass().getCanonicalName());
     }
   }
 


### PR DESCRIPTION
Use `Class.getCanonicalName()` instead of just `.getName()` to log class' names of the objects being handled by the `DefaultRemoteManagerImplementation` and the `HandlerContainer`. We need it to produce human-readable class names for objects like `byte[]` etc. in the logs.

JIRA: [REEF-1903](https://issues.apache.org/jira/browse/REEF-1903)