### PR TITLE
[REEF-1904] add toString() to LocalAddressProvider implementations

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/HostnameBasedLocalAddressProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/HostnameBasedLocalAddressProvider.java
@@ -31,7 +31,9 @@ import java.util.logging.Logger;
  * A LocalAddressProvider that uses <code>Inet4Address.getLocalHost().getHostAddress()</code>.
  */
 public final class HostnameBasedLocalAddressProvider implements LocalAddressProvider {
+
   private static final Logger LOG = Logger.getLogger(HostnameBasedLocalAddressProvider.class.getName());
+
   private String cached = null;
 
   /**
@@ -62,5 +64,10 @@ public final class HostnameBasedLocalAddressProvider implements LocalAddressProv
     return Tang.Factory.getTang().newConfigurationBuilder()
         .bind(LocalAddressProvider.class, HostnameBasedLocalAddressProvider.class)
         .build();
+  }
+
+  @Override
+  public String toString() {
+    return "HostnameBasedLocalAddressProvider:" + this.getLocalAddress();
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/LoopbackLocalAddressProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/LoopbackLocalAddressProvider.java
@@ -31,6 +31,8 @@ import java.net.InetAddress;
  */
 public final class LoopbackLocalAddressProvider implements LocalAddressProvider {
 
+  private final String address = InetAddress.getLoopbackAddress().getHostAddress();
+
   @Inject
   private LoopbackLocalAddressProvider() {
   }
@@ -38,7 +40,7 @@ public final class LoopbackLocalAddressProvider implements LocalAddressProvider 
   @Override
   public String getLocalAddress() {
     // Use the loopback address.
-    return InetAddress.getLoopbackAddress().getHostAddress();
+    return this.address;
   }
 
   @Override
@@ -47,5 +49,10 @@ public final class LoopbackLocalAddressProvider implements LocalAddressProvider 
         .bind(LocalAddressProvider.class, LoopbackLocalAddressProvider.class)
         .bindNamedParameter(RemoteConfiguration.HostAddress.class, getLocalAddress())
         .build();
+  }
+
+  @Override
+  public String toString() {
+    return "LoopbackLocalAddressProvider:" + address;
   }
 }


### PR DESCRIPTION
Add `.toString()` to `LocalAddressProvider` implementations. We need this to improve log readability in the remote manager.

JIRA: [REEF-1904](https://issues.apache.org/jira/browse/REEF-1904)