### PR TITLE
[REEF-1969] Switch to StyleCop 5.0

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge.CLR/packages.config
+++ b/lang/cs/Org.Apache.REEF.Bridge.CLR/packages.config
@@ -20,5 +20,5 @@ under the License.
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Client.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/packages.config
@@ -20,7 +20,7 @@ under the License.
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/JobSubmissionResult.cs
@@ -364,7 +364,7 @@ namespace Org.Apache.REEF.Client.Common
                     _driverUrl = values[TrackingUrlKey].ToString();
                     LOGGER.Log(Level.Info, "trackingUrl[" + _driverUrl + "]");
 
-                    if (0 == string.Compare(_driverUrl, UnAssigned))
+                    if (string.Compare(_driverUrl, UnAssigned) == 0)
                     {
                         resultKind = UrlResultKind.UrlNotAssignedYet;
                     }

--- a/lang/cs/Org.Apache.REEF.Client/Local/TestRunner/LocalTestRunner.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Local/TestRunner/LocalTestRunner.cs
@@ -61,7 +61,7 @@ namespace Org.Apache.REEF.Client.Local.TestRunner
                 assertFileName);
             IJobSubmissionResult jobStatus = _client.SubmitAndGetJobStatus(jobRequest);
 
-            if (null == jobStatus)
+            if (jobStatus == null)
             {
                 return TestResult.Fail(
                     "JobStatus returned by the Client was null. This points to an environment setup problem.");

--- a/lang/cs/Org.Apache.REEF.Client/packages.config
+++ b/lang/cs/Org.Apache.REEF.Client/packages.config
@@ -19,6 +19,6 @@ under the License.
 -->
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net45" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Common.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Common.Tests/packages.config
@@ -18,7 +18,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Common/Files/PathUtilities.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Files/PathUtilities.cs
@@ -45,11 +45,7 @@ namespace Org.Apache.REEF.Common.Files
         /// <returns></returns>
         public static bool AreNormalizedEquals(string path1, string path2)
         {
-            if (path1 == null || path2 == null)
-            {
-                return false;
-            }
-            return NormalizePath(path1).Equals(NormalizePath(path2));
+            return path1 != null && path2 != null && NormalizePath(path1).Equals(NormalizePath(path2));
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Common/Files/PathUtilities.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Files/PathUtilities.cs
@@ -45,7 +45,7 @@ namespace Org.Apache.REEF.Common.Files
         /// <returns></returns>
         public static bool AreNormalizedEquals(string path1, string path2)
         {
-            if (null == path1 || null == path2)
+            if (path1 == null || path2 == null)
             {
                 return false;
             }

--- a/lang/cs/Org.Apache.REEF.Common/Jar/ResourceHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Jar/ResourceHelper.cs
@@ -60,12 +60,12 @@ namespace Org.Apache.REEF.Common.Jar
         public ResourceHelper(Assembly assembly)
         {
             var names = assembly.GetManifestResourceNames();
-            if (names == null || names.Length == 0 || null == names[0])
+            if (names == null || names.Length == 0 || names[0] == null)
             {
                 throw new ApplicationException("Could not retrieve Assembly Manifest Resource names");
             }
             var manifestResources = assembly.GetManifestResourceStream(names[0]);
-            if (null == manifestResources)
+            if (manifestResources == null)
             {
                 throw new ApplicationException("Could not retrieve Assembly Manifest Resource stream");
             }
@@ -81,7 +81,7 @@ namespace Org.Apache.REEF.Common.Jar
         internal T GetResource<T>(string resourceName)
         {
             var resource = _resourceSet.GetObject(resourceName);
-            if (null == resource)
+            if (resource == null)
             {
                 throw new ApplicationException(string.Format(CouldNotRetrieveResource, resourceName));
             }

--- a/lang/cs/Org.Apache.REEF.Common/packages.config
+++ b/lang/cs/Org.Apache.REEF.Common/packages.config
@@ -21,7 +21,7 @@ under the License.
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Driver/packages.config
+++ b/lang/cs/Org.Apache.REEF.Driver/packages.config
@@ -21,5 +21,5 @@ under the License.
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Evaluator.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Evaluator.Tests/packages.config
@@ -20,7 +20,7 @@ under the License.
 <packages>
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net45" />
   <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Evaluator/packages.config
+++ b/lang/cs/Org.Apache.REEF.Evaluator/packages.config
@@ -19,5 +19,5 @@ under the License.
 -->
 <packages>
   <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/packages.config
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/packages.config
@@ -18,5 +18,5 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Examples.DriverRestart/packages.config
+++ b/lang/cs/Org.Apache.REEF.Examples.DriverRestart/packages.config
@@ -18,5 +18,5 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/packages.config
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/packages.config
@@ -18,6 +18,6 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Examples/packages.config
+++ b/lang/cs/Org.Apache.REEF.Examples/packages.config
@@ -20,5 +20,5 @@ under the License.
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/packages.config
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/packages.config
@@ -18,5 +18,5 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/packages.config
@@ -19,7 +19,7 @@ under the License.
 -->
 <packages>
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
@@ -324,34 +324,34 @@ namespace Org.Apache.REEF.IMRU.API
         /// <exception cref="NullReferenceException">If any of the required parameters is not set.</exception>
         public IMRUJobDefinition Build()
         {
-            if (null == _jobName)
+            if (_jobName == null)
             {
                 Exceptions.Throw(new NullReferenceException("Job name cannot be null"),
                     Logger);
             }
 
-            if (null == _mapFunctionConfiguration)
+            if (_mapFunctionConfiguration == null)
             {
                 Exceptions.Throw(new NullReferenceException("Map function configuration cannot be null"), Logger);
             }
 
-            if (null == _mapInputCodecConfiguration)
+            if (_mapInputCodecConfiguration == null)
             {
                 Exceptions.Throw(new NullReferenceException("Map input codec configuration cannot be null"), Logger);
             }
 
-            if (null == _updateFunctionCodecsConfiguration)
+            if (_updateFunctionCodecsConfiguration == null)
             {
                 Exceptions.Throw(new NullReferenceException("Update function codecs configuration cannot be null"),
                     Logger);
             }
 
-            if (null == _reduceFunctionConfiguration)
+            if (_reduceFunctionConfiguration == null)
             {
                 Exceptions.Throw(new NullReferenceException("Reduce function configuration cannot be null"), Logger);
             }
 
-            if (null == _updateFunctionConfiguration)
+            if (_updateFunctionConfiguration == null)
             {
                 Exceptions.Throw(new NullReferenceException("Update function configuration cannot be null"), Logger);
             }

--- a/lang/cs/Org.Apache.REEF.IMRU/packages.config
+++ b/lang/cs/Org.Apache.REEF.IMRU/packages.config
@@ -18,5 +18,5 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.IO.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/packages.config
@@ -19,7 +19,7 @@ under the License.
 -->
 <packages>
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HDFSCommandRunner.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HDFSCommandRunner.cs
@@ -122,7 +122,7 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
             {
                 var processName = string.Format("HDFS_Attempt_{0}_of_{1}", attemptNumber, _numberOfRetries);
                 var result = RunAttempt(processStartInfo, _timeOutInMilliSeconds, processName);
-                if (null != result)
+                if (result != null)
                 {
                     LogCommandOutput(result);
                     return result;
@@ -153,7 +153,7 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
         {
             var hadoopHomeFromEnv = Environment.GetEnvironmentVariable(HadoopHomeEnvironmentVariableName);
             Logger.Log(Level.Verbose, "{0} evaluated to {1}.", HadoopHomeEnvironmentVariableName, hadoopHomeFromEnv);
-            if (null == hadoopHomeFromEnv)
+            if (hadoopHomeFromEnv == null)
             {
                 throw new Exception(HadoopHomeEnvironmentVariableName +
                                     " not set and no path to the hadoop installation provided.");

--- a/lang/cs/Org.Apache.REEF.IO/packages.config
+++ b/lang/cs/Org.Apache.REEF.IO/packages.config
@@ -23,7 +23,7 @@ under the License.
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="6.1.0" targetFramework="net45" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/packages.config
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/packages.config
@@ -18,5 +18,5 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Network.Examples/packages.config
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/packages.config
@@ -18,5 +18,5 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Network.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/packages.config
@@ -18,7 +18,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Network/packages.config
+++ b/lang/cs/Org.Apache.REEF.Network/packages.config
@@ -28,7 +28,7 @@ under the License.
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net451" />

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/packages.config
@@ -18,5 +18,5 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/packages.config
@@ -21,7 +21,7 @@ under the License.
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Tang.Tools/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tang.Tools/packages.config
@@ -18,5 +18,5 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
@@ -285,12 +285,12 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
             if (!string.IsNullOrEmpty(np.GetAlias()))
             {
-                IDictionary<string, string> mapping = null;
-                _aliasLookupTable.TryGetValue(np.GetAliasLanguage().ToString(), out mapping);
-                if (mapping == null)
+                var aliasLanguage = np.GetAliasLanguage().ToString();
+                IDictionary<string, string> mapping;
+                if (!_aliasLookupTable.TryGetValue(aliasLanguage, out mapping))
                 {
                     mapping = new Dictionary<string, string>();
-                    _aliasLookupTable.Add(np.GetAliasLanguage().ToString(), mapping);
+                    _aliasLookupTable.Add(aliasLanguage, mapping);
                 }
                 try
                 {

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
@@ -287,7 +287,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             {
                 IDictionary<string, string> mapping = null;
                 _aliasLookupTable.TryGetValue(np.GetAliasLanguage().ToString(), out mapping);
-                if (null == mapping)
+                if (mapping == null)
                 {
                     mapping = new Dictionary<string, string>();
                     _aliasLookupTable.Add(np.GetAliasLanguage().ToString(), mapping);

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
@@ -40,7 +40,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         public static INode CreateClassNode(INode parent, Type clazz)
         {
             // var namedParameter = clazz.GetCustomAttribute<NamedParameterAttribute>();
-            var unit = null != clazz.GetCustomAttribute<UnitAttribute>();
+            var unit = clazz.GetCustomAttribute<UnitAttribute>() != null;
             string simpleName = ReflectionUtilities.GetName(clazz);
             string fullName = ReflectionUtilities.GetAssemblyQualifiedName(clazz);
 
@@ -64,7 +64,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
             foreach (ConstructorInfo c in clazz.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))  
             {
-                var constructorAnnotatedInjectable = null != c.GetCustomAttribute<InjectAttribute>();
+                var constructorAnnotatedInjectable = c.GetCustomAttribute<InjectAttribute>() != null;
 
                 bool constructorInjectable = constructorAnnotatedInjectable;
 
@@ -91,7 +91,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
             string defaultImplementation = null;
             DefaultImplementationAttribute defaultImpl = clazz.GetCustomAttribute<DefaultImplementationAttribute>();
-            if (null != defaultImpl)
+            if (defaultImpl != null)
             {
                 Type defaultImplementationClazz = defaultImpl.Value;
 

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectorImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectorImpl.cs
@@ -125,7 +125,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
                     Org.Apache.REEF.Utilities.Diagnostics.Exceptions.Throw(new InjectionException("Could not get class for " + key), LOGGER); 
                 }
             }
-            else if (plan.GetNode() is IClassNode && null != GetCachedInstance((IClassNode)plan.GetNode()))
+            else if (plan.GetNode() is IClassNode && GetCachedInstance((IClassNode)plan.GetNode()) != null)
             {
                 return GetCachedInstance((IClassNode)plan.GetNode());
             }
@@ -512,7 +512,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
             {
                 List<InjectionPlan> constructors = new List<InjectionPlan>();
                 List<IConstructorDef> constructorList = new List<IConstructorDef>();
-                if (null != this.configuration.GetLegacyConstructor(thisCN))
+                if (this.configuration.GetLegacyConstructor(thisCN) != null)
                 {
                     constructorList.Add(this.configuration.GetLegacyConstructor(thisCN));
                 }

--- a/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/ReflectionUtilities.cs
@@ -304,7 +304,7 @@ namespace Org.Apache.REEF.Tang.Util
         /// <returns></returns>
         public static Type EnsureInterfaceType(Type interf)
         {
-            if (interf != null && interf.IsGenericType && null == interf.FullName)
+            if (interf != null && interf.IsGenericType && interf.FullName == null)
             {
                 return interf.GetGenericTypeDefinition(); // this is to test if this line is ever reached
             }

--- a/lang/cs/Org.Apache.REEF.Tang/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tang/packages.config
@@ -21,5 +21,5 @@ under the License.
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/HelloSimpleEventHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/HelloSimpleEventHandlers.cs
@@ -310,7 +310,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         {
             Logger.Log(Level.Info, "SubmitNextTask with evaluator id: " + activeContext.EvaluatorId);
             IConfiguration finalConfiguration = GetNextTaskConfiguration();
-            if (null != finalConfiguration)
+            if (finalConfiguration != null)
             {
                 Logger.Log(Level.Info, "Executing task id " + _taskContext.CurrentTaskId());
                 Logger.Log(Level.Info, string.Format(CultureInfo.InvariantCulture, "Submitting Task {0}", _taskContext.CurrentTaskId()));

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -236,7 +236,7 @@ namespace Org.Apache.REEF.Tests.Functional
                 }
                 else if (numberOfOccurrences == 0)
                 {
-                    Assert.True(0 == successIndicators.Count(),
+                    Assert.True(successIndicators.Count() == 0,
                         "Message \"" + message + "\" not expected to occur but occurs " + successIndicators.Count() + " times");
                 }
                 else

--- a/lang/cs/Org.Apache.REEF.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tests/packages.config
@@ -24,7 +24,7 @@ under the License.
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Utilities/packages.config
+++ b/lang/cs/Org.Apache.REEF.Utilities/packages.config
@@ -19,5 +19,5 @@ under the License.
 -->
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/packages.config
@@ -19,7 +19,7 @@ under the License.
 -->
 <packages>
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/lang/cs/Org.Apache.REEF.Wake/Examples/P2p/Pull2Push.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Examples/P2p/Pull2Push.cs
@@ -71,11 +71,11 @@ namespace Org.Apache.REEF.Wake.Examples.P2p
             {
                 // Grab the next available message source, if any
                 IEventSource<T> nextSource = _sources.Dequeue();
-                if (null != nextSource)
+                if (nextSource != null)
                 {
                     // Grab the next message from that source, if any
                     T message = nextSource.GetNext();
-                    if (null != message)
+                    if (message != null)
                     {
                         // Add the source to the end of the queue again.
                         _sources.Enqueue(nextSource);

--- a/lang/cs/Org.Apache.REEF.Wake/packages.config
+++ b/lang/cs/Org.Apache.REEF.Wake/packages.config
@@ -23,7 +23,7 @@ under the License.
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" developmentDependency="true" />
   <package id="Microsoft.Hadoop.Avro" version="1.5.6" targetFramework="net45" />
   <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net451" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net451" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net45" />

--- a/lang/cs/build.DotNet.props
+++ b/lang/cs/build.DotNet.props
@@ -44,7 +44,7 @@ under the License.
     <NSubstituteVersion>1.8.2.0</NSubstituteVersion>
     <ProtobufVersion>2.1.0</ProtobufVersion>
     <SystemReactiveVersion>3.1.1</SystemReactiveVersion>
-    <StyleCopVersion>4.7.49.1</StyleCopVersion>
+    <StyleCopVersion>5.0.0</StyleCopVersion>
     <TransientFaultHandlingVersion>1.0.0</TransientFaultHandlingVersion>
     <NSubstituteVersion>2.0.3</NSubstituteVersion>
     <WindowsAzureStorageVersion>8.1.3</WindowsAzureStorageVersion>

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -71,7 +71,7 @@ under the License.
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
     <ProtobufVersion>2.1.0</ProtobufVersion>
     <SystemReactiveVersion>3.1.1</SystemReactiveVersion>
-    <StyleCopVersion>4.7.49.1</StyleCopVersion>
+    <StyleCopVersion>5.0.0</StyleCopVersion>
     <NSubstituteVersion>1.8.2.0</NSubstituteVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
This updates all package references to use version `5.0.0` of StyleCop. Also, it fixes newly introduced StyleCop warnings. All of those are just inverting comparisons of the form `constant == variable` to `variable == constant`.

JIRA:
  [REEF-1069](https://issues.apache.org/jira/browse/REEF-1969)