### PR TITLE
[REEF-1826] REEF_Must_be_Invoked_in_a_Directory_that_Contains_Its_DLLs

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
@@ -87,9 +87,6 @@ namespace Org.Apache.REEF.Client.Common
             // Create the driver configuration
             CreateDriverConfiguration(appParameters, driverFolderPath);
 
-            // Add the REEF assemblies
-            AddAssemblies();
-
             // Initiate the final copy
             _fileSets.CopyToDriverFolder(driverFolderPath);
 
@@ -148,34 +145,6 @@ namespace Org.Apache.REEF.Client.Common
             // generate .config file for Evaluator executable
             File.WriteAllText(Path.Combine(driverFolderPath, _fileNames.GetGlobalFolderPath(), EvaluatorExecutable), 
                 DefaultDriverConfigurationFileContents);
-        }
-
-        /// <summary>
-        /// Adds all Assemlies to the Global folder in the Driver.
-        /// </summary>
-        private void AddAssemblies()
-        {
-            // TODO: Be more precise, e.g. copy the JAR only to the driver.
-            var assemblies = Directory.GetFiles(@".\").Where(IsAssemblyToCopy);
-            _fileSets.AddToGlobalFiles(assemblies);
-        }
-
-        /// <summary>
-        /// Returns true, if the given file path references a DLL or EXE or JAR.
-        /// </summary>
-        /// <param name="filePath"></param>
-        /// <returns></returns>
-        private static bool IsAssemblyToCopy(string filePath)
-        {
-            var fileName = Path.GetFileName(filePath);
-            if (string.IsNullOrWhiteSpace(fileName))
-            {
-                return false;
-            }
-            var lowerCasePath = fileName.ToLower();
-            return lowerCasePath.EndsWith(DLLFileNameExtension) ||
-                   lowerCasePath.EndsWith(EXEFileNameExtension) ||
-                   lowerCasePath.StartsWith(ClientConstants.ClientJarFilePrefix);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
@@ -17,6 +17,7 @@
 
 using System;
 using Org.Apache.REEF.Client.API;
+using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Client.Local;
 using Org.Apache.REEF.Client.Yarn;
 using Org.Apache.REEF.Client.YARN.HDI;
@@ -27,7 +28,6 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
-using Org.Apache.REEF.Client.Common;
 
 namespace Org.Apache.REEF.Examples.HelloREEF
 {
@@ -64,6 +64,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
             var helloJobRequest = _reefClient.NewJobRequestBuilder()
                 .AddDriverConfiguration(helloDriverConfiguration)
                 .AddGlobalAssemblyForType(typeof(HelloDriver))
+                .AddGlobalAssembliesInDirectoryOfExecutingAssembly()
                 .SetJobIdentifier("HelloREEF")
                 .SetJavaLogLevel(JavaLoggingSetting.Verbose)
                 .Build();
@@ -110,7 +111,13 @@ namespace Org.Apache.REEF.Examples.HelloREEF
 
         public static void MainSimple(string[] args)
         {
-            TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(args.Length > 0 ? args[0] : Local)).GetInstance<HelloREEF>().Run();
+            var runtime = args.Length > 0 ? args[0] : Local;
+
+            // Execute the HelloREEF, with these parameters injected
+            TangFactory.GetTang()
+                .NewInjector(GetRuntimeConfiguration(runtime))
+                .GetInstance<HelloREEF>()
+                .Run();
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Utilities/ClientUtilities.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/ClientUtilities.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Org.Apache.REEF.Utilities
+{
+    /// <summary>
+    /// A library of helper functions for REEF clients
+    /// </summary>
+    public static class ClientUtilities
+    {
+        /// <summary>
+        /// Gets the path of the executing assembly as a string.
+        /// </summary>
+        /// <returns>A string path to the executing assembly</returns>
+        public static string GetPathToExecutingAssembly()
+        {
+            return Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).AbsolutePath);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.Reef.Utilities.csproj
+++ b/lang/cs/Org.Apache.REEF.Utilities/Org.Apache.Reef.Utilities.csproj
@@ -54,6 +54,7 @@ under the License.
     <Compile Include="Attributes\ThreadSafeAttribute.cs" />
     <Compile Include="Attributes\UnstableAttribute.cs" />
     <Compile Include="ByteUtilities.cs" />
+    <Compile Include="ClientUtilities.cs" />
     <Compile Include="Collections\PriorityQueue.cs" />
     <Compile Include="Collections\ReadOnlySet.cs" />
     <Compile Include="Diagnostics\DiagnosticsMessages.cs" />


### PR DESCRIPTION
This addressed the issue by

  * Adding the directory to use to source assemblies as a parameter to the `REEF Client`
  * Added a helper function to use the directory of the currently-running executable
  * Updated HelloREEF to use the executable directory instead of the current working directory

JIRA:
REEF-1826

Pull request:
This closes #1826