### PR TITLE
[REEF-2034] AdlsAccountName Expects FQDN

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureDataLakeFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureDataLakeFileSystem.cs
@@ -199,7 +199,7 @@ namespace Org.Apache.REEF.IO.Tests
         {
             string dirStructure = FakeFileUri.AbsolutePath;
             Uri createdUri = _fs.CreateUriForPath(dirStructure);
-            Assert.Equal(createdUri, new Uri($"adl://{_context.AdlAccountFQDN}{dirStructure}"));
+            Assert.Equal(createdUri, new Uri($"adl://{_context.AdlsAccountFqdn}{dirStructure}"));
         }
 
         [Fact]
@@ -210,13 +210,13 @@ namespace Org.Apache.REEF.IO.Tests
 
         private sealed class TestContext
         {
-            public readonly string AdlAccountFQDN = "adlAccount.azuredatalakestore.net";
+            public readonly string AdlsAccountFqdn = "adlsAccount.azuredatalakestore.net";
             public readonly AdlsClient MockAdlsClient = Microsoft.Azure.DataLake.Store.MockAdlsFileSystem.MockAdlsClient.GetMockClient();
 
             public AzureDataLakeFileSystem GetAdlsFileSystem()
             {
                 var conf = AzureDataLakeFileSystemConfiguration.ConfigurationModule
-                     .Set(AzureDataLakeFileSystemConfiguration.DataLakeStorageAccountFQDN, "adlsAccountFQDN")
+                     .Set(AzureDataLakeFileSystemConfiguration.DataLakeStorageAccountFqdn, "adlsAccountFqdn")
                     .Set(AzureDataLakeFileSystemConfiguration.Tenant, "tenant")
                     .Set(AzureDataLakeFileSystemConfiguration.ClientId, "clientId")
                     .Set(AzureDataLakeFileSystemConfiguration.SecretKey, "secretKey")
@@ -225,7 +225,7 @@ namespace Org.Apache.REEF.IO.Tests
                 var testDataLakeStoreClient = Substitute.For<IDataLakeStoreClient>();
                 injector.BindVolatileInstance(testDataLakeStoreClient);
                 testDataLakeStoreClient.GetAdlsClient().ReturnsForAnyArgs(MockAdlsClient);
-                testDataLakeStoreClient.AccountFQDN.Returns(AdlAccountFQDN);
+                testDataLakeStoreClient.AccountFqdn.Returns(AdlsAccountFqdn);
                 var fs = injector.GetInstance<AzureDataLakeFileSystem>();
                 return fs;
             }

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureDataLakeFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureDataLakeFileSystem.cs
@@ -199,7 +199,7 @@ namespace Org.Apache.REEF.IO.Tests
         {
             string dirStructure = FakeFileUri.AbsolutePath;
             Uri createdUri = _fs.CreateUriForPath(dirStructure);
-            Assert.Equal(createdUri, new Uri($"adl://{_context.AdlAccountName}{dirStructure}"));
+            Assert.Equal(createdUri, new Uri($"adl://{_context.AdlAccountFQDN}{dirStructure}"));
         }
 
         [Fact]
@@ -210,13 +210,13 @@ namespace Org.Apache.REEF.IO.Tests
 
         private sealed class TestContext
         {
-            public readonly string AdlAccountName = "adlAccount";
+            public readonly string AdlAccountFQDN = "adlAccount.azuredatalakestore.net";
             public readonly AdlsClient MockAdlsClient = Microsoft.Azure.DataLake.Store.MockAdlsFileSystem.MockAdlsClient.GetMockClient();
 
             public AzureDataLakeFileSystem GetAdlsFileSystem()
             {
                 var conf = AzureDataLakeFileSystemConfiguration.ConfigurationModule
-                     .Set(AzureDataLakeFileSystemConfiguration.DataLakeStorageAccountName, "adlsAccountName")
+                     .Set(AzureDataLakeFileSystemConfiguration.DataLakeStorageAccountFQDN, "adlsAccountFQDN")
                     .Set(AzureDataLakeFileSystemConfiguration.Tenant, "tenant")
                     .Set(AzureDataLakeFileSystemConfiguration.ClientId, "clientId")
                     .Set(AzureDataLakeFileSystemConfiguration.SecretKey, "secretKey")
@@ -225,7 +225,7 @@ namespace Org.Apache.REEF.IO.Tests
                 var testDataLakeStoreClient = Substitute.For<IDataLakeStoreClient>();
                 injector.BindVolatileInstance(testDataLakeStoreClient);
                 testDataLakeStoreClient.GetAdlsClient().ReturnsForAnyArgs(MockAdlsClient);
-                testDataLakeStoreClient.AccountFQDN.Returns(AdlAccountName);
+                testDataLakeStoreClient.AccountFQDN.Returns(AdlAccountFQDN);
                 var fs = injector.GetInstance<AzureDataLakeFileSystem>();
                 return fs;
             }

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureDataLakeFileSystemE2E.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureDataLakeFileSystemE2E.cs
@@ -49,7 +49,7 @@ namespace Org.Apache.REEF.IO.Tests
             // use its authentication key as the SecretKey
             // https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal#get-application-id-and-authentication-key
             // Fill in before running test!
-            const string AdlsAccountName = "#####.azuredatalakestore.net";
+            const string AdlsAccountFQDN = "#####.azuredatalakestore.net";
             const string Tenant = "microsoft.onmicrosoft.com";
             const string TokenAudience = @"https://datalake.azure.net/";
             const string ClientId = "########-####-####-####-############"; // e.g. "c2897d56-5eef-4030-8b7a-46b5c0acd05c"
@@ -58,7 +58,7 @@ namespace Org.Apache.REEF.IO.Tests
             _defaultFolderName = "reef-test-folder-" + Guid.NewGuid();
 
             IConfiguration conf = AzureDataLakeFileSystemConfiguration.ConfigurationModule
-                .Set(AzureDataLakeFileSystemConfiguration.DataLakeStorageAccountName, AdlsAccountName)
+                .Set(AzureDataLakeFileSystemConfiguration.DataLakeStorageAccountFQDN, AdlsAccountFQDN)
                 .Set(AzureDataLakeFileSystemConfiguration.Tenant, Tenant)
                 .Set(AzureDataLakeFileSystemConfiguration.ClientId, ClientId)
                 .Set(AzureDataLakeFileSystemConfiguration.SecretKey, SecretKey)
@@ -67,7 +67,7 @@ namespace Org.Apache.REEF.IO.Tests
             _fileSystem = TangFactory.GetTang().NewInjector(conf).GetInstance<AzureDataLakeFileSystem>();
 
             ServiceClientCredentials adlCreds = GetCredsSpiSecretKey(Tenant, new Uri(TokenAudience), ClientId, SecretKey);
-            _adlsClient = AdlsClient.CreateClient(AdlsAccountName, adlCreds);
+            _adlsClient = AdlsClient.CreateClient(AdlsAccountFQDN, adlCreds);
         }
 
         public void Dispose()

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureDataLakeFileSystemE2E.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureDataLakeFileSystemE2E.cs
@@ -49,7 +49,7 @@ namespace Org.Apache.REEF.IO.Tests
             // use its authentication key as the SecretKey
             // https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal#get-application-id-and-authentication-key
             // Fill in before running test!
-            const string AdlsAccountFQDN = "#####.azuredatalakestore.net";
+            const string AdlsAccountFqdn = "#####.azuredatalakestore.net";
             const string Tenant = "microsoft.onmicrosoft.com";
             const string TokenAudience = @"https://datalake.azure.net/";
             const string ClientId = "########-####-####-####-############"; // e.g. "c2897d56-5eef-4030-8b7a-46b5c0acd05c"
@@ -58,7 +58,7 @@ namespace Org.Apache.REEF.IO.Tests
             _defaultFolderName = "reef-test-folder-" + Guid.NewGuid();
 
             IConfiguration conf = AzureDataLakeFileSystemConfiguration.ConfigurationModule
-                .Set(AzureDataLakeFileSystemConfiguration.DataLakeStorageAccountFQDN, AdlsAccountFQDN)
+                .Set(AzureDataLakeFileSystemConfiguration.DataLakeStorageAccountFqdn, AdlsAccountFqdn)
                 .Set(AzureDataLakeFileSystemConfiguration.Tenant, Tenant)
                 .Set(AzureDataLakeFileSystemConfiguration.ClientId, ClientId)
                 .Set(AzureDataLakeFileSystemConfiguration.SecretKey, SecretKey)
@@ -67,7 +67,7 @@ namespace Org.Apache.REEF.IO.Tests
             _fileSystem = TangFactory.GetTang().NewInjector(conf).GetInstance<AzureDataLakeFileSystem>();
 
             ServiceClientCredentials adlCreds = GetCredsSpiSecretKey(Tenant, new Uri(TokenAudience), ClientId, SecretKey);
-            _adlsClient = AdlsClient.CreateClient(AdlsAccountFQDN, adlCreds);
+            _adlsClient = AdlsClient.CreateClient(AdlsAccountFqdn, adlCreds);
         }
 
         public void Dispose()

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystem.cs
@@ -239,7 +239,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
 
         private string GetUriPrefix()
         {
-            return $"adl://{_client.AccountFQDN}";
+            return $"adl://{_client.AccountFqdn}";
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystemConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystemConfiguration.cs
@@ -31,7 +31,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
         /// <summary>
         /// The account FQDN to be used to connect to the data lake store
         /// </summary>
-        public static readonly RequiredParameter<string> DataLakeStorageAccountFQDN = new RequiredParameter<string>();
+        public static readonly RequiredParameter<string> DataLakeStorageAccountFqdn = new RequiredParameter<string>();
 
         /// <summary>
         /// The Tenant to be used to authenticate with Azure
@@ -61,7 +61,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
             .BindSetEntry<DriverConfigurationProviders, AzureDataLakeFileSystemConfigurationProvider, IConfigurationProvider>(
                 GenericType<DriverConfigurationProviders>.Class, GenericType<AzureDataLakeFileSystemConfigurationProvider>.Class)
             .BindImplementation(GenericType<IFileSystem>.Class, GenericType<AzureDataLakeFileSystem>.Class)
-            .BindNamedParameter(GenericType<DataLakeStorageAccountFQDN>.Class, DataLakeStorageAccountFQDN)
+            .BindNamedParameter(GenericType<DataLakeStorageAccountFqdn>.Class, DataLakeStorageAccountFqdn)
             .BindNamedParameter(GenericType<Tenant>.Class, Tenant)
             .BindNamedParameter(GenericType<ClientId>.Class, ClientId)
             .BindNamedParameter(GenericType<SecretKey>.Class, SecretKey)

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystemConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystemConfiguration.cs
@@ -31,7 +31,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
         /// <summary>
         /// The account FQDN to be used to connect to the data lake store
         /// </summary>
-        public static readonly RequiredParameter<string> DataLakeStorageAccountName = new RequiredParameter<string>();
+        public static readonly RequiredParameter<string> DataLakeStorageAccountFQDN = new RequiredParameter<string>();
 
         /// <summary>
         /// The Tenant to be used to authenticate with Azure
@@ -61,7 +61,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
             .BindSetEntry<DriverConfigurationProviders, AzureDataLakeFileSystemConfigurationProvider, IConfigurationProvider>(
                 GenericType<DriverConfigurationProviders>.Class, GenericType<AzureDataLakeFileSystemConfigurationProvider>.Class)
             .BindImplementation(GenericType<IFileSystem>.Class, GenericType<AzureDataLakeFileSystem>.Class)
-            .BindNamedParameter(GenericType<DataLakeStorageAccountName>.Class, DataLakeStorageAccountName)
+            .BindNamedParameter(GenericType<DataLakeStorageAccountFQDN>.Class, DataLakeStorageAccountFQDN)
             .BindNamedParameter(GenericType<Tenant>.Class, Tenant)
             .BindNamedParameter(GenericType<ClientId>.Class, ClientId)
             .BindNamedParameter(GenericType<SecretKey>.Class, SecretKey)

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystemConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystemConfigurationProvider.cs
@@ -35,7 +35,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
 
         [Inject]
         private AzureDataLakeFileSystemConfigurationProvider(
-            [Parameter(typeof(DataLakeStorageAccountFQDN))] string adlsAccountFQDN,
+            [Parameter(typeof(DataLakeStorageAccountFqdn))] string adlsAccountFqdn,
             [Parameter(typeof(Tenant))] string tenant,
             [Parameter(typeof(ClientId))] string clientId,
             [Parameter(typeof(SecretKey))] string secretKey,
@@ -44,7 +44,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
             _configuration = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindImplementation(GenericType<IFileSystem>.Class, GenericType<AzureDataLakeFileSystem>.Class)
                 .BindImplementation(GenericType<IAdlsCredentials>.Class, GenericType<SecretKeyAdlsCredentials>.Class)
-                .BindStringNamedParam<DataLakeStorageAccountFQDN>(adlsAccountFQDN)
+                .BindStringNamedParam<DataLakeStorageAccountFqdn>(adlsAccountFqdn)
                 .BindStringNamedParam<Tenant>(tenant)
                 .BindStringNamedParam<ClientId>(clientId)
                 .BindStringNamedParam<SecretKey>(secretKey)

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystemConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeFileSystemConfigurationProvider.cs
@@ -35,7 +35,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
 
         [Inject]
         private AzureDataLakeFileSystemConfigurationProvider(
-            [Parameter(typeof(DataLakeStorageAccountName))] string adlsAccountName,
+            [Parameter(typeof(DataLakeStorageAccountFQDN))] string adlsAccountFQDN,
             [Parameter(typeof(Tenant))] string tenant,
             [Parameter(typeof(ClientId))] string clientId,
             [Parameter(typeof(SecretKey))] string secretKey,
@@ -44,7 +44,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
             _configuration = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindImplementation(GenericType<IFileSystem>.Class, GenericType<AzureDataLakeFileSystem>.Class)
                 .BindImplementation(GenericType<IAdlsCredentials>.Class, GenericType<SecretKeyAdlsCredentials>.Class)
-                .BindStringNamedParam<DataLakeStorageAccountName>(adlsAccountName)
+                .BindStringNamedParam<DataLakeStorageAccountFQDN>(adlsAccountFQDN)
                 .BindStringNamedParam<Tenant>(tenant)
                 .BindStringNamedParam<ClientId>(clientId)
                 .BindStringNamedParam<SecretKey>(secretKey)

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeStoreClient.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeStoreClient.cs
@@ -29,9 +29,9 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
         private readonly AdlsClient _adlsClient;
 
         [Inject]
-        private AzureDataLakeStoreClient([Parameter(typeof(DataLakeStorageAccountName))] string adlsAccountName, IAdlsCredentials adlsCredentials)
+        private AzureDataLakeStoreClient([Parameter(typeof(DataLakeStorageAccountFQDN))] string adlsAccountFQDN, IAdlsCredentials adlsCredentials)
         {
-            _adlsClient = AdlsClient.CreateClient(adlsAccountName, adlsCredentials.Credentials);
+            _adlsClient = AdlsClient.CreateClient(adlsAccountFQDN, adlsCredentials.Credentials);
         }
 
         public AdlsClient GetAdlsClient()

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeStoreClient.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/AzureDataLakeStoreClient.cs
@@ -29,9 +29,9 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
         private readonly AdlsClient _adlsClient;
 
         [Inject]
-        private AzureDataLakeStoreClient([Parameter(typeof(DataLakeStorageAccountFQDN))] string adlsAccountFQDN, IAdlsCredentials adlsCredentials)
+        private AzureDataLakeStoreClient([Parameter(typeof(DataLakeStorageAccountFqdn))] string adlsAccountFqdn, IAdlsCredentials adlsCredentials)
         {
-            _adlsClient = AdlsClient.CreateClient(adlsAccountFQDN, adlsCredentials.Credentials);
+            _adlsClient = AdlsClient.CreateClient(adlsAccountFqdn, adlsCredentials.Credentials);
         }
 
         public AdlsClient GetAdlsClient()
@@ -39,6 +39,6 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
             return _adlsClient;
         }
 
-        public string AccountFQDN => _adlsClient.AccountFQDN;
+        public string AccountFqdn => _adlsClient.AccountFQDN;
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/IDataLakeStoreClient.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/IDataLakeStoreClient.cs
@@ -31,6 +31,6 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
         /// <summary>
         /// Returns the account name for the AdlsClient.
         /// </summary>
-        string AccountFQDN { get; }
+        string AccountFqdn { get; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/IDataLakeStoreClient.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/IDataLakeStoreClient.cs
@@ -29,7 +29,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake
         AdlsClient GetAdlsClient();
 
         /// <summary>
-        /// Returns the account name for the AdlsClient.
+        /// Returns the account FQDN for the AdlsClient.
         /// </summary>
         string AccountFqdn { get; }
     }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/Parameters/DataLakeStorageAccountFQDN.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/Parameters/DataLakeStorageAccountFQDN.cs
@@ -23,7 +23,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake.Parameters
     /// The account FQDN to be used to connect to the data lake store
     /// </summary>
     [NamedParameter("The account FQDN to be used to connect to the data lake store")]
-    internal sealed class DataLakeStorageAccountName : Name<string>
+    internal sealed class DataLakeStorageAccountFQDN : Name<string>
     {
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/Parameters/DataLakeStorageAccountFqdn.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureDataLake/Parameters/DataLakeStorageAccountFqdn.cs
@@ -23,7 +23,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureDataLake.Parameters
     /// The account FQDN to be used to connect to the data lake store
     /// </summary>
     [NamedParameter("The account FQDN to be used to connect to the data lake store")]
-    internal sealed class DataLakeStorageAccountFQDN : Name<string>
+    internal sealed class DataLakeStorageAccountFqdn : Name<string>
     {
     }
 }


### PR DESCRIPTION
This addressed the issue by renaming the parameter AdlsAccountName to
AdlsAccountFQDN for clarity.

JIRA:
  [REEF-2034](https://issues.apache.org/jira/browse/REEF-2034)

Pull request:
  This closes #