### PR TITLE
[REEF-1958] Set logging level to Verbose in all processes of HelloREEF example

### DIFF
--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloDriver.cs
@@ -42,13 +42,17 @@ namespace Org.Apache.REEF.Examples.HelloREEF
         /// <summary>
         /// Submits the HelloTask to the Evaluator.
         /// </summary>
-        /// <param name="allocatedEvaluator"></param>
+        /// <param name="allocatedEvaluator">Newly allocated evaluator's proxy object.</param>
         public void OnNext(IAllocatedEvaluator allocatedEvaluator)
         {
+            _Logger.Log(Level.Info, "Evaluator allocated: {0}", allocatedEvaluator);
+
             var taskConfiguration = TaskConfiguration.ConfigurationModule
                 .Set(TaskConfiguration.Identifier, "HelloTask")
                 .Set(TaskConfiguration.Task, GenericType<HelloTask>.Class)
                 .Build();
+
+            _Logger.Log(Level.Verbose, "Submit task: {0}", taskConfiguration);
             allocatedEvaluator.SubmitTask(taskConfiguration);
         }
 
@@ -62,12 +66,12 @@ namespace Org.Apache.REEF.Examples.HelloREEF
         }
 
         /// <summary>
-        /// Called to start the user mode driver
+        /// Called to start the user mode driver.
         /// </summary>
-        /// <param name="driverStarted"></param>
+        /// <param name="driverStarted">Notification that the Driver is up and running.</param>
         public void OnNext(IDriverStarted driverStarted)
         {
-            _Logger.Log(Level.Info, string.Format("HelloDriver started at {0}", driverStarted.StartTime));
+            _Logger.Log(Level.Info, "HelloDriver started at {0}", driverStarted.StartTime);
             _evaluatorRequestor.Submit(_evaluatorRequestor.NewBuilder().SetMegabytes(64).Build());
         }
     }

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
@@ -57,6 +57,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
             var helloDriverConfiguration = DriverConfiguration.ConfigurationModule
                 .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<HelloDriver>.Class)
                 .Set(DriverConfiguration.OnDriverStarted, GenericType<HelloDriver>.Class)
+                .Set(DriverConfiguration.CustomTraceLevel, Level.Verbose.ToString())
                 .Build();
 
             // The JobSubmission contains the Driver configuration as well as the files needed on the Driver.
@@ -91,7 +92,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
                     return YARNClientConfiguration.ConfigurationModuleYARNRest.Build();
                 case HDInsight:
                     // To run against HDInsight please replace placeholders below, with actual values for
-                    // connection string, container name (available at Azure portal) and HDInsight 
+                    // connection string, container name (available at Azure portal) and HDInsight
                     // credentials (username and password)
                     const string connectionString = "ConnString";
                     const string continerName = "foo";

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEFYarn.cs
@@ -61,7 +61,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
         private readonly IList<string> _nodeNames;
 
         [Inject]
-        private HelloREEFYarn(IYarnREEFClient reefClient, 
+        private HelloREEFYarn(IYarnREEFClient reefClient,
             JobRequestBuilder jobRequestBuilder,
             [Parameter(typeof(NodeNames))] ISet<string> nodeNames)
         {
@@ -78,7 +78,8 @@ namespace Org.Apache.REEF.Examples.HelloREEF
             // The driver configuration contains all the needed handler bindings
             var helloDriverConfiguration = DriverConfiguration.ConfigurationModule
                 .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<HelloDriverYarn>.Class)
-                .Set(DriverConfiguration.OnDriverStarted, GenericType<HelloDriverYarn>.Class)              
+                .Set(DriverConfiguration.OnDriverStarted, GenericType<HelloDriverYarn>.Class)
+                .Set(DriverConfiguration.CustomTraceLevel, Level.Verbose.ToString())
                 .Build();
 
             var driverConfig = TangFactory.GetTang()
@@ -88,7 +89,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
             {
                 driverConfig.BindSetEntry<NodeNames, string>(GenericType<NodeNames>.Class, n);
             }
-            
+
             // The JobSubmission contains the Driver configuration as well as the files needed on the Driver.
             var helloJobRequest = _jobRequestBuilder
                 .AddDriverConfiguration(driverConfig.Build())
@@ -133,8 +134,8 @@ namespace Org.Apache.REEF.Examples.HelloREEF
             }
             else
             {
-                Logger.Log(Level.Info, 
-                    "Failed to kill application {0}, possible reasons are application id is invalid or application has completed.", 
+                Logger.Log(Level.Info,
+                    "Failed to kill application {0}, possible reasons are application id is invalid or application has completed.",
                     appId);
             }
         }


### PR DESCRIPTION
Set logging level to `Verbose` in HelloREEF (local and YARN versions) for the Driver and the Evaluators, + better logging and some cleanup in the HelloREEF C# driver to make sure that setting logging levels works properly.

JIRA: [REEF-1958](https://issues.apache.org/jira/browse/REEF-1958)