### PR TITLE
[REEF-1951] Make Driver Status more robust.

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/API/DriverStatus.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/DriverStatus.cs
@@ -23,6 +23,11 @@ namespace Org.Apache.REEF.Client.API
     internal enum DriverStatus
     {
         /// <summary>
+        /// Represents the fact that the Driver status hasn't been received yet.
+        /// </summary>
+        UNKNOWN,
+
+        /// <summary>
         /// Driver is initializing.
         /// </summary>
         INIT,

--- a/lang/cs/Org.Apache.REEF.Client/API/Parameters.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/Parameters.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.Client.API.Parameters
+{
+    /// <summary>
+    /// Interval ins ms between connection attempts to the Driver's HTTP Server to obtain Status information.
+    /// </summary>
+    [NamedParameter(DefaultValue = "500", Documentation = 
+        "Interval ins ms between connection attempts to the Driver's HTTP Server to obtain Status information.")]
+    internal sealed class DriverHTTPConnectionRetryInterval : Name<int>
+    {
+        // Intentionally empty
+    }
+
+    /// <summary>
+    /// Number of Retries when connecting to the Driver's HTTP server.
+    /// </summary>
+    [NamedParameter(DefaultValue = "10",
+        Documentation = "Number of Retries when connecting to the Driver's HTTP server.")]
+    internal sealed class DriverHTTPConnectionAttempts : Name<int>
+    {
+        // Intentionally empty
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/Common/IJobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/IJobSubmissionResult.cs
@@ -49,7 +49,7 @@ namespace Org.Apache.REEF.Client.Common
         /// <summary>
         /// Waits for the Driver to complete.
         /// </summary>
-        /// <exception cref="System.Net.WebException">If the Driver cannot be reached.</exception>
+        /// <exception cref="System.Net.WebException">If the Driver could be reached at least once.</exception>
         [Unstable("0.17", "Uses the HTTP server in the Java Driver. Might not work if that cannot be reached.")]
         void WaitForDriverToFinish();
     }

--- a/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
@@ -158,10 +158,9 @@ namespace Org.Apache.REEF.Client.Common
         /// <returns>The obtained Driver Status or DriverStatus.UNKNOWN, if the Driver was never reached.</returns>
         private DriverStatus FetchFirstDriverStatus()
         {
-            var policy = new RetryPolicy<AllErrorsTransientStrategy>(_numberOfRetries, TimeSpan.FromMilliseconds(_retryInterval));
-            DriverStatus result = DriverStatus.UNKNOWN;
-            policy.ExecuteAction(() => result = FetchDriverStatus());
-            return result;
+            var timeOut = TimeSpan.FromMilliseconds(_retryInterval);
+            var policy = new RetryPolicy<AllErrorsTransientStrategy>(_numberOfRetries, timeOut);
+            return policy.ExecuteAction<DriverStatus>(FetchDriverStatus);
         }
 
         protected abstract string GetDriverUrl(string filepath);

--- a/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
@@ -63,7 +63,7 @@ namespace Org.Apache.REEF.Client.Common
         /// <summary>
         /// Retry interval in ms when connecting to the Driver's HTTP endpoint.
         /// </summary>
-        private readonly int _retryInterval;
+        private readonly TimeSpan _retryInterval;
 
         internal JobSubmissionResult(IREEFClient reefClient, string filePath, int numberOfRetries, int retryInterval)
         {
@@ -77,7 +77,7 @@ namespace Org.Apache.REEF.Client.Common
             _driverUrl = GetDriverUrl(filePath);
 
             _numberOfRetries = numberOfRetries;
-            _retryInterval = retryInterval;
+            _retryInterval = TimeSpan.FromMilliseconds(retryInterval);
         }
 
         /// <summary>
@@ -158,8 +158,7 @@ namespace Org.Apache.REEF.Client.Common
         /// <returns>The obtained Driver Status or DriverStatus.UNKNOWN, if the Driver was never reached.</returns>
         private DriverStatus FetchFirstDriverStatus()
         {
-            var timeOut = TimeSpan.FromMilliseconds(_retryInterval);
-            var policy = new RetryPolicy<AllErrorsTransientStrategy>(_numberOfRetries, timeOut);
+            var policy = new RetryPolicy<AllErrorsTransientStrategy>(_numberOfRetries, _retryInterval);
             return policy.ExecuteAction<DriverStatus>(FetchDriverStatus);
         }
 

--- a/lang/cs/Org.Apache.REEF.Client/Local/LocalJobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Local/LocalJobSubmissionResult.cs
@@ -34,8 +34,11 @@ namespace Org.Apache.REEF.Client.Local
 
         private const string UriTemplate = @"http://{0}/";
 
-        internal LocalJobSubmissionResult(IREEFClient reefClient, string filePath) 
-            : base(reefClient, filePath)
+        internal LocalJobSubmissionResult(IREEFClient reefClient, 
+            string filePath, 
+            int numberOfRetries, 
+            int retryInterval) 
+            : base(reefClient, filePath, numberOfRetries, retryInterval)
         {
         }
 

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -74,6 +74,7 @@ under the License.
     <Compile Include="API\JobRequest.cs" />
     <Compile Include="API\JobRequestBuilder.cs" />
     <Compile Include="API\JobRequestBuilderFactory.cs" />
+    <Compile Include="API\Parameters.cs" />
     <Compile Include="API\TcpPortConfigurationModule.cs" />
     <Compile Include="Avro\AvroAppSubmissionParameters.cs" />
     <Compile Include="Avro\AvroJobSubmissionParameters.cs" />

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YarnJobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YarnJobSubmissionResult.cs
@@ -24,8 +24,11 @@ namespace Org.Apache.REEF.Client.YARN
 {
     internal class YarnJobSubmissionResult : JobSubmissionResult
     {
-        internal YarnJobSubmissionResult(IREEFClient reefClient, string filePath) 
-            : base(reefClient, filePath)
+        internal YarnJobSubmissionResult(IREEFClient reefClient, 
+            string filePath,
+            int numberOfRetries,
+            int retryInterval) 
+            : base(reefClient, filePath, numberOfRetries, retryInterval)
         {
         }
 

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Parameters/HTTPStatusAlarmInterval.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Parameters/HTTPStatusAlarmInterval.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.bridge.client.Parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * The interval between alarms in DriverStatusHTTPHandler.
+ */
+@NamedParameter(default_value = "200", doc = "The interval between alarms in DriverStatusHTTPHandler.")
+public final class HTTPStatusAlarmInterval implements Name<Integer> {
+
+  private HTTPStatusAlarmInterval() {
+    //intentionally empty
+  }
+}

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Parameters/HTTPStatusNumberOfRetries.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Parameters/HTTPStatusNumberOfRetries.java
@@ -27,7 +27,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
 @NamedParameter(default_value = "10", doc = "Number of times the HTTPStatusHandler will advance its alarm.")
 public final class HTTPStatusNumberOfRetries implements Name<Integer> {
 
-  private HTTPStatusNumberOfRetries(){
+  private HTTPStatusNumberOfRetries() {
     // Intentionally empty.
   }
 }

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Parameters/HTTPStatusNumberOfRetries.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Parameters/HTTPStatusNumberOfRetries.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.bridge.client.Parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * Number of times the HTTPStatusHandler will advance its alarm.
+ */
+@NamedParameter(default_value = "10", doc = "Number of times the HTTPStatusHandler will advance its alarm.")
+public final class HTTPStatusNumberOfRetries implements Name<Integer> {
+
+  private HTTPStatusNumberOfRetries(){
+    // Intentionally empty.
+  }
+}

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Parameters/package-info.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Parameters/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Named Parameters of the Java side of the .NET Client.
+ */
+package org.apache.reef.bridge.client.Parameters;

--- a/lang/java/reef-bridge-client/src/test/java/org/apache/reef/bridge/client/TestDriverStatusHTTPHandler.java
+++ b/lang/java/reef-bridge-client/src/test/java/org/apache/reef/bridge/client/TestDriverStatusHTTPHandler.java
@@ -19,6 +19,8 @@
 package org.apache.reef.bridge.client;
 
 import org.apache.reef.proto.ReefServiceProtos;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -71,8 +73,8 @@ public final class TestDriverStatusHTTPHandler {
    * {@link org.apache.reef.runtime.common.driver.client.JobStatusHandler}.
    */
   @Test
-  public void testLastStatus() {
-    final DriverStatusHTTPHandler tester = new DriverStatusHTTPHandler();
+  public void testLastStatus() throws InjectionException {
+    final DriverStatusHTTPHandler tester = getInstance();
 
     for (final ReefServiceProtos.JobStatusProto status : allStatuses) {
       tester.onNext(status);
@@ -84,8 +86,8 @@ public final class TestDriverStatusHTTPHandler {
    * Test the wait and notify for correctness.
    */
   @Test
-  public void testAsyncCalls() throws InterruptedException {
-    final DriverStatusHTTPHandler tester = new DriverStatusHTTPHandler();
+  public void testAsyncCalls() throws InterruptedException, InjectionException {
+    final DriverStatusHTTPHandler tester = getInstance();
 
     final WaitingRunnable waiter = new WaitingRunnable(tester);
 
@@ -98,6 +100,10 @@ public final class TestDriverStatusHTTPHandler {
       waitingThread.join();
       Assert.assertEquals(DriverStatusHTTPHandler.getMessageForStatus(status), waiter.getResult());
     }
+  }
+
+  private static DriverStatusHTTPHandler getInstance() throws InjectionException {
+    return Tang.Factory.getTang().newInjector().getInstance(DriverStatusHTTPHandler.class);
   }
 
   private final class WaitingRunnable implements Runnable {


### PR DESCRIPTION
This change makes the communication of the Driver status between the Driver and the .NET Client more robust. It gueards against the Client calling the HTTP server to late by changes on the Java side. It guards
against calling the HTTP server to early by changes on the .NET side.

On the *Java side*, this introduces a new alarm on the clock that makes sure that `DriverStatusHTTPHandler` is called at least once via HTTP in 2s after launching.

On the *.NET Side*, this introduces a retry loop around the first attempt to connect to the Driver. This makes sure we don't call it too early.

JIRA:
  [REEF-1951](https://issues.apache.org/jira/browse/REEF-1951)