### PR TITLE
[REEF-1968] Allow the use of C#7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ atlassian-ide-plugin.xml
 *.VC.db
 *.vcxproj.user
 .vs
+.vscode
 #
 # ----------------------------------------------------------------------
 # OS Files

--- a/lang/cs/build.DotNet.props
+++ b/lang/cs/build.DotNet.props
@@ -33,6 +33,11 @@ under the License.
     <DefaultItemExcludes>$(DefaultItemExcludes);**/AssemblyInfo.cs;packages.config;*.nuspec</DefaultItemExcludes>
   </PropertyGroup>
 
+  <!-- Allow for C# 7.2 language constructs -->
+  <PropertyGroup>
+    <LangVersion>7.2</LangVersion>
+  </PropertyGroup>
+  
   <PropertyGroup>
     <Platforms>x64</Platforms>
     <PlatformTarget>x64</PlatformTarget>

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -56,6 +56,11 @@ under the License.
     <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
   </PropertyGroup>
 
+  <!-- Allow for C# 7.2 language constructs -->
+  <PropertyGroup>
+    <LangVersion>7.2</LangVersion>
+  </PropertyGroup>
+
   <!-- REEF NuGet properties -->
   <PropertyGroup>
     <IsSnapshot>true</IsSnapshot>


### PR DESCRIPTION
This adds a directiive to both `build.props` and `build.DotNet.props` to allow for C# 7.2 code.

This also adds the `.vscode` folder to `.gitignore`.

JIRA:
  [REEF-1968](https://issues.apache.org/jira/browse/REEF-1968)