### PR TITLE
[REEF-2035] BlobFs parameters should be account name and key

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/YARN/HDI/HDInsightClientConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/HDI/HDInsightClientConfiguration.cs
@@ -76,7 +76,7 @@ namespace Org.Apache.REEF.Client.YARN.HDI
                 GenericType<HDInsightCommandLineEnvironment>.Class)
             .BindImplementation(GenericType<IResourceFileRemoteUrlToClusterUrlConverter>.Class,
                 GenericType<HDInsightResourceFileRemoteUrlToClusterUrlConverter>.Class)
-            .Merge(AzureBlockBlobFileSystemConfiguration.ConfigurationModule)
+            .Merge(AzureBlobFileSystemConfiguration.ConfigurationModule)
             .Build();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
@@ -113,7 +113,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
                         .Set(HDInsightClientConfiguration.HDInsightPasswordParameter, @"pwd")
                         .Set(HDInsightClientConfiguration.HDInsightUsernameParameter, @"foo")
                         .Set(HDInsightClientConfiguration.HDInsightUrlParameter, @"https://foo.azurehdinsight.net/")
-                        .Set(HDInsightClientConfiguration.JobSubmissionDirectoryPrefix, string.Format(@"/{0}/tmp", containerName))
+                        .Set(HDInsightClientConfiguration.JobSubmissionDirectoryPrefix, $@"/{containerName}/tmp")
                         .Set(AzureBlobFileSystemConfiguration.AccountName, blobStorageAccountName)
                         .Set(AzureBlobFileSystemConfiguration.AccountKey, blobStorageAccountKey)
                         .Build();

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
@@ -103,16 +103,18 @@ namespace Org.Apache.REEF.Examples.HelloREEF
                     return YARNClientConfiguration.ConfigurationModuleYARNRest.Build();
                 case HDInsight:
                     // To run against HDInsight please replace placeholders below, with actual values for
-                    // connection string, container name (available at Azure portal) and HDInsight
+                    // blob storage account name and key, container name (available at Azure portal) and HDInsight
                     // credentials (username and password)
-                    const string connectionString = "ConnString";
-                    const string continerName = "foo";
+                    const string blobStorageAccountName = "name";
+                    const string blobStorageAccountKey = "key";
+                    const string containerName = "foo";
                     return HDInsightClientConfiguration.ConfigurationModule
                         .Set(HDInsightClientConfiguration.HDInsightPasswordParameter, @"pwd")
                         .Set(HDInsightClientConfiguration.HDInsightUsernameParameter, @"foo")
                         .Set(HDInsightClientConfiguration.HDInsightUrlParameter, @"https://foo.azurehdinsight.net/")
