### PR TITLE
[REEF-1945] Unit test TestMetricsMessages fails in master

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Telemetry/MetricsService.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Telemetry/MetricsService.cs
@@ -75,7 +75,7 @@ namespace Org.Apache.REEF.Common.Telemetry
             var msgReceived = ByteUtilities.ByteArraysToString(contextMessage.Message);
             var counters = new EvaluatorMetrics(msgReceived).GetMetricsCounters();
 
-            Logger.Log(Level.Verbose, "Received {0} counters with context message: {1}.",
+            Logger.Log(Level.Info, "Received {0} counters with context message: {1}.",
                 counters.GetCounters().Count(), msgReceived);
 
             _countersData.Update(counters);


### PR DESCRIPTION
Change the logging level of a message in `MetricsService` event handler from `Verbose` to `Info`.
That makes the unit test that checks for that message in the logs pass.

The bug was introduced (by me!!) during the merge of #1342 into master. Sorry guys 😢 

JIRA: [REEF-1945](https://issues.apache.org/jira/browse/REEF-1945)