### PR TITLE
[REEF-1975] Support stream option for Azure Blob storage

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlockBlobFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlockBlobFileSystem.cs
@@ -42,19 +42,19 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
         }
 
         /// <summary>
-        /// Not supported for Azure Blobs, will throw <see cref="NotSupportedException"/>.
+        /// Returns a Stream object to the blob specified by the fileUri.
         /// </summary>
         public Stream Open(Uri fileUri)
         {
-            throw new NotSupportedException("Open is not supported for AzureBlockBlobFileSystem.");
+            return _client.GetBlockBlobReference(fileUri).Open();
         }
 
         /// <summary>
-        /// Not supported for Azure Blobs, will throw <see cref="NotSupportedException"/>.
+        /// Creates a blob for the specified fileUri and returns a write Stream object to it.
         /// </summary>
         public Stream Create(Uri fileUri)
         {
-            throw new NotSupportedException("Open is not supported for AzureBlockBlobFileSystem.");
+            return _client.GetBlockBlobReference(fileUri).Create();
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlockBlob.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlockBlob.cs
@@ -59,6 +59,16 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
             _blob = new CloudBlockBlob(uri, credentials);
         }
 
+        public Stream Open()
+        {
+            return _blob.OpenRead();
+        }
+
+        public Stream Create()
+        {
+            return _blob.OpenWrite();
+        }
+
         public bool Exists()
         {
             var task = _blob.ExistsAsync();

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/ICloudBlockBlob.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/ICloudBlockBlob.cs
@@ -46,6 +46,20 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
         CopyState CopyState { get; }
 
         /// <summary>
+        /// Opens a stream to the blob content.
+        /// </summary>
+        /// <returns>System.IO.Stream object.</returns>
+        /// <exception cref="StorageException">If blob does not exist</exception>
+        Stream Open();
+
+        /// <summary>
+        /// Creates a blob and returns a write Stream object to it.
+        /// </summary>
+        /// <returns>System.IO.Stream object.</returns>
+        /// <exception cref="StorageException">If blob cannot be created</exception>
+        Stream Create();
+
+        /// <summary>
         /// Makes a round trip to the server to test if the blob exists.
         /// </summary>
         /// <returns>True if exists. False otherwise.</returns>


### PR DESCRIPTION
This addressed the issue by
* Implementing the Open and Create methods of AzureBlockBlob FileSystem
 to return read and write streams to the existing/created files

JIRA
[REEF-1975] (https://issues.apache.org/jira/browse/REEF-1975)