### PR TITLE
[REEF-2033] Introduce configurable azure blob exponential retry policy

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystemE2E.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlockBlobFileSystemE2E.cs
@@ -67,28 +67,24 @@ namespace Org.Apache.REEF.IO.Tests
         private bool CheckBlobExists(ICloudBlob blob)
         {
             var task = blob.ExistsAsync();
-            task.Wait();
             return task.Result;
         }
 
         private bool CheckContainerExists(CloudBlobContainer container)
         {
             var task = container.ExistsAsync();
-            task.Wait();
             return task.Result;
         }
 
         private ICloudBlob GetBlobReferenceFromServer(CloudBlobContainer container, string blobName)
         {
             var task = container.GetBlobReferenceFromServerAsync(blobName);
-            task.Wait();
             return task.Result;
         }
 
         private string DownloadText(CloudBlockBlob blob)
         {
             var task = blob.DownloadTextAsync();
-            task.Wait();
             return task.Result;
         }
 
@@ -120,7 +116,6 @@ namespace Org.Apache.REEF.IO.Tests
             blob = container.GetBlockBlobReference(HelloFile);
             Assert.True(CheckBlobExists(blob));
             var readTask = blob.OpenReadAsync();
-            readTask.Wait();
             using (var reader = new StreamReader(readTask.Result))
             {
                 string streamText = reader.ReadToEnd();

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobClient.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobClient.cs
@@ -32,6 +32,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
     internal sealed class AzureCloudBlobClient : ICloudBlobClient
     {
         private readonly CloudBlobClient _client;
+        private readonly BlobRequestOptions _requestOptions;
 
         public StorageCredentials Credentials 
         { 
@@ -44,6 +45,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
         {
             _client = CloudStorageAccount.Parse(connectionString).CreateCloudBlobClient();
             _client.DefaultRequestOptions.RetryPolicy = retryPolicy;
+            _requestOptions = new BlobRequestOptions() { RetryPolicy = retryPolicy };
         }
 
         public Uri BaseUri
@@ -54,18 +56,17 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
         public ICloudBlob GetBlobReferenceFromServer(Uri blobUri)
         {
             var task = _client.GetBlobReferenceFromServerAsync(blobUri);
-            task.Wait();
             return task.Result;
         }
 
         public ICloudBlobContainer GetContainerReference(string containerName)
         {
-            return new AzureCloudBlobContainer(_client.GetContainerReference(containerName));
+            return new AzureCloudBlobContainer(_client.GetContainerReference(containerName), _requestOptions);
         }
 
         public ICloudBlockBlob GetBlockBlobReference(Uri uri)
         {
-            return new AzureCloudBlockBlob(uri, _client.Credentials);
+            return new AzureCloudBlockBlob(uri, _client.Credentials, _requestOptions);
         }
 
         public BlobResultSegment ListBlobsSegmented(

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobContainer.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobContainer.cs
@@ -25,22 +25,23 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
     internal sealed class AzureCloudBlobContainer : ICloudBlobContainer
     {
         private readonly CloudBlobContainer _container;
+        private readonly BlobRequestOptions _requestOptions;
 
-        public AzureCloudBlobContainer(CloudBlobContainer container)
+        public AzureCloudBlobContainer(CloudBlobContainer container, BlobRequestOptions requestOptions)
         {
             _container = container;
+            _requestOptions = requestOptions;
         }
 
         public bool CreateIfNotExists()
         {
-            var task = _container.CreateIfNotExistsAsync();
-            task.Wait();
+            var task = _container.CreateIfNotExistsAsync(_requestOptions, null);
             return task.Result;
         }
 
         public void DeleteIfExists()
         {
-            _container.DeleteIfExistsAsync().Wait();
+            _container.DeleteIfExistsAsync(null, _requestOptions, null).Wait();
         }
 
         public ICloudBlobDirectory GetDirectoryReference(string directoryName)

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobDirectory.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobDirectory.cs
@@ -40,7 +40,6 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
         public IEnumerable<IListBlobItem> ListBlobs(bool useFlatListing = false)
         {
             var task = _directory.ListBlobsSegmentedAsync(useFlatListing, BlobListingDetails.All, null, null, null, null);
-            task.Wait();
             return task.Result.Results;
         }
     }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/RetryPolicy/Exponential/ExponentialRetryPolicy.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/RetryPolicy/Exponential/ExponentialRetryPolicy.cs
@@ -20,17 +20,23 @@ using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using Org.Apache.REEF.Tang.Annotations;
 
-namespace Org.Apache.REEF.IO.FileSystem.AzureBlob.RetryPolicy
+namespace Org.Apache.REEF.IO.FileSystem.AzureBlob.RetryPolicy.Exponential
 {
-    internal class DefaultAzureBlobRetryPolicy : IAzureBlobRetryPolicy
+    /// <summary>
+    /// Represents a retry policy that performs a specified number of retries,
+    /// using a randomized exponential back off scheme to determine the interval between retries.
+    /// </summary>
+    internal sealed class ExponentialRetryPolicy : IAzureBlobRetryPolicy
     {
         private readonly IRetryPolicy _retryPolicy;
 
         [Inject]
-        private DefaultAzureBlobRetryPolicy()
+        private ExponentialRetryPolicy(
+            [Parameter(typeof(ExponentialRetryPolicyParameterNames.RetryCount))] int retryCount,
+            [Parameter(typeof(ExponentialRetryPolicyParameterNames.RetryInterval))] double retryInterval)
         {
-            _retryPolicy = new ExponentialRetry();
-        } 
+            _retryPolicy = new ExponentialRetry(TimeSpan.FromSeconds(retryInterval), retryCount);
+        }
 
         public IRetryPolicy CreateInstance()
         {
@@ -41,6 +47,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob.RetryPolicy
             OperationContext operationContext)
         {
             return _retryPolicy.ShouldRetry(currentRetryCount, statusCode, lastException, out retryInterval, operationContext);
+
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/RetryPolicy/Exponential/ExponentialRetryPolicyConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/RetryPolicy/Exponential/ExponentialRetryPolicyConfiguration.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Util;
+
+namespace Org.Apache.REEF.IO.FileSystem.AzureBlob.RetryPolicy.Exponential
+{
+    public sealed class ExponentialRetryPolicyConfiguration : ConfigurationModuleBuilder
+    {
+        /// <summary>
+        /// The exponential retry count.
+        /// </summary>
+        public static readonly OptionalParameter<int> RetryCount = new OptionalParameter<int>();
+
+        /// <summary>
+        /// The exponential retry interval in seconds.
+        /// </summary>
+        public static readonly OptionalParameter<double> RetryInterval = new OptionalParameter<double>();
+
+        /// <summary>
+        /// Configuration Module for ExponentialRetryPolicy implementation of IAzureBlobRetryPolicy.
+        /// </summary>
+        public static ConfigurationModule ConfigurationModule = new ExponentialRetryPolicyConfiguration()
+            .BindImplementation(GenericType<IAzureBlobRetryPolicy>.Class, GenericType<ExponentialRetryPolicy>.Class)
+            .BindNamedParameter(GenericType<ExponentialRetryPolicyParameterNames.RetryCount>.Class, RetryCount)
+            .BindNamedParameter(GenericType<ExponentialRetryPolicyParameterNames.RetryInterval>.Class, RetryInterval)
+            .Build();
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/RetryPolicy/Exponential/ExponentialRetryPolicyParameterNames.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/RetryPolicy/Exponential/ExponentialRetryPolicyParameterNames.cs
@@ -15,32 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using Org.Apache.REEF.Tang.Annotations;
 
-namespace Org.Apache.REEF.IO.FileSystem.AzureBlob.RetryPolicy
+namespace Org.Apache.REEF.IO.FileSystem.AzureBlob.RetryPolicy.Exponential
 {
-    internal class DefaultAzureBlobRetryPolicy : IAzureBlobRetryPolicy
+    public static class ExponentialRetryPolicyParameterNames
     {
-        private readonly IRetryPolicy _retryPolicy;
-
-        [Inject]
-        private DefaultAzureBlobRetryPolicy()
+        [NamedParameter("The exponential retry count", "retryCount", defaultValue: "3")]
+        public class RetryCount : Name<int>
         {
-            _retryPolicy = new ExponentialRetry();
-        } 
-
-        public IRetryPolicy CreateInstance()
-        {
-            return _retryPolicy;
         }
 
-        public bool ShouldRetry(int currentRetryCount, int statusCode, Exception lastException, out TimeSpan retryInterval,
-            OperationContext operationContext)
+        [NamedParameter("The exponential retry interval in seconds", "retryInterval", defaultValue: "4")]
+        public class RetryInterval : Name<double>
         {
-            return _retryPolicy.ShouldRetry(currentRetryCount, statusCode, lastException, out retryInterval, operationContext);
         }
     }
 }


### PR DESCRIPTION
[REEF-2033] Introduce configurable azure blob exponential retry policy
  
Currently, the AzureBlob retry policy defaults to Azure Blob Client's default ExponentialRetryPolicy which has retry count as 3 and retry interval as 4 seconds. Higher load jobs require custom setting of these values to overcome azure blob throttling - https://issues.apache.org/jira/projects/REEF/issues/REEF-2017. This change allows user to set their own retry count and intervals for azure blob retry policy
  
JIRA:
  [REEF-2033](https://issues.apache.org/jira/browse/REEF-2033)
 
Pull request:
  This closes [1470](https://github.com/apache/reef/pull/1470)