### PR TITLE
[REEF-1988] Incorrect version of Azure Authentication

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO/packages.config
+++ b/lang/cs/Org.Apache.REEF.IO/packages.config
@@ -27,7 +27,7 @@ under the License.
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.28.3" targetFramework="net452" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.10" targetFramework="net452" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.7" targetFramework="net452" />
-  <package id="Microsoft.Rest.ClientRuntime.Azure.Authentication" version="2.3.2" targetFramework="net452" />
+  <package id="Microsoft.Rest.ClientRuntime.Azure.Authentication" version="2.3.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="NLog" version="4.4.12" targetFramework="net452" />
   <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net45" developmentDependency="true" />


### PR DESCRIPTION
 - Change the version number of the Microsoft.Rest.ClientRuntime.Azure.Authentication
   package from 2.3.2 to 2.3.1 to remove the associated build error.

 JIRA:
   [REEF-1988] (https://issues.apache.org/jira/browse/REEF-1988)

 Pull request:
   This closes #