### PR TITLE
[REEF-2016] - Fix CreateUriForPath methods of different IFileSystems to not append prefix if given path already contains it

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequest.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequest.cs
@@ -29,7 +29,7 @@ namespace Org.Apache.REEF.Driver.Evaluator
     internal class EvaluatorRequest : IEvaluatorRequest
     {
         internal EvaluatorRequest()
-            : this(0, 0, 1, string.Empty, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true, string.Empty)
+            : this(0, 0, 1, string.Empty, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true, String.Empty)
         {
         }
 
@@ -44,7 +44,7 @@ namespace Org.Apache.REEF.Driver.Evaluator
         }
 
         internal EvaluatorRequest(int number, int megaBytes, string rack)
-            : this(number, megaBytes, 1, rack, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true, string.Empty)
+            : this(number, megaBytes, 1, rack, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true, String.Empty)
         {
         }
 

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequest.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequest.cs
@@ -29,7 +29,7 @@ namespace Org.Apache.REEF.Driver.Evaluator
     internal class EvaluatorRequest : IEvaluatorRequest
     {
         internal EvaluatorRequest()
-            : this(0, 0, 1, string.Empty, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true, String.Empty)
+            : this(0, 0, 1, string.Empty, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true, string.Empty)
         {
         }
 
@@ -44,7 +44,7 @@ namespace Org.Apache.REEF.Driver.Evaluator
         }
 
         internal EvaluatorRequest(int number, int megaBytes, string rack)
-            : this(number, megaBytes, 1, rack, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true, String.Empty)
+            : this(number, megaBytes, 1, rack, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true, string.Empty)
         {
         }
 

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystem.cs
@@ -124,10 +124,17 @@ namespace Org.Apache.REEF.IO.Tests
         }
 
         [Fact]
