### PR TITLE
[REEF-1962] Make REEF compile in VS 2013 and 2015 again

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/API/Testing/AssertResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/Testing/AssertResult.cs
@@ -33,9 +33,9 @@ namespace Org.Apache.REEF.Client.API.Testing
             IsTrue = isTrue;
         }
 
-        public string Message { get; }
+        public string Message { get; private set; }
 
-        public bool IsTrue { get; }
+        public bool IsTrue { get; private set; }
 
         public bool IsFalse
         {

--- a/lang/cs/Org.Apache.REEF.Client/API/Testing/TestRunnerFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/Testing/TestRunnerFactory.cs
@@ -53,8 +53,10 @@ namespace Org.Apache.REEF.Client.API.Testing
         /// <returns>True, if the tests are supposed to run on YARN.</returns>
         private static bool RunOnYarn()
         {
-            return bool.TryParse(Environment.GetEnvironmentVariable(TestOnYARNEnvironmentVariable),
-                       out bool runOnYARN) && runOnYARN;
+            bool runOnYARN;
+            return bool.TryParse(
+                Environment.GetEnvironmentVariable(TestOnYARNEnvironmentVariable),
+                out runOnYARN) && runOnYARN;
         }
     }
 }


### PR DESCRIPTION
Summary of changes:
   * Add `private set` to `AssertResult` properties to make code compile in VS2013
   * Remove `out` variable inlining to make code compile in VS2015

JIRA: [REEF-1962](https://issues.apache.org/jira/browse/REEF-1962)