### PR TITLE
[REEF-2047] Upgrade Hadoop Version Referenced by REEF to 2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ under the License.
         <reef.log.dir>${project.build.directory}/log</reef.log.dir>
         <bundle.snappy>false</bundle.snappy>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hadoop.version>2.7.5</hadoop.version>
+        <hadoop.version>2.9.1</hadoop.version>
         <spark.version>2.1.0</spark.version>
         <avro.version>1.8.1</avro.version>
         <parquet.version>1.9.0</parquet.version>


### PR DESCRIPTION
This addressed the issue by:
  * Upgrading the pom to use hadoop 2.9.1, where allocation ID is in the NMClient API.

JIRA:
  [REEF-2047](https://issues.apache.org/jira/browse/REEF-2047)

Pull request:
  This closes #