-        public void TestCreateUriForPath()
+        public void TestCreateUriForPathNoPrefix()
         {
             var testContext = new TestContext();
             Assert.Equal(FakeUri, testContext.GetAzureFileSystem().CreateUriForPath(FakeUri.LocalPath));
+        }
+
+        [Fact]
+        public void TestCreateUriForPathWithPrefix()
+        {
+            var testContext = new TestContext();
+            Assert.Equal(FakeUri, testContext.GetAzureFileSystem().CreateUriForPath(FakeUri.AbsoluteUri));
         }
 
         private sealed class TestContext

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystem.cs
@@ -36,16 +36,21 @@ namespace Org.Apache.REEF.IO.Tests
     public sealed class TestAzureBlockBlobFileSystem
     {
         private static readonly Uri FakeUri = new Uri("http://storageacct.blob.core.windows.net/container/file");
+        private TestContext testContext;
 
         private static Uri BaseUri
         {
             get { return new Uri(FakeUri.GetLeftPart(UriPartial.Authority)); }
         }
 
+        public TestAzureBlockBlobFileSystem()
+        {
+            this.testContext = new TestContext();
+        }
+
         [Fact]
         public void TestCreate()
         {
-            var testContext = new TestContext();
             Stream stream = testContext.GetAzureFileSystem().Create(FakeUri);
             testContext.TestCloudBlockBlob.Received(1).Create();
             Assert.Equal(testContext.TestCreateStream, stream);
@@ -54,7 +59,6 @@ namespace Org.Apache.REEF.IO.Tests
         [Fact]
         public void TestOpen()
         {
-            var testContext = new TestContext();
             Stream stream = testContext.GetAzureFileSystem().Open(FakeUri);
             testContext.TestCloudBlockBlob.Received(1).Open();
             Assert.Equal(testContext.TestOpenStream, stream);
@@ -63,7 +67,6 @@ namespace Org.Apache.REEF.IO.Tests
         [Fact]
         public void TestDelete()
         {
-            var testContext = new TestContext();
             testContext.GetAzureFileSystem().Delete(FakeUri);
             testContext.TestCloudBlockBlob.Received(1).Delete();
         }
@@ -71,7 +74,6 @@ namespace Org.Apache.REEF.IO.Tests
         [Fact]
         public void TestExists()
         {
-            var testContext = new TestContext();
             testContext.GetAzureFileSystem().Exists(FakeUri);
             testContext.TestCloudBlockBlob.Received(1).Exists();
         }
@@ -79,7 +81,6 @@ namespace Org.Apache.REEF.IO.Tests
         [Fact]
         public void TestCopyToLocal()
         {
-            var testContext = new TestContext();
             testContext.GetAzureFileSystem().CopyToLocal(FakeUri, "local");
             testContext.TestCloudBlockBlob.Received(1).DownloadToFile("local", FileMode.CreateNew);
         }
@@ -87,7 +88,6 @@ namespace Org.Apache.REEF.IO.Tests
         [Fact]
         public void TestCopyFromLocal()
         {
-            var testContext = new TestContext();
             testContext.GetAzureFileSystem().CopyFromLocal("local", FakeUri);
             testContext.TestCloudBlockBlob.Received(1).UploadFromFile("local", FileMode.Open);
         }
@@ -118,7 +118,6 @@ namespace Org.Apache.REEF.IO.Tests
         [Fact]
         public void TestDeleteDirectoryRecursive()
         {
-            var testContext = new TestContext();
             testContext.TestCloudBlobDirectory.ListBlobs(true).ReturnsForAnyArgs(Enumerable.Repeat(testContext.TestCloudBlob, 5));
             testContext.GetAzureFileSystem().DeleteDirectory(new Uri("http://test.com/container/directory/directory"));
             testContext.TestCloudBlobClient.Received(1).GetContainerReference("container");
@@ -131,14 +130,12 @@ namespace Org.Apache.REEF.IO.Tests
         [Fact]
         public void TestCreateUriForAbsolutePathInvalid()
         {
-            var testContext = new TestContext();
             Assert.Throws<ArgumentException>(() => testContext.GetAzureFileSystem().CreateUriForPath("http://www.invalidstorageaccount.com/container/folder1/file1.txt"));
         }
 
         [Fact]
         public void TestCreateUriForAbsolutePath()
         {
-            var testContext = new TestContext();
             Uri uri = new Uri("http://storageacct.blob.core.windows.net/container/folder1/folder2/file.txt");
             Uri resultUri = testContext.GetAzureFileSystem().CreateUriForPath(uri.AbsoluteUri);
             Assert.Equal<Uri>(uri, resultUri);
@@ -147,7 +144,6 @@ namespace Org.Apache.REEF.IO.Tests
         [Fact]
         public void TestCreateUriForRelativePathValid()
         {
-            var testContext = new TestContext();
             string relativePath = "container/folder1/folder2/file.txt";
             Uri expectedUri = new Uri(BaseUri, relativePath);
             Uri resultUri = testContext.GetAzureFileSystem().CreateUriForPath(relativePath);
@@ -157,8 +153,6 @@ namespace Org.Apache.REEF.IO.Tests
         [Fact]
         public void TestCreateUriForRelativePathWithContainerNameTooSmall()
         {
-            var testContext = new TestContext();
-
             // Container name must be atleast 3 characters.
             string relativePath = "c1/folder1/folder2/file.txt";
             Uri expectedUri = new Uri(BaseUri, relativePath);
@@ -168,11 +162,8 @@ namespace Org.Apache.REEF.IO.Tests
         [Fact]
         public void TestCreateUriForRelativePathWithInvalidContainerName()
         {
-            var testContext = new TestContext();
-
             // Container name cannot contain a colon character.
             string relativePath = "c:/folder1/folder2/file.txt";
-            Uri expectedUri = new Uri(BaseUri, relativePath);
             Assert.Throws<ArgumentException>(() => testContext.GetAzureFileSystem().CreateUriForPath(relativePath));
         }
 

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureDataLakeFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureDataLakeFileSystem.cs
@@ -195,11 +195,20 @@ namespace Org.Apache.REEF.IO.Tests
         }
 
         [Fact]
-        public void TestCreateUriForPath()
+        public void TestCreateUriForPathNoPrefix()
         {
             string dirStructure = FakeFileUri.AbsolutePath;
             Uri createdUri = _fs.CreateUriForPath(dirStructure);
             Assert.Equal(createdUri, new Uri($"adl://{_context.AdlAccountName}{dirStructure}"));
+        }
+
+        [Fact]
+        public void TestCreateUriForPathWithPrefix()
+        {
+            string dirStructure = FakeFileUri.AbsolutePath;
+            string uriString = $"adl://{_context.AdlAccountName}{dirStructure}";
+            Uri createdUri = _fs.CreateUriForPath(uriString);
+            Assert.Equal(createdUri, new Uri(uriString));
         }
 
         [Fact]

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
@@ -18,6 +18,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Org.Apache.REEF.IO.FileSystem;
 using Org.Apache.REEF.IO.FileSystem.Hadoop;
 using Org.Apache.REEF.Tang.Annotations;
@@ -140,6 +141,20 @@ namespace Org.Apache.REEF.IO.Tests
         {
             // Create() is not supported by HadoopFileSystem. Create a local file and use CopyFromLocal instead.
             Assert.Throws<NotImplementedException>(() => _fileSystem.Create(GetTempUri()));
+        }
+
+        [Fact(Skip = "These tests need to be run in an environment with HDFS installed.")]
+        public void CreateUriForPathNoPrefix()
+        {
+            var uri = _fileSystem.CreateUriForPath("/tmp/TestHadoop");
+            Assert.True(new Regex("hdfs://[a-z]+:\\d+/tmp/TestHadoop").Match(uri.AbsoluteUri).Success);
+        }
+
+        [Fact(Skip = "These tests need to be run in an environment with HDFS installed.")]
+        public void CreateUriForPathWithPrefix()
+        {
+            var uriString = "hdfs://localhost:9000/tmp/TestHadoop";
+            Assert.Equal(uriString, _fileSystem.CreateUriForPath(uriString).AbsoluteUri);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
@@ -146,15 +146,22 @@ namespace Org.Apache.REEF.IO.Tests
         [Fact(Skip = "These tests need to be run in an environment with HDFS installed.")]
         public void CreateUriForPathNoPrefix()
         {
-            var uri = _fileSystem.CreateUriForPath("/tmp/TestHadoop");
+            Uri uri = _fileSystem.CreateUriForPath("/tmp/TestHadoop");
             Assert.True(new Regex("hdfs://[a-z]+:\\d+/tmp/TestHadoop").Match(uri.AbsoluteUri).Success);
+        }
+
+        [Fact(Skip = "These tests need to be run in an environment with HDFS installed.")]
+        public void TestCreateUriForPathInvalid()
+        {
+            Assert.Throws<ArgumentException>(() => _fileSystem.CreateUriForPath("http://www.invalidhadoopfs.com/container/folder1/file1.txt"));
         }
 
         [Fact(Skip = "These tests need to be run in an environment with HDFS installed.")]
         public void CreateUriForPathWithPrefix()
         {
-            var uriString = "hdfs://localhost:9000/tmp/TestHadoop";
-            Assert.Equal(uriString, _fileSystem.CreateUriForPath(uriString).AbsoluteUri);
+            string uriString = "hdfs://localhost:9000/tmp/TestHadoop";
+            Uri uri = new Uri(uriString);
+            Assert.Equal(uri, _fileSystem.CreateUriForPath(uriString));
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
@@ -160,8 +160,7 @@ namespace Org.Apache.REEF.IO.Tests
         public void CreateUriForPathWithPrefix()
         {
             string uriString = "hdfs://localhost:9000/tmp/TestHadoop";
-            Uri uri = new Uri(uriString);
-            Assert.Equal(uri, _fileSystem.CreateUriForPath(uriString));
+            Assert.Equal(new Uri(uriString), _fileSystem.CreateUriForPath(uriString));
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlockBlobFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlockBlobFileSystem.cs
@@ -191,7 +191,12 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
         /// <returns>The URI to the remote file</returns>
         public Uri CreateUriForPath(string path)
         {
-            return new Uri(_client.BaseUri.AbsoluteUri.TrimEnd('/') + '/' + path.Trim('/'));
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path), "Specified path is null");
+            }
+            var uriPrefix = GetUriPrefix();
+            return path.StartsWith(uriPrefix) ? new Uri(path) : new Uri(uriPrefix + '/' + path.Trim('/'));
         }
 
         /// <summary>
@@ -215,6 +220,11 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
             }
 
             return new FileStatus(lastModifiedTime.Value.DateTime, blobReference.Properties.Length);
+        }
+
+        private string GetUriPrefix()
+        {
+            return _client.BaseUri.AbsoluteUri.TrimEnd('/');
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlockBlobFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlockBlobFileSystem.cs
@@ -211,7 +211,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
 
             if (!resultUri.AbsoluteUri.StartsWith(_client.BaseUri.AbsoluteUri))
             {
-                throw new ArgumentException($"Given uri must begin with valid prefix ({_client.BaseUri.AbsoluteUri})", nameof(path));
+                throw new ArgumentException($"Given URI must begin with valid prefix ({_client.BaseUri.AbsoluteUri})", nameof(path));
             }
 
             if (resultUri.Segments.Count() < 2)

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlockBlobFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlockBlobFileSystem.cs
@@ -188,8 +188,9 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
         /// <summary>
         /// Creates a Uri using the relative path to the remote file (including the container),
         /// getting the absolute URI from the Blob client's base URI.
+        /// If path is null or the prefix doesn't match the base uri in the FileSystem, throw ArgumentException.
         /// </summary>
-        /// <param name="path">The relative path to the remote file, including the container</param>
+        /// <param name="path">The relative or absolute path to the remote file, including the container</param>
         /// <returns>The URI to the remote file</returns>
         public Uri CreateUriForPath(string path)
         {
@@ -206,6 +207,16 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
             catch (UriFormatException)
             {
                 resultUri = new Uri(_client.BaseUri, path);
+            }
+
+            if (!resultUri.AbsoluteUri.StartsWith(_client.BaseUri.AbsoluteUri))
+            {
+                throw new ArgumentException($"Given uri must begin with valid prefix ({_client.BaseUri.AbsoluteUri})", nameof(path));
+            }
+
+            if (resultUri.Segments.Count() < 2)
+            {
+                throw new ArgumentException("Input path must have a container name", nameof(path));
             }
 
             string containerName = resultUri.Segments[1].Trim(UrlPathSeparator);

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystem.cs
@@ -33,6 +33,11 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
         private readonly IDataLakeStoreClient _client;
         private readonly AdlsClient _adlsClient;
 
+        private string UriPrefix
+        {
+            get { return $"adl://{_client.AccountFQDN}"; }
+        }
+
         [Inject]
         private AzureDataLakeFileSystem(IDataLakeStoreClient client)
         {
@@ -192,7 +197,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
         /// <summary>
         /// Create Uri from a given file path.
         /// The file path can be full with prefix or relative without prefix.
-        /// If null is passed as the path, ArgumentException will be thrown.
+        /// If path is null or the prefix doesn't match the prefix in the FileSystem, throw ArgumentException.
         /// </summary>
         /// <exception cref="ArgumentNullException">If specified path is null</exception>
         public Uri CreateUriForPath(string path)
@@ -201,8 +206,24 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
             {
                 throw new ArgumentNullException(nameof(path), "Specified path is null");
             }
-            var uriPrefix = GetUriPrefix();
-            return path.StartsWith(uriPrefix) ? new Uri(path) : new Uri(uriPrefix + '/' + path.Trim('/'));
+
+            Uri resultUri = null;
+
+            try
+            {
+                resultUri = new Uri(path);
+            }
+            catch (UriFormatException)
+            {
+                resultUri = new Uri(new Uri(this.UriPrefix), path);
+            }
+
+            if (!resultUri.AbsoluteUri.StartsWith(this.UriPrefix))
+            {
+                throw new ArgumentException($"Given uri must begin with valid prefix ({this.UriPrefix})", nameof(path));
+            }
+
+            return resultUri;
         }
 
         /// <summary>
@@ -223,11 +244,6 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
             }
 
             return new FileStatus(entrySummary.LastModifiedTime.Value, entrySummary.Length);
-        }
-
-        private string GetUriPrefix()
-        {
-            return $"adl://{_client.AccountFQDN}";
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystem.cs
@@ -201,7 +201,8 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
             {
                 throw new ArgumentNullException(nameof(path), "Specified path is null");
             }
-            return new Uri($"{GetUriPrefix()}/{path.TrimStart('/')}");
+            var uriPrefix = GetUriPrefix();
+            return path.StartsWith(uriPrefix) ? new Uri(path) : new Uri(uriPrefix + '/' + path.Trim('/'));
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystem.cs
@@ -220,7 +220,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
 
             if (!resultUri.AbsoluteUri.StartsWith(this.UriPrefix))
             {
-                throw new ArgumentException($"Given uri must begin with valid prefix ({this.UriPrefix})", nameof(path));
+                throw new ArgumentException($"Given URI must begin with valid prefix ({this.UriPrefix})", nameof(path));
             }
 
             return resultUri;

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
@@ -55,7 +55,7 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
         /// <summary>
         /// Create Uri from a given file name
         /// If the path already contains prefix, use it directly and verify the prefix after it is created.
-        /// Otherwise add the prefix in fron of the relative path.
+        /// Otherwise add the prefix in front of the relative path.
         /// If path is null or the prefix doesn't match the prefix in the FileSystem, throw ArgumentException
         /// </summary>
         /// <param name="path"></param>
@@ -67,11 +67,8 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
             {
                 throw new ArgumentException("null path passed in CreateUriForPath");
             }
-
-            Uri uri;
-            uri = new Uri(path);
+            var uri = path.StartsWith(_uriPrefix) ? new Uri(path) : new Uri(_uriPrefix + '/' + path.Trim('/'));
             Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Uri {0} created in CreateUriForPath.", uri));
-
             return uri;
         }
 

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
@@ -62,13 +62,27 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
         /// <returns></returns>
         public Uri CreateUriForPath(string path)
         {
-            Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "CreateUriForPath with path: {0}, _uriPrefix: {1}.", path, _uriPrefix));
             if (path == null)
             {
-                throw new ArgumentException("null path passed in CreateUriForPath");
+                throw new ArgumentNullException("path");
             }
-            var uri = path.StartsWith(_uriPrefix) ? new Uri(path) : new Uri(_uriPrefix + '/' + path.Trim('/'));
-            Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Uri {0} created in CreateUriForPath.", uri));
+
+            Uri uri = null;
+            try
+            {
+                uri = new Uri(path);
+            }
+            catch (UriFormatException)
+            {
+                uri = new Uri(new Uri(_uriPrefix), path);
+            }
+
+            if (!uri.AbsoluteUri.StartsWith(_uriPrefix))
+            {
+                throw new ArgumentException($"Given uri does not begin with valid prefix ({_uriPrefix})");
+            }
+
+            Logger.Log(Level.Verbose, string.Format(CultureInfo.CurrentCulture, "Uri {0} created in CreateUriForPath for path {1}.", uri, path));
             return uri;
         }
 

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
@@ -64,7 +64,7 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
         {
             if (path == null)
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
 
             Uri uri = null;
@@ -79,10 +79,9 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
 
             if (!uri.AbsoluteUri.StartsWith(_uriPrefix))
             {
-                throw new ArgumentException($"Given uri does not begin with valid prefix ({_uriPrefix})");
+                throw new ArgumentException($"Given URI does not begin with valid prefix ({_uriPrefix})");
             }
 
-            Logger.Log(Level.Verbose, string.Format(CultureInfo.CurrentCulture, "Uri {0} created in CreateUriForPath for path {1}.", uri, path));
             return uri;
         }
 


### PR DESCRIPTION
…prefix is given path already contains it