### PR TITLE
[REEF-2037] Make local file system deleteDirectory api recursive

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestLocalFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestLocalFileSystem.cs
@@ -157,6 +157,27 @@ namespace Org.Apache.REEF.IO.Tests
             fs.DeleteDirectory(directoryUri);
         }
 
+        [Fact]
+        public void TestDeleteDirectory()
+        {
+            var fs = GetFileSystem();
+            var directoryUri = new Uri(Path.Combine(Path.GetTempPath(), TempFileName) + "/");
+            string childDirName = "childDir";
+            const string fileName = "testfile";
+            fs.CreateDirectory(directoryUri);
+            var childDirUri = new Uri(directoryUri, childDirName);
+            fs.CreateDirectory(childDirUri);
+            var fileUri = new Uri(directoryUri, fileName);
+            MakeRemoteTestFile(fs, fileUri);
+            var childDirFileUri = new Uri(directoryUri, $"{childDirName}/{fileName}");
+            MakeRemoteTestFile(fs, childDirFileUri);
+            fs.DeleteDirectory(directoryUri);
+            Assert.False(File.Exists(childDirFileUri.AbsolutePath));
+            Assert.False(File.Exists(fileUri.AbsolutePath));
+            Assert.False(File.Exists(childDirUri.AbsolutePath));
+            Assert.False(File.Exists(directoryUri.AbsolutePath));
+        }
+
         private IFileSystem GetFileSystem()
         {
             return TangFactory.GetTang()

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestLocalFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestLocalFileSystem.cs
@@ -161,20 +161,26 @@ namespace Org.Apache.REEF.IO.Tests
         public void TestDeleteDirectory()
         {
             var fs = GetFileSystem();
+            // Create directory
             var directoryUri = new Uri(Path.Combine(Path.GetTempPath(), TempFileName) + "/");
-            string childDirName = "childDir";
-            const string fileName = "testfile";
             fs.CreateDirectory(directoryUri);
+
+            // Create sub directory
+            string childDirName = "childDir";
             var childDirUri = new Uri(directoryUri, childDirName);
             fs.CreateDirectory(childDirUri);
+
+            // Create file
+            const string fileName = "testfile";
             var fileUri = new Uri(directoryUri, fileName);
             MakeRemoteTestFile(fs, fileUri);
+
+            //Create sub directory file      
             var childDirFileUri = new Uri(directoryUri, $"{childDirName}/{fileName}");
             MakeRemoteTestFile(fs, childDirFileUri);
+
             fs.DeleteDirectory(directoryUri);
-            Assert.False(File.Exists(childDirFileUri.AbsolutePath));
-            Assert.False(File.Exists(fileUri.AbsolutePath));
-            Assert.False(File.Exists(childDirUri.AbsolutePath));
+
             Assert.False(File.Exists(directoryUri.AbsolutePath));
         }
 

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Local/LocalFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Local/LocalFileSystem.cs
@@ -107,7 +107,7 @@ namespace Org.Apache.REEF.IO.FileSystem.Local
 
         public void DeleteDirectory(Uri directoryUri)
         {
-            Directory.Delete(directoryUri.LocalPath);
+            Directory.Delete(directoryUri.LocalPath, true);
         }
 
         public IEnumerable<Uri> GetChildren(Uri directoryUri)


### PR DESCRIPTION
[REEF-2037] Introduce configurable azure blob exponential retry policy
  
DeleteDirectory of LocalFileSystem does not do recursive delete unlike other filesystem implementations
  
JIRA:
  [REEF-2037](https://issues.apache.org/jira/browse/REEF-2037)
 
Pull request:
  This closes [1474](https://github.com/apache/reef/pull/1474)