### PR TITLE
[REEF-2010] Update DotNet libraries to target .netstandard2.0

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.DotNet.vcxproj
+++ b/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.DotNet.vcxproj
@@ -23,7 +23,6 @@ under the License.
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <SolutionDir Condition="'$(SolutionDir)' == ''">..</SolutionDir>
     <ConfigurationType>Application</ConfigurationType>
-
     <!-- Added for when the .net core build is enabled. This prevents assemblies for the bridge
          to be copied to the bin folder. -->
     <ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>
@@ -112,8 +111,9 @@ under the License.
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <AdditionalIncludeDirectories>..\..\java\reef-bridge-java\target\classes;$(JAVA_HOME)\include;$(JAVA_HOME)\include\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-      <AdditionalUsingDirectories Condition="'$(EnableDotNetBuild)' == 'False'">$(AdditionalUsingDirectories);$(BinDir)$(Configuration)\Org.Apache.REEF.Driver\net461</AdditionalUsingDirectories>
-      <AdditionalUsingDirectories Condition="'$(EnableDotNetBuild)' == 'True'">$(AdditionalUsingDirectories);$(BinDir)$(Configuration)\Org.Apache.REEF.Driver\netstandard2.0</AdditionalUsingDirectories>
+      <AdditionalUsingDirectories>$(BinDir)$(Configuration)\Org.Apache.REEF.Driver\netstandard2.0;C:\Program Files\dotnet\sdk\2.1.4\Microsoft\Microsoft.NET.Build.Extensions\net461\lib;$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <!-- Disable C4691 about missing references. This is benign as the warning reports using a default implementation. -->
+      <DisableSpecificWarnings>4691;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -129,8 +129,9 @@ under the License.
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <AdditionalIncludeDirectories>..\..\java\reef-bridge-java\target\classes;$(JAVA_HOME)\include;$(JAVA_HOME)\include\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-      <AdditionalUsingDirectories Condition="'$(EnableDotNetBuild)' == 'False'">$(AdditionalUsingDirectories);$(BinDir)$(Configuration)\Org.Apache.REEF.Driver\net461</AdditionalUsingDirectories>
-      <AdditionalUsingDirectories Condition="'$(EnableDotNetBuild)' == 'True'">$(AdditionalUsingDirectories);$(BinDir)$(Configuration)\Org.Apache.REEF.Driver\netstandard2.0</AdditionalUsingDirectories>
+      <AdditionalUsingDirectories>$(BinDir)$(Configuration)\Org.Apache.REEF.Driver\netstandard2.0;$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <!-- Disable C4691 about missing references. This is benign as the warning reports using a default implementation. -->
+      <DisableSpecificWarnings>4691;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -209,7 +210,6 @@ under the License.
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-  
   <!-- Adds an empty pack target so that this project is skipped when packing. -->
   <Target Name="Pack">
   </Target>

--- a/lang/cs/Org.Apache.REEF.Client/AzureBatch/Storage/AzureStorageClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/AzureBatch/Storage/AzureStorageClient.cs
@@ -78,7 +78,7 @@ namespace Org.Apache.REEF.Client.AzureBatch.Storage
         {
             CloudBlobClient cloudBlobClient = CloudStorageAccount.Parse(this._storageConnectionString).CreateCloudBlobClient();
             CloudBlobContainer cloudBlobContainer = cloudBlobClient.GetContainerReference(this._storageContainerName);
-            cloudBlobContainer.CreateIfNotExists();
+            cloudBlobContainer.CreateIfNotExistsAsync().Wait();
             return cloudBlobContainer.GetSharedAccessSignature(CreateSASPolicy());
         }
 

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.DotNet.csproj
@@ -26,7 +26,7 @@ under the License.
   </PropertyGroup>
   <Import Project="..\build.DotNetLibrary.props" />
   <PropertyGroup>
-    <TempResxFile Condition="$(TempResxFile) == ''">Resources.DotNet.resx</TempResxFile>
+    <TempResxFile Condition="$(TempResxFile) == ''">$(OutputPath)\$(TargetFramework)\Resources.DotNet.resx</TempResxFile>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(TempResxFile)">
@@ -153,12 +153,8 @@ under the License.
     </ItemGroup>
     <Copy SourceFiles="@(MySourceFiles)" DestinationFiles="@(MySourceFiles->'$(TargetDir)%(Filename)%(Extension)')" />
   </Target>
-  <!--
-  <Target Name="AfterBuild">
+  <Target Name="RemovingTempResx" AfterTargets="AfterBuild">
+    <Message Text="Removing temporary resx file" Importance="high"/>
     <Delete Files="$(TempResxFile)" />
-    <RemoveDir Directories="$(BaseIntermediateOutputPath)" />
   </Target>
-  <Target Name="BeforeBuild" DependsOnTargets="RewriteClientResources">
-  </Target>
-  -->
 </Project>

--- a/lang/cs/Org.Apache.REEF.FatNuGet/Org.Apache.REEF.FatNuGet.DotNet.csproj
+++ b/lang/cs/Org.Apache.REEF.FatNuGet/Org.Apache.REEF.FatNuGet.DotNet.csproj
@@ -29,13 +29,18 @@ under the License.
     <PackageReference Include="Microsoft.Avro.Core" Version="$(AvroVersion)" />
   </ItemGroup>
 
