### PR TITLE
[REEF-1906] Make ProtocolSerializer java class injectable by Tang

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/ProtocolSerializer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/ProtocolSerializer.java
@@ -113,7 +113,7 @@ public final class ProtocolSerializer {
     final String classId = getClassId(message.getClass());
     try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
 
-      LOG.log(Level.INFO, "Serializing message: {0}", classId);
+      LOG.log(Level.FINEST, "Serializing message: {0}", classId);
 
       final IMessageSerializer serializer = this.nameToSerializerMap.get(classId);
       if (serializer != null) {
@@ -143,7 +143,7 @@ public final class ProtocolSerializer {
       // Read the header message.
       final Header header = this.headerReader.read(null, decoder);
       final String classId = header.getClassName().toString();
-      LOG.log(Level.INFO, "Deserializing Avro message: {0}", classId);
+      LOG.log(Level.FINEST, "Deserializing Avro message: {0}", classId);
 
       // Get the appropriate deserializer and deserialize the message.
       final IMessageDeserializer deserializer = this.nameToDeserializerMap.get(classId);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/ProtocolSerializerNamespace.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/ProtocolSerializerNamespace.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.avro;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * ProtocolSerializer parameter: full name of the package containing protocol messages.
+ */
+@NamedParameter(doc = "full name of the package containing protocol messages",
+    short_name = "protocol_serializer_namespace")
+public final class ProtocolSerializerNamespace implements Name<String> {
+  /** Do not instantiate that class. */
+  private ProtocolSerializerNamespace() { }
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/impl/MessageSerializerImpl.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/impl/MessageSerializerImpl.java
@@ -23,6 +23,7 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.reef.wake.avro.IMessageSerializer;
+import org.apache.reef.wake.avro.ProtocolSerializer;
 import org.apache.reef.wake.avro.message.Header;
 
 import java.io.ByteArrayOutputStream;
@@ -43,7 +44,7 @@ public class MessageSerializerImpl<TMessage> implements IMessageSerializer {
    * @param msgMetaClass The reflection class for the message.
    */
   public MessageSerializerImpl(final Class<TMessage> msgMetaClass) {
-    this.msgMetaClassName = msgMetaClass.getSimpleName();
+    this.msgMetaClassName = ProtocolSerializer.getClassId(msgMetaClass);
     this.messageWriter = new SpecificDatumWriter<>(msgMetaClass);
   }
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MultiObserverImpl.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MultiObserverImpl.java
@@ -31,10 +31,11 @@ import java.util.logging.Logger;
 /**
  * The MultiObserverImpl class uses reflection to discover which onNext()
  * event processing methods are defined and then map events to them.
- * @param <TSubCls> The subclass derived from MultiObserverImpl.
  */
-public abstract class MultiObserverImpl<TSubCls> implements MultiObserver {
+public abstract class MultiObserverImpl implements MultiObserver {
+
   private static final Logger LOG = Logger.getLogger(MultiObserverImpl.class.getName());
+
   private final Map<String, Method> methodMap = new HashMap<>();
 
   /**
@@ -62,8 +63,8 @@ public abstract class MultiObserverImpl<TSubCls> implements MultiObserver {
    * @param <TEvent> The type of the event being processed.
    */
   private <TEvent> void unimplemented(final long identifier, final TEvent event) {
-    LOG.log(Level.INFO, "Unimplemented event: [{0}]: {1}",
-        new String[]{String.valueOf(identifier), event.getClass().getName()});
+    LOG.log(Level.SEVERE, "Unimplemented event: [{0}]: {1}", new Object[] {identifier, event});
+    throw new RuntimeException("Event not supported: " + event);
   }
 
   /**
@@ -74,13 +75,13 @@ public abstract class MultiObserverImpl<TSubCls> implements MultiObserver {
    */
   @Override
   public <TEvent> void onNext(final long identifier, final TEvent event)
-    throws IllegalAccessException, InvocationTargetException {
+      throws IllegalAccessException, InvocationTargetException {
 
     // Get the reflection method for this call.
     final Method onNext = methodMap.get(event.getClass().getName());
     if (onNext != null) {
       // Process the event.
-      onNext.invoke((TSubCls) this, identifier, event);
+      onNext.invoke(this, identifier, event);
     } else {
       // Log the unprocessed event.
       unimplemented(identifier, event);


### PR DESCRIPTION
Summary of changes:
   * Add `@Inject` annotation to `ProtocolSerializer` constructor
   * Create a named class `ProtocolSerializerNamespace`
   * Implement static `.getClassId()` method to get unified class ID available to all serialization code
   * Use injection in the `ProtocolSerializerTest` unit tests
   * Minor refactoring and logging improvements in message serialization code and around

JIRA: [REEF-1906](https://issues.apache.org/jira/browse/REEF-1906)