-                        .Set(HDInsightClientConfiguration.JobSubmissionDirectoryPrefix, string.Format(@"/{0}/tmp", continerName))
-                        .Set(AzureBlockBlobFileSystemConfiguration.ConnectionString, connectionString)
+                        .Set(HDInsightClientConfiguration.JobSubmissionDirectoryPrefix, string.Format(@"/{0}/tmp", containerName))
+                        .Set(AzureBlobFileSystemConfiguration.AccountName, blobStorageAccountName)
+                        .Set(AzureBlobFileSystemConfiguration.AccountKey, blobStorageAccountKey)
                         .Build();
                 case AzureBatch:
                     return AzureBatchRuntimeClientConfiguration.ConfigurationModule

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlobFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlobFileSystem.cs
@@ -142,13 +142,14 @@ namespace Org.Apache.REEF.IO.Tests
 
             public IFileSystem GetAzureFileSystem()
             {
-                var conf = AzureBlockBlobFileSystemConfiguration.ConfigurationModule
-                    .Set(AzureBlockBlobFileSystemConfiguration.ConnectionString, "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;")
+                var conf = AzureBlobFileSystemConfiguration.ConfigurationModule
+                    .Set(AzureBlobFileSystemConfiguration.AccountName, "devstoreaccount1")
+                    .Set(AzureBlobFileSystemConfiguration.AccountKey, "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==")
                     .Build();
 
                 var injector = TangFactory.GetTang().NewInjector(conf);
                 injector.BindVolatileInstance(TestCloudBlobClient);
-                var fs = injector.GetInstance<AzureBlockBlobFileSystem>();
+                var fs = injector.GetInstance<AzureBlobFileSystem>();
                 TestCloudBlobClient.BaseUri.ReturnsForAnyArgs(new Uri(FakeUri.GetLeftPart(UriPartial.Authority)));
                 TestCloudBlockBlob.Open().Returns(TestOpenStream);
                 TestCloudBlockBlob.Create().Returns(TestCreateStream);

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlobFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlobFileSystem.cs
@@ -180,8 +180,8 @@ namespace Org.Apache.REEF.IO.Tests
             public IFileSystem GetAzureFileSystem()
             {
                 var conf = AzureBlobFileSystemConfiguration.ConfigurationModule
-                    .Set(AzureBlobFileSystemConfiguration.AccountName, "devstoreaccount1")
-                    .Set(AzureBlobFileSystemConfiguration.AccountKey, "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==")
+                    .Set(AzureBlobFileSystemConfiguration.AccountName, "accountName")
+                    .Set(AzureBlobFileSystemConfiguration.AccountKey, "accountKey")
                     .Build();
 
                 var injector = TangFactory.GetTang().NewInjector(conf);

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlobFileSystemE2E.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestAzureBlobFileSystemE2E.cs
@@ -39,17 +39,21 @@ namespace Org.Apache.REEF.IO.Tests
         private IFileSystem _fileSystem;
         private CloudBlobClient _client;
         private CloudBlobContainer _container;
+        private const string AzureBlobConnectionFormat = "DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};";
 
         public TestAzureBlockBlobFileSystemE2E()
         {
             // Fill in before running test!
-            const string ConnectionString = "DefaultEndpointsProtocol=http;AccountName=myAccount;AccountKey=myKey;";
+            const string AccountName = "";
+            const string AccountKey = "";
+            string ConnectionString = string.Format(AzureBlobConnectionFormat, AccountName, AccountKey);
             var defaultContainerName = "reef-test-container-" + Guid.NewGuid();
-            var conf = AzureBlockBlobFileSystemConfiguration.ConfigurationModule
-                .Set(AzureBlockBlobFileSystemConfiguration.ConnectionString, ConnectionString)
+            var conf = AzureBlobFileSystemConfiguration.ConfigurationModule
+                .Set(AzureBlobFileSystemConfiguration.AccountName, AccountName)
+                .Set(AzureBlobFileSystemConfiguration.AccountKey, AccountKey)
                 .Build();
 
-            _fileSystem = TangFactory.GetTang().NewInjector(conf).GetInstance<AzureBlockBlobFileSystem>();
+            _fileSystem = TangFactory.GetTang().NewInjector(conf).GetInstance<AzureBlobFileSystem>();
             _client = CloudStorageAccount.Parse(ConnectionString).CreateCloudBlobClient();
             _container = _client.GetContainerReference(defaultContainerName);
             _container.CreateIfNotExists();

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlobFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlobFileSystem.cs
@@ -31,12 +31,12 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
     /// This particular File System implementation only supports 
     /// block blob operations
     /// </summary>
-    internal sealed class AzureBlockBlobFileSystem : IFileSystem
+    internal sealed class AzureBlobFileSystem : IFileSystem
     {
         private readonly ICloudBlobClient _client;
 
         [Inject]
-        private AzureBlockBlobFileSystem(ICloudBlobClient client)
+        private AzureBlobFileSystem(ICloudBlobClient client)
         {
             _client = client;
         }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlobFileSystemConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlobFileSystemConfiguration.cs
@@ -30,9 +30,10 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
     /// <remarks>
     /// Stream-based operations are not supported.
     /// </remarks>
-    public sealed class AzureBlockBlobFileSystemConfiguration : ConfigurationModuleBuilder
+    public sealed class AzureBlobFileSystemConfiguration : ConfigurationModuleBuilder
     {
-        public static readonly RequiredParameter<string> ConnectionString = new RequiredParameter<string>();
+        public static readonly RequiredParameter<string> AccountName = new RequiredParameter<string>();
+        public static readonly RequiredParameter<string> AccountKey = new RequiredParameter<string>();
 
         public static readonly OptionalImpl<IAzureBlobRetryPolicy> RetryPolicy = new OptionalImpl<IAzureBlobRetryPolicy>(); 
 
@@ -40,11 +41,12 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
         /// Set AzureBlockBlobFileSystemProvider to DriverConfigurationProviders.
         /// Set all the parameters needed for injecting AzureBlockBlobFileSystemProvider.
         /// </summary>
-        public static readonly ConfigurationModule ConfigurationModule = new AzureBlockBlobFileSystemConfiguration()
-            .BindSetEntry<DriverConfigurationProviders, AzureBlockBlobFileSystemConfigurationProvider, IConfigurationProvider>(
-                GenericType<DriverConfigurationProviders>.Class, GenericType<AzureBlockBlobFileSystemConfigurationProvider>.Class)
-            .BindImplementation(GenericType<IFileSystem>.Class, GenericType<AzureBlockBlobFileSystem>.Class)
-            .BindNamedParameter(GenericType<AzureStorageConnectionString>.Class, ConnectionString)
+        public static readonly ConfigurationModule ConfigurationModule = new AzureBlobFileSystemConfiguration()
+            .BindSetEntry<DriverConfigurationProviders, AzureBlobFileSystemConfigurationProvider, IConfigurationProvider>(
+                GenericType<DriverConfigurationProviders>.Class, GenericType<AzureBlobFileSystemConfigurationProvider>.Class)
+            .BindImplementation(GenericType<IFileSystem>.Class, GenericType<AzureBlobFileSystem>.Class)
+            .BindNamedParameter(GenericType<AzureBlobStorageAccountName>.Class, AccountName)
+            .BindNamedParameter(GenericType<AzureBlobStorageAccountKey>.Class, AccountKey)
             .BindImplementation(GenericType<IAzureBlobRetryPolicy>.Class, RetryPolicy)
             .Build();
     }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlobFileSystemConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureBlobFileSystemConfigurationProvider.cs
@@ -30,20 +30,22 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
     /// The client that is going to use AzureBlockBlobFileSystem in its driver and evaluators should set 
     /// configuration data through AzureBlockBlobFileSystem configuration module in the client's configuration
     /// </summary>
-    internal sealed class AzureBlockBlobFileSystemConfigurationProvider : IConfigurationProvider
+    internal sealed class AzureBlobFileSystemConfigurationProvider : IConfigurationProvider
     {
         private readonly IConfiguration _configuration;
 
         [Inject]
-        private AzureBlockBlobFileSystemConfigurationProvider(
-            [Parameter(typeof(AzureStorageConnectionString))] string connectionString,
+        private AzureBlobFileSystemConfigurationProvider(
+            [Parameter(typeof(AzureBlobStorageAccountName))] string accountName,
+            [Parameter(typeof(AzureBlobStorageAccountKey))] string accountKey,
             IAzureBlobRetryPolicy retryPolicy)
         {
             _configuration = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindImplementation(GenericType<IFileSystem>.Class, GenericType<AzureBlockBlobFileSystem>.Class)
+                .BindImplementation(GenericType<IFileSystem>.Class, GenericType<AzureBlobFileSystem>.Class)
                 .BindImplementation(typeof(IAzureBlobRetryPolicy), retryPolicy.GetType())
-                .BindStringNamedParam<AzureStorageConnectionString>(connectionString)
-                .BindSetEntry<EvaluatorConfigurationProviders, AzureBlockBlobFileSystemConfigurationProvider, IConfigurationProvider>()
+                .BindStringNamedParam<AzureBlobStorageAccountName>(accountName)
+                .BindStringNamedParam<AzureBlobStorageAccountKey>(accountKey)
+                .BindSetEntry<EvaluatorConfigurationProviders, AzureBlobFileSystemConfigurationProvider, IConfigurationProvider>()
                 .Build();
         }
 

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobClient.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/AzureCloudBlobClient.cs
@@ -31,6 +31,7 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
     internal sealed class AzureCloudBlobClient : ICloudBlobClient
     {
         private readonly CloudBlobClient _client;
+        private const string AzureBlobConnectionFormat = "DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};";
 
         public StorageCredentials Credentials 
         { 
@@ -38,9 +39,11 @@ namespace Org.Apache.REEF.IO.FileSystem.AzureBlob
         }
 
         [Inject]
-        private AzureCloudBlobClient([Parameter(typeof(AzureStorageConnectionString))] string connectionString,
+        private AzureCloudBlobClient([Parameter(typeof(AzureBlobStorageAccountName))] string accountName,
+                                     [Parameter(typeof(AzureBlobStorageAccountKey))] string accountKey,
                                      IAzureBlobRetryPolicy retryPolicy)
         {
+            var connectionString = string.Format(AzureBlobConnectionFormat, accountName, accountKey);
             _client = CloudStorageAccount.Parse(connectionString).CreateCloudBlobClient();
             _client.DefaultRequestOptions.RetryPolicy = retryPolicy;
         }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/Parameters/AzureBlobStorageAccountKey.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/Parameters/AzureBlobStorageAccountKey.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.IO.FileSystem.AzureBlob.Parameters
+{
+    [NamedParameter("The Azure Blob Storage account key")]
+    public sealed class AzureBlobStorageAccountKey : Name<string>
+    {
+        private AzureBlobStorageAccountKey()
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/Parameters/AzureBlobStorageAccountName.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/AzureBlob/Parameters/AzureBlobStorageAccountName.cs
@@ -19,10 +19,10 @@ using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.IO.FileSystem.AzureBlob.Parameters
 {
-    [NamedParameter("The connection string for Azure Storage")]
-    public sealed class AzureStorageConnectionString : Name<string>
+    [NamedParameter("The Azure Blob Storage account name")]
+    public sealed class AzureBlobStorageAccountName : Name<string>
     {
-        private AzureStorageConnectionString()
+        private AzureBlobStorageAccountName()
         {
         }
     }


### PR DESCRIPTION
Took out the connection string parameter and replaced with account name
and account key. Connection string is then constructed whenever
necessary.

[REEF-2035] (https://issues.apache.org/jira/browse/REEF-2035)

Pull Request:
  This closes #