### PR TITLE
[REEF-2052] Use Yarn allocation ID to keep track of allocated containers

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
+++ b/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
@@ -104,7 +104,8 @@ namespace Org {
                             !EvaluatorRequestorClr2Java();
                             virtual void OnError(String^ message);
                             virtual void Submit(IEvaluatorRequest^ request);
-                            virtual array<byte>^ GetDefinedRuntimes();
+							virtual void Remove(String^ requestId);
+							virtual array<byte>^ GetDefinedRuntimes();
                         };
 
                         public ref class TaskMessageClr2Java : public ITaskMessageClr2Java {

--- a/lang/cs/Org.Apache.REEF.Bridge/EvaluatorRequestorClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/EvaluatorRequestorClr2Java.cpp
@@ -53,26 +53,47 @@ namespace Org {
               ManagedLog::LOGGER->LogStart("EvaluatorRequestorClr2Java::Submit");
               JNIEnv *env = RetrieveEnv(_jvm);
               jclass jclassEvaluatorRequestor = env->GetObjectClass(_jobjectEvaluatorRequestor);
-              jmethodID jmidSubmit = env->GetMethodID(jclassEvaluatorRequestor, "submit", "(IIIZLjava/lang/String;Ljava/lang/String;Ljava/util/ArrayList;Ljava/lang/String;)V");
+			  jmethodID jmidSubmit = env->GetMethodID(jclassEvaluatorRequestor, "submit", "(Ljava/lang/String;IIIZLjava/lang/String;Ljava/lang/String;Ljava/util/ArrayList;Ljava/lang/String;)V");
 
+			  ManagedLog::LOGGER->LogStart("EvaluatorRequestorClr2Java::Submit2");
               if (jmidSubmit == NULL) {
                 fprintf(stdout, " jmidSubmit is NULL\n");
                 fflush(stdout);
                 return;
               }
-              env->CallObjectMethod(
+			  ManagedLog::LOGGER->LogStart("EvaluatorRequestorClr2Java::Submit3:RequestId:" + request->RequestId);
+			  env->CallObjectMethod(
                 _jobjectEvaluatorRequestor,
                 jmidSubmit,
+				JavaStringFromManagedString(env, request->RequestId),
                 request->Number,
                 request->MemoryMegaBytes,
                 request->VirtualCore,
-                request->RelaxLocality,
+				request->RelaxLocality,
                 JavaStringFromManagedString(env, request->Rack),
                 JavaStringFromManagedString(env, request->RuntimeName),
                 JavaArrayListFromManagedList(env, request->NodeNames),
 				JavaStringFromManagedString(env, request->NodeLabelExpression));
               ManagedLog::LOGGER->LogStop("EvaluatorRequestorClr2Java::Submit");
             }
+
+			void EvaluatorRequestorClr2Java::Remove(String^ requestId) {
+				ManagedLog::LOGGER->LogStart("EvaluatorRequestorClr2Java::Remove");
+				JNIEnv *env = RetrieveEnv(_jvm);
+				jclass jclassEvaluatorRequestor = env->GetObjectClass(_jobjectEvaluatorRequestor);
+				jmethodID jmidRemove = env->GetMethodID(jclassEvaluatorRequestor, "remove", "(Ljava/lang/String;)V");
+
+				if (jmidRemove == NULL) {
+					fprintf(stdout, " jmidRemove is NULL\n");
+					fflush(stdout);
+					return;
+				}
+				env->CallObjectMethod(
+					_jobjectEvaluatorRequestor,
+					jmidRemove,
+					JavaStringFromManagedString(env, requestId));
+				ManagedLog::LOGGER->LogStop("EvaluatorRequestorClr2Java::Remove");
+			}
 
             array<byte>^ EvaluatorRequestorClr2Java::GetDefinedRuntimes() {
               ManagedLog::LOGGER->LogStart("EvaluatorRequestorClr2Java::GetDefinedRuntimes");

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IEvaluatorRequestorClr2Java.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IEvaluatorRequestorClr2Java.cs
@@ -25,6 +25,8 @@ namespace Org.Apache.REEF.Driver.Bridge.Clr2java
     {
         void Submit(IEvaluatorRequest evaluatorRequest);
 
+        void Remove(string requestId);
+
         byte[] GetDefinedRuntimes();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/EvaluatorRequestor.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/EvaluatorRequestor.cs
@@ -65,8 +65,8 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
 
         public void Submit(IEvaluatorRequest request)
         {
-            LOGGER.Log(Level.Info, "Submitting request for {0} evaluators and {1} MB memory and  {2} core to rack {3} runtime {4}, nodeNames to schedule {5} and RelaxLocality is {6}.",
-                request.Number, request.MemoryMegaBytes, request.VirtualCore, request.Rack, request.RuntimeName, string.Join(",", request.NodeNames.ToArray()), request.RelaxLocality);
+            LOGGER.Log(Level.Info, "Submitting request for {0} evaluators and {1} MB memory and  {2} core to rack {3} runtime {4}, nodeNames to schedule {5} and RelaxLocality is {6}, requestId {7}.",
+                request.Number, request.MemoryMegaBytes, request.VirtualCore, request.Rack, request.RuntimeName, string.Join(",", request.NodeNames.ToArray()), request.RelaxLocality, request.RequestId);
             lock (Evaluators)
             {
                 for (var i = 0; i < request.Number; i++)
@@ -94,6 +94,11 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             }
 
             Clr2Java.Submit(request);
+        }
+
+        public void Remove(string requestId)
+        {
+            Clr2Java.Remove(requestId);
         }
 
         public EvaluatorRequestBuilder NewBuilder()

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequest.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequest.cs
@@ -19,6 +19,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using Org.Apache.REEF.Driver.Bridge.Events;
+using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Driver.Evaluator
 {
@@ -28,11 +30,16 @@ namespace Org.Apache.REEF.Driver.Evaluator
     [DataContract]
     internal class EvaluatorRequest : IEvaluatorRequest
     {
-        internal EvaluatorRequest() : this(number: 0, megaBytes: 0)
-        {
-        }
+        internal EvaluatorRequest()
+            : this(number: 0, megaBytes: 0)
 
-        internal EvaluatorRequest(int number, int megaBytes) : this(number: number, megaBytes: megaBytes, core: 1)
+        private static readonly Logger Logger = Logger.GetLogger(typeof(EvaluatorRequest));
+
+        internal EvaluatorRequest(int number, int megaBytes)
+            : this(
+                  number: number,
+                  megaBytes: megaBytes,
+                  core: 1)
         {
         }
 
@@ -92,19 +99,21 @@ namespace Org.Apache.REEF.Driver.Evaluator
             ICollection<string> nodeNames,
             bool relaxLocality)
                 : this(
-                number: number,
-                megaBytes: megaBytes,
-                core: core,
-                rack: rack,
-                evaluatorBatchId: evaluatorBatchId,
-                runtimeName: string.Empty,
-                nodeNames: nodeNames,
-                relaxLocality: relaxLocality,
-                nodeLabelExpression: string.Empty)
+                    requestId: string.Empty,
+                    number: number,
+                    megaBytes: megaBytes,
+                    core: core,
+                    rack: rack,
+                    evaluatorBatchId: evaluatorBatchId,
+                    runtimeName: string.Empty,
+                    nodeNames: nodeNames,
+                    relaxLocality: relaxLocality,
+                    nodeLabelExpression: string.Empty)
         {
         }
 
         internal EvaluatorRequest(
+            string requestId,
             int number,
             int megaBytes,
             int core,
@@ -115,9 +124,12 @@ namespace Org.Apache.REEF.Driver.Evaluator
             bool relaxLocality,
             string nodeLabelExpression)
         {
+            Logger.Log(Level.Verbose, "EvaluatorRequest constructor: RequestId {0}, Number: {1},  Priority: {2}.", requestId, number, priority);
+            RequestId = requestId;
             Number = number;
             MemoryMegaBytes = megaBytes;
             VirtualCore = core;
+            Priority = priority;
             Rack = rack;
             EvaluatorBatchId = evaluatorBatchId;
             RuntimeName = runtimeName;
@@ -125,6 +137,9 @@ namespace Org.Apache.REEF.Driver.Evaluator
             RelaxLocality = relaxLocality;
             NodeLabelExpression = nodeLabelExpression;
         }
+
+        [DataMember]
+        public string RequestId { get; private set; }
 
         [DataMember]
         public int MemoryMegaBytes { get; private set; }

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequestBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequestBuilder.cs
@@ -33,6 +33,7 @@ namespace Org.Apache.REEF.Driver.Evaluator
 
         internal EvaluatorRequestBuilder(IEvaluatorRequest request)
         {
+            RequestId = request.RequestId;
             Number = request.Number;
             MegaBytes = request.MemoryMegaBytes;
             VirtualCore = request.VirtualCore;
@@ -46,6 +47,7 @@ namespace Org.Apache.REEF.Driver.Evaluator
 
         internal EvaluatorRequestBuilder()
         {
+            RequestId = "RequestId-" + Guid.NewGuid().ToString("N");
             Number = 1;
             VirtualCore = 1;
             MegaBytes = 64;
@@ -57,9 +59,22 @@ namespace Org.Apache.REEF.Driver.Evaluator
             _nodeLabelExpression = string.Empty;
         }
 
+        public string RequestId { get; private set; }
+
         public int Number { get; private set; }
         public int MegaBytes { get; private set; }
         public int VirtualCore { get; private set; }
+
+        /// <summary>
+        /// Set the request id for the evaluator request.
+        /// </summary>
+        /// <param name="requestId"></param>
+        /// <returns></returns>
+        public EvaluatorRequestBuilder SetRequestId(string requestId)
+        {
+            RequestId = requestId;
+            return this;
+        }
 
         /// <summary>
         /// Set the number of evaluators to request.
@@ -177,7 +192,9 @@ namespace Org.Apache.REEF.Driver.Evaluator
         /// <returns></returns>
         public IEvaluatorRequest Build()
         {
-            return new EvaluatorRequest(Number, MegaBytes, VirtualCore, rack: _rackName, evaluatorBatchId: _evaluatorBatchId, runtimeName: _runtimeName, nodeNames: _nodeNames, relaxLocality: _relaxLocality, nodeLabelExpression: _nodeLabelExpression);
+            return new EvaluatorRequest(RequestId, Number, MegaBytes, VirtualCore, rack: _rackName,
+                evaluatorBatchId: _evaluatorBatchId, runtimeName: _runtimeName, nodeNames: _nodeNames,
+                relaxLocality: _relaxLocality, nodeLabelExpression: _nodeLabelExpression);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/IEvaluatorRequest.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/IEvaluatorRequest.cs
@@ -25,6 +25,11 @@ namespace Org.Apache.REEF.Driver.Evaluator
     public interface IEvaluatorRequest
     {
         /// <summary>
+        /// Evaluator request id.
+        /// </summary>
+        string RequestId { get; }
+
+        /// <summary>
         /// Memory for the Evaluator in megabytes.
         /// </summary>
         int MemoryMegaBytes { get; }

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/IEvaluatorRequestor.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/IEvaluatorRequestor.cs
@@ -36,6 +36,12 @@ namespace Org.Apache.REEF.Driver.Evaluator
         void Submit(IEvaluatorRequest request);
 
         /// <summary>
+        /// Remove an evaluator request for specified request id.
+        /// </summary>
+        /// <param name="requestId">Request Id to be removed.</param>
+        void Remove(string requestId);
+
+        /// <summary>
         /// Returns a builder for new Evaluator requests.
         /// </summary>
         /// <returns></returns>

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/ImruDriverCancelTests.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/ImruDriverCancelTests.cs
@@ -253,6 +253,11 @@ namespace Org.Apache.REEF.IMRU.Tests
                 // but can't throw exception here as Driver calls this method before cancellation flow can be initiated.
             }
 
+            public void Remove(string requestId)
+            {
+                // for test we don't really remove evaluator request,
+            }
+
             public EvaluatorRequestBuilder NewBuilder()
             {
                 var builder = Activator.CreateInstance(

--- a/lang/cs/Org.Apache.REEF.Tests/Performance/TestHelloREEF/TestHelloDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Performance/TestHelloREEF/TestHelloDriver.cs
@@ -39,6 +39,8 @@ namespace Org.Apache.REEF.Tests.Performance.TestHelloREEF
         private static readonly Logger Logger = Logger.GetLogger(typeof(TestHelloDriver));
         private readonly IEvaluatorRequestor _evaluatorRequestor;
 
+        private const string RequestIdPrefix = "RequestId-";
+
         /// <summary>
         /// Specify if the desired node names is relaxed
         /// </summary>
@@ -90,7 +92,9 @@ namespace Org.Apache.REEF.Tests.Performance.TestHelloREEF
         {
             Logger.Log(Level.Info, "Received IDriverStarted, numberOfContainers: {0}", _numberOfContainers);
 
+            var requestId = RequestIdPrefix + Guid.NewGuid();
             _evaluatorRequestor.Submit(_evaluatorRequestor.NewBuilder()
+                .SetRequestId(requestId)
                 .SetMegabytes(64)
                 .SetNumber(_numberOfContainers)
                 .SetRelaxLocality(_relaxLocality)

--- a/lang/cs/Org.Apache.REEF.Tests/Performance/TestHelloREEF/TestHelloREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Performance/TestHelloREEF/TestHelloREEFClient.cs
@@ -63,6 +63,7 @@ namespace Org.Apache.REEF.Tests.Performance.TestHelloREEF
             int driverMemory = 1024;
             string testFolder = DefaultRuntimeFolder + TestId;
             TestRun(GetRuntimeConfigurationForLocal(numberOfContainers, testFolder), driverMemory);
+            ValidateSuccessForLocalRuntime(numberOfContainers, testFolder: testFolder);
             CleanUp(testFolder);
         }
 

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/EvaluatorRequestorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/EvaluatorRequestorBridge.java
@@ -71,6 +71,17 @@ public final class EvaluatorRequestorBridge extends NativeBridge {
                      final String runtimeName,
                      final ArrayList<String> nodeNames,
                      final String nodeLabelExpression) {
+    submit("", evaluatorsNumber, memory, virtualCore, relaxLocality, rack, runtimeName, nodeNames, nodeLabelExpression);
+  }
+  public void submit(final String requestId,
+                     final int evaluatorsNumber,
+                     final int memory,
+                     final int virtualCore,
+                     final boolean relaxLocality,
+                     final String rack,
+                     final String runtimeName,
+                     final ArrayList<String> nodeNames,
+                     final String nodeLabelExpression) {
     if (this.isBlocked) {
       throw new RuntimeException("Cannot request additional Evaluator, this is probably because " +
           "the Driver has crashed and restarted, and cannot ask for new container due to YARN-2433.");
@@ -84,6 +95,7 @@ public final class EvaluatorRequestorBridge extends NativeBridge {
       clrEvaluatorsNumber += evaluatorsNumber;
 
       final EvaluatorRequest request = EvaluatorRequest.newBuilder()
+          .setRequestId(requestId)
           .setNumber(evaluatorsNumber)
           .setMemory(memory)
           .setNumberOfCores(virtualCore)
@@ -93,9 +105,15 @@ public final class EvaluatorRequestorBridge extends NativeBridge {
           .setNodeLabelExpression(nodeLabelExpression)
           .build();
 
-      LOG.log(Level.FINE, "submitting evaluator request {0}", request);
+      LOG.log(Level.FINE, "EvaluatorRequestorBridge.submit(), requestId {0}, evaluatorsNumber:{1}",
+          new Object[] {requestId, evaluatorsNumber});
       jevaluatorRequestor.submit(request);
     }
+  }
+
+  public void remove(final String evaluatorRequestId) {
+    LOG.log(Level.INFO, "Received remove request for id {0}.", evaluatorRequestId);
+    jevaluatorRequestor.remove(evaluatorRequestId);
   }
 
   public int getEvaluatorNumber() {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -34,6 +34,7 @@ import java.util.List;
 @Provided
 public final class EvaluatorRequest {
 
+  private final String requestId;
   private final int megaBytes;
   private final int number;
   private final int cores;
@@ -57,11 +58,10 @@ public final class EvaluatorRequest {
                    final List<String> nodeNames,
                    final List<String> rackNames,
                    final String runtimeName) {
-    this(number, megaBytes, cores, nodeNames, rackNames, runtimeName, true, null);
+    this("", number, megaBytes, cores, nodeNames, rackNames, runtimeName, true, null);
   }
-
-
-  EvaluatorRequest(final int number,
+  EvaluatorRequest(final String requestId,
+                   final int number,
                    final int megaBytes,
                    final int cores,
                    final List<String> nodeNames,
@@ -69,6 +69,7 @@ public final class EvaluatorRequest {
                    final String runtimeName,
                    final boolean relaxLocality,
                    final String nodeLabelExpression) {
+    this.requestId = requestId;
     this.number = number;
     this.megaBytes = megaBytes;
     this.cores = cores;
@@ -96,6 +97,15 @@ public final class EvaluatorRequest {
    */
   public static Builder newBuilder(final EvaluatorRequest request) {
     return new Builder(request);
+  }
+
+  /**
+   * Access the request id of Evaluators requested.
+   *
+   * @return The request id.
+   */
+  public String getRequestId() {
+    return this.requestId;
   }
 
   /**
@@ -175,6 +185,7 @@ public final class EvaluatorRequest {
   public static class Builder<T extends Builder> implements org.apache.reef.util.Builder<EvaluatorRequest> {
 
     private int n = 1;
+    private String requestId = "";
     private int megaBytes = -1;
     private int cores = 1; //if not set, default to 1
     private final List<String> nodeNames = new ArrayList<>();
@@ -194,6 +205,7 @@ public final class EvaluatorRequest {
      * @return this Builder
      */
     private Builder(final EvaluatorRequest request) {
+      setRequestId(request.getRequestId());
       setNumber(request.getNumber());
       setMemory(request.getMegaBytes());
       setNumberOfCores(request.getNumberOfCores());
@@ -206,6 +218,18 @@ public final class EvaluatorRequest {
         addRackName(rackName);
       }
       setNodeLabelExpression(request.getNodeLabelExpression());
+    }
+
+    /**
+     * Set the request id.
+     *
+     * @param requestId for the Evaluator request.
+     * @return this builder
+     */
+    @SuppressWarnings("checkstyle:hiddenfield")
+    public T setRequestId(final String requestId) {
+      this.requestId = requestId;
+      return (T) this;
     }
 
     /**
@@ -326,9 +350,8 @@ public final class EvaluatorRequest {
      */
     @Override
     public EvaluatorRequest build() {
-      return new EvaluatorRequest(this.n, this.megaBytes, this.cores, this.nodeNames,
-          this.rackNames, this.runtimeName, this.relaxLocality,
-          this.nodeLabelExpression);
+      return new EvaluatorRequest(this.requestId, this.n, this.megaBytes, this.cores, this.nodeNames,
+          this.rackNames, this.runtimeName, this.relaxLocality, this.nodeLabelExpression);
     }
 
     /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequestor.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequestor.java
@@ -37,6 +37,12 @@ public interface EvaluatorRequestor {
   void submit(final EvaluatorRequest req);
 
   /**
+   * Remove the submitted EvaluatorRequest.
+   * @param requestId to be removed.
+   */
+  void remove(final String requestId);
+
+  /**
    * Get a new Builder for the evaluator with fluid interface.
    * @return Builder for the evaluator
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
@@ -35,6 +35,11 @@ import java.util.List;
 public interface ResourceRequestEvent {
 
   /**
+   * @return The request id.
+   */
+  String getRequestId();
+
+  /**
    * @return The number of resources requested
    */
   int getResourceCount();

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
@@ -29,6 +29,7 @@ import java.util.List;
  * Use newBuilder to construct an instance.
  */
 public final class ResourceRequestEventImpl implements ResourceRequestEvent {
+  private final String requestId;
   private final int resourceCount;
   private final List<String> nodeNameList;
   private final List<String> rackNameList;
@@ -40,6 +41,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
   private final String runtimeName;
 
   private ResourceRequestEventImpl(final Builder builder) {
+    this.requestId = builder.requestId == null ? "" : builder.requestId;
     this.resourceCount = BuilderUtils.notNull(builder.resourceCount);
     this.nodeNameList = BuilderUtils.notNull(builder.nodeNameList);
     this.rackNameList = BuilderUtils.notNull(builder.rackNameList);
@@ -49,6 +51,11 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     this.relaxLocality = Optional.ofNullable(builder.relaxLocality);
     this.nodeLabelExpression = Optional.ofNullable(builder.nodeLabelExpression);
     this.runtimeName = builder.runtimeName == null ? "" : builder.runtimeName;
+  }
+
+  @Override
+  public String getRequestId() {
+    return requestId;
   }
 
   @Override
@@ -104,6 +111,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
    * Builder used to create ResourceRequestEvent instances.
    */
   public static final class Builder implements org.apache.reef.util.Builder<ResourceRequestEvent> {
+    private String requestId;
     private Integer resourceCount;
     private List<String> nodeNameList = new ArrayList<>();
     private List<String> rackNameList = new ArrayList<>();
@@ -118,6 +126,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
      * Create a builder from an existing ResourceRequestEvent.
      */
     public Builder mergeFrom(final ResourceRequestEvent resourceRequestEvent) {
+      this.requestId = resourceRequestEvent.getRequestId();
       this.resourceCount = resourceRequestEvent.getResourceCount();
       this.nodeNameList = resourceRequestEvent.getNodeNameList();
       this.rackNameList = resourceRequestEvent.getRackNameList();
@@ -129,6 +138,14 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
       this.nodeLabelExpression = resourceRequestEvent
           .getNodeLabelExpression()
           .orElse(null);
+      return this;
+    }
+
+    /**
+     * @see ResourceRequestEvent#getRequestId()
+     */
+    public Builder setRequestId(final String requestId) {
+      this.requestId = requestId;
       return this;
     }
 

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerRequestHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerRequestHandler.java
@@ -31,5 +31,14 @@ public interface YarnContainerRequestHandler {
    *
    * @param containerRequests set of container requests
    */
+  void onContainerRequest(final String requestId, final AMRMClient.ContainerRequest... containerRequests);
+
+  /**
+   * Container requests without request id. Will be deprecated in 0.18.
+   * @param containerRequests
+   */
+  @Deprecated
   void onContainerRequest(final AMRMClient.ContainerRequest... containerRequests);
+
+  void onContainerRequestRemove(String requestId);
 }

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerRequestHandlerImpl.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerRequestHandlerImpl.java
@@ -39,9 +39,26 @@ public final class YarnContainerRequestHandlerImpl implements YarnContainerReque
     LOG.log(Level.FINEST, "Instantiated 'YarnContainerRequestHandler'");
   }
 
+  /**
+   * Container requests without request id. Will be deprecated in 0.18.
+   * @param containerRequests
+   */
+  @Deprecated
   @Override
   public void onContainerRequest(final AMRMClient.ContainerRequest... containerRequests) {
     LOG.log(Level.FINEST, "Sending container requests to YarnContainerManager.");
     this.containerManager.onContainerRequest(containerRequests);
+  }
+
+  @Override
+  public void onContainerRequest(final String requestId, final AMRMClient.ContainerRequest... containerRequests) {
+    LOG.log(Level.FINEST, "Sending container requests to YarnContainerManager.");
+    this.containerManager.onContainerRequest(requestId, containerRequests);
+  }
+
+  @Override
+  public void onContainerRequestRemove(final String requestId) {
+    LOG.log(Level.FINEST, "Sending container request remove to YarnContainerManager.");
+    this.containerManager.onContainerRequestRemove(requestId);
   }
 }

--- a/lang/java/reef-runtime-yarn/src/test/java/org/apache/reef/runtime/yarn/driver/YarnResourceRequestHandlerTest.java
+++ b/lang/java/reef-runtime-yarn/src/test/java/org/apache/reef/runtime/yarn/driver/YarnResourceRequestHandlerTest.java
@@ -26,9 +26,13 @@ import org.apache.hadoop.yarn.client.api.AMRMClient;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.util.logging.LoggingScopeFactory;
-import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.junit.Assert;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Tests for YarnResourceRequestHandler.
@@ -46,9 +50,22 @@ public final class YarnResourceRequestHandlerTest {
   private class MockContainerRequestHandler implements YarnContainerRequestHandler {
     private AMRMClient.ContainerRequest[] requests;
 
+    private ConcurrentHashMap<String, List<AMRMClient.ContainerRequest>> indexedRequest = new ConcurrentHashMap<>();
+
     @Override
     public void onContainerRequest(final AMRMClient.ContainerRequest... containerRequests) {
       this.requests = containerRequests;
+    }
+
+    @Override
+    public void onContainerRequest(final String requestId, final AMRMClient.ContainerRequest... containerRequests) {
+      this.indexedRequest.put(requestId, Arrays.asList(containerRequests));
+      this.requests = containerRequests;
+    }
+
+    @Override
+    public void onContainerRequestRemove(final String requestId) {
+      this.indexedRequest.remove(requestId);
     }
 
     AMRMClient.ContainerRequest[] getRequests() {


### PR DESCRIPTION
This addressed the issue by:
  * Using the Yarn allocationID API that was introduced in hadoop 2.9.1 in the Yarn Runtime.
  * Adding a corresponding property in the EvaluatorRequest class for c# and java.

  JIRA:
    [REEF-2052](https://issues.apache.org/jira/browse/REEF-2052] Use Yarn allocation ID to keep track of allocated containers

  Pull request:
    This closes #