### PR TITLE
[REEF-2013] Running on Azure Batch fails with a Null Exception error

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequest.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequest.cs
@@ -75,7 +75,7 @@ namespace Org.Apache.REEF.Driver.Evaluator
             RuntimeName = runtimeName;
             NodeNames = nodeNames;
             RelaxLocality = relaxLocality;
-            NodeLabelExpression = NodeLabelExpression;
+            NodeLabelExpression = nodeLabelExpression;
         }
 
         [DataMember]


### PR DESCRIPTION
 - This was due to the node label not being set correctly resulting a
 null value when being passed down to Java. This is now set to the
 correct value.

JIRA:
   [REEF-2013](https://issues.apache.org/jira/browse/REEF-2013)

Pull Request:
This closes #