### PR TITLE
[REEF-1966] Allow user to define app.config for Evaluator

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
@@ -48,7 +48,7 @@ namespace Org.Apache.REEF.Client.Common
         @"    </assemblyBinding>" +
         @"  </runtime>" +
         @"</configuration>";
-        private const string EvaluatorExecutable = "Org.Apache.REEF.Evaluator.exe.config";
+        private const string EvaluatorExecutableConfig = "Org.Apache.REEF.Evaluator.exe.config";
 
         private static readonly Logger Logger = Logger.GetLogger(typeof(DriverFolderPreparationHelper));
         private readonly AvroConfigurationSerializer _configurationSerializer;
@@ -154,8 +154,16 @@ namespace Org.Apache.REEF.Client.Common
             File.WriteAllText(Path.Combine(driverFolderPath, _fileNames.GetBridgeExeConfigPath()), config);
 
             // generate .config file for Evaluator executable
-            File.WriteAllText(Path.Combine(driverFolderPath, _fileNames.GetGlobalFolderPath(), EvaluatorExecutable), 
-                DefaultDriverConfigurationFileContents);
+            var userDefinedEvaluatorConfigFileName = Path.Combine(JarFolder, EvaluatorExecutableConfig);
+            var evaluatorConfigFilName = Path.Combine(driverFolderPath, _fileNames.GetGlobalFolderPath(), EvaluatorExecutableConfig);
+            string evaluatorAppConfigString = DefaultDriverConfigurationFileContents;
+
+            if (File.Exists(userDefinedEvaluatorConfigFileName))
+            {
+                evaluatorAppConfigString = File.ReadAllText(userDefinedEvaluatorConfigFileName);
+            }
+            Logger.Log(Level.Verbose, "Create EvaluatorConfigFile {0} with config {1}.", evaluatorConfigFilName, evaluatorAppConfigString);
+            File.WriteAllText(evaluatorConfigFilName, evaluatorAppConfigString);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.csproj
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.csproj
@@ -67,6 +67,7 @@ under the License.
   <ItemGroup>
     <None Include="$(SolutionDir)\App.config">
       <Link>App.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Org.Apache.REEF.Evaluator.nuspec" />
     <None Include="packages.config" />


### PR DESCRIPTION
* Use user define app.config for Evaluator if any otherwise use default
* Remove app.config file from Evaluator project

JIRA: [REEF-1966](https://issues.apache.org/jira/browse/REEF-1966)
This closes #