### PR TITLE
[REEF-1964] Allow_IMRU_jobs_in_REEF.NET_to_be_executed_from_any_direc…

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
@@ -162,6 +162,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
             var imruJobSubmission = _jobRequestBuilder
                 .AddDriverConfiguration(imruDriverConfiguration)
                 .AddGlobalAssemblyForType(typeof(IMRUDriver<TMapInput, TMapOutput, TResult, TPartitionType>))
+                .AddGlobalAssembliesInDirectoryOfExecutingAssembly()
                 .SetJobIdentifier(jobDefinition.JobName)
                 .SetDriverMemory(5000)
                 .Build();


### PR DESCRIPTION
…tory

This addressed the issue by
  * Making the IMRU client explicitly add the assemblies from the executing directory. This changes the default behavior but maintains backwards compatibility.

JIRA:
  [REEF-1964](https://issues.apache.org/jira/browse/REEF-1964)

Pull request:
  This closes #