-    <!-- Project Reference conditionals allow for targeting specific projects based upon the target framework. -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <!-- Evaluator as a .netcoreapp can not be linked by a .netstandard library, therefore this is only linked for net461 -->
-    <ProjectReference Include="..\Org.Apache.REEF.Evaluator\Org.Apache.REEF.Evaluator.DotNet.csproj" PrivateAssets="All"/>
-    <!-- IMRU Examples as a .netcoreapp can not be linked by a .netstandard library, therefore this is only linked for net461 -->
-    <ProjectReference Include="..\Org.Apache.REEF.IMRU.Examples\Org.Apache.REEF.IMRU.Examples.DotNet.csproj" PrivateAssets="All"/>
+  <ItemGroup>
+    <Content Include="$(BinDir)\$(Configuration)\Org.Apache.REEF.Evaluator\net461\Org.Apache.REEF.Evaluator.exe">
+      <Pack>true</Pack>
+      <PackagePath>lib\netstandard2.0</PackagePath>
+    </Content>
+
+    <Content Include="$(BinDir)\$(Configuration)\Org.Apache.REEF.IMRU.Examples\net461\Org.Apache.REEF.IMRU.Examples.exe">
+      <Pack>true</Pack>
+      <PackagePath>lib\netstandard2.0</PackagePath>
+    </Content>
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Org.Apache.REEF.Client\Org.Apache.REEF.Client.DotNet.csproj" PrivateAssets="All"/>
     <ProjectReference Include="..\Org.Apache.REEF.Common\Org.Apache.REEF.Common.DotNet.csproj" PrivateAssets="All"/>

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobContainer.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobContainer.cs
@@ -33,7 +33,9 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
 
         public bool CreateIfNotExists()
         {
-            return _container.CreateIfNotExists();
+            var task = _container.CreateIfNotExistsAsync();
+            task.Wait();
+            return task.Result;
         }
 
         public void DeleteIfExists()

--- a/lang/cs/build.DotNet.props
+++ b/lang/cs/build.DotNet.props
@@ -27,12 +27,11 @@ under the License.
     <AvroVersion>0.1.0</AvroVersion>
     <MicrosoftDataLakeStoreVersion>1.1.3</MicrosoftDataLakeStoreVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
-    <NSubstituteVersion>1.8.2.0</NSubstituteVersion>
     <ProtobufVersion>2.1.0</ProtobufVersion>
     <SystemReactiveVersion>3.1.1</SystemReactiveVersion>
     <StyleCopVersion>5.0.0</StyleCopVersion>
     <TransientFaultHandlingVersion>1.0.0</TransientFaultHandlingVersion>
-    <NSubstituteVersion>2.0.3</NSubstituteVersion>
+    <NSubstituteVersion>3.1.0</NSubstituteVersion>
     <WindowsAzureStorageVersion>8.1.3</WindowsAzureStorageVersion>
   </PropertyGroup>
 </Project>

--- a/lang/cs/build.DotNetLibrary.props
+++ b/lang/cs/build.DotNetLibrary.props
@@ -18,12 +18,6 @@ under the License.
 
 <Import Project="build.DotNet.props"/>
 <PropertyGroup>
-  <TargetFrameworks>net461</TargetFrameworks>
-
-  <!-- If EnableDotNetBuild is true, override the target frameworks to include dot net core -->
-  <TargetFrameworks Condition="'$(EnableDotNetBuild)' == 'true'">netstandard2.0</TargetFrameworks>
-
-  <!-- If on Linux, override the target frameworks to netcoreapp2.0 -->
-  <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
+  <TargetFrameworks>netstandard2.0</TargetFrameworks>
 </PropertyGroup>
 </Project>

--- a/lang/cs/xunit.DotNet.props
+++ b/lang/cs/xunit.DotNet.props
@@ -16,7 +16,7 @@ specific language governing permissions and limitations
 under the License.
 -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" NoWarn="NU1701"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" NoWarn="NU1701"/>
     <PackageReference Include="xunit" Version="2.2.0" NoWarn="NU1701"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" NoWarn="NU1701"/>
     <PackageReference Include="xunit.runner.console" Version="2.2.0" NoWarn="NU1701"/>


### PR DESCRIPTION
This change updates all libraries to target .net standard 2.0 while
leaving the executables and tests targeting .net461.
 - Update the NSubstitute library and Microsoft.Net.Test.Sdk libraries
 as the older versions were causing an issue with the tests.
 - Changed a Blob call to use the Async method.

JIRA:
 [REEF-2010](https://issues.apache.org/jira/browse/REEF-2010)

Pull Request:
 Closes #

[REEF-1996] Move the Client resx file generation to the bin folder
 - Moves the resx generation to now happen in
 bin/.netcore/Org.Apache.REEF.Client
 - Also deletes the file post build process. This is to mirror the
 behavior from the old build.

JIRA:
  [REEF-1996](https://issues.apache.org/jira/browse/REEF-1996)

Pull Request:
  Closes #