### PR TITLE
[REEF-1935] Improve logging in Wake NettyMessagingTransport and related classes

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventDecoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventDecoder.java
@@ -59,4 +59,8 @@ public class RemoteEventDecoder<T> implements Decoder<RemoteEvent<T>> {
     }
   }
 
+  @Override
+  public String toString() {
+    return String.format("RemoteEventDecoder: { decoder: %s }", this.decoder);
+  }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventEncoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventEncoder.java
@@ -63,6 +63,6 @@ public class RemoteEventEncoder<T> implements Encoder<RemoteEvent<T>> {
 
   @Override
   public String toString() {
-    return "RemoteEventEncoder:" + this.encoder;
+    return String.format("RemoteEventEncoder: { encoder: %s }", this.encoder);
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventEncoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventEncoder.java
@@ -61,4 +61,8 @@ public class RemoteEventEncoder<T> implements Encoder<RemoteEvent<T>> {
     return builder.build().toByteArray();
   }
 
+  @Override
+  public String toString() {
+    return "RemoteEventEncoder:" + this.encoder;
+  }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
@@ -49,4 +49,9 @@ final class LinkReference {
   AtomicInteger getConnectInProgress() {
     return this.connectInProgress;
   }
+
+  @Override
+  public String toString() {
+    return "LinkReference: { " + this.link + " }"; // NettyLink has a good .toString() implementation
+  }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
@@ -52,6 +52,6 @@ final class LinkReference {
 
   @Override
   public String toString() {
-    return "LinkReference: { " + this.link + " }"; // NettyLink has a good .toString() implementation
+    return String.format("LinkReference: { link: %s }", this.link); // NettyLink has a good .toString() implementation
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
@@ -371,6 +371,6 @@ public final class NettyMessagingTransport implements Transport {
 
   @Override
   public String toString() {
-    return "NettyMessagingTransport:" + this.localAddress;
+    return String.format("NettyMessagingTransport: { address: %s }", this.localAddress);
   }
 }


### PR DESCRIPTION
Summary of changes:
   * Implement `.toString()` for `LinkReference`
   * Implement `.toString()` for `RemoteEventEncoder`
   * Implement `.toString()` for `NettyMessagingTransport`
   * Improve logging and remove redundant code from `NettyMessagingTransport` constructor

JIRA: [REEF-1935](https://issues.apache.org/jira/browse/REEF-1935)