### PR TITLE
[REEF-1959] Fix bug in ClassPathBuilder#addAllToSuffix

### DIFF
--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/ClassPathBuilder.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/ClassPathBuilder.java
@@ -100,7 +100,7 @@ final class ClassPathBuilder {
    */
   void addAllToSuffix(final String... entries) {
     for (final String classPathEntry : entries) {
-      this.addToPrefix(classPathEntry);
+      this.addToSuffix(classPathEntry);
     }
   }
 


### PR DESCRIPTION
This fixes a wrong method call inside of the addAllToSuffix method

JIRA:
  [REEF-1959](https://issues.apache.org/jira/projects/REEF/issues/REEF-1959)