### PR TITLE
[REEF-2014] Azure Batch REEF .NET Driver is not able to exit when using REEFEnvrionment to launch

### DIFF
--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/AzureBatchBootstrapREEFLauncher.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/AzureBatchBootstrapREEFLauncher.java
@@ -92,6 +92,10 @@ public final class AzureBatchBootstrapREEFLauncher {
     } catch (final InjectionException ex) {
       throw fatal("Unable to configure and start REEFEnvironment.", ex);
     }
+
+    LOG.log(Level.INFO, "Exiting BootstrapLauncher.main()");
+
+    System.exit(0); // TODO[REEF-1715]: Should be able to exit cleanly at the end of main()
   }
 
   private static Configuration generateConfigurationFromJobSubmissionParameters(final File params) throws IOException {


### PR DESCRIPTION
This addresses the issue by

     Add System.exit(0) in AzureBatchBootstrapREEFLauncher.java, which
     applies the same logic in REEFLauncher.

JIRA:
  [REEF-2014] https://issues.apache.org/jira/browse/REEF-2014

Pull request:
  This closes #