### PR TITLE
[REEF-2055] Use `gitbox` instead of `git-wip-us`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ under the License.
 
     <scm>
         <connection>scm:git:git@github.com:apache/reef</connection>
-        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/reef</developerConnection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/reef</developerConnection>
         <url>scm:git:git@github.com:apache/reef</url>
         <tag>HEAD</tag>
     </scm>

--- a/website/src/site/resources/doap.rdf
+++ b/website/src/site/resources/doap.rdf
@@ -59,8 +59,8 @@ under the License.
     </release>
     <repository>
       <GitRepository>
-        <location rdf:resource="https://git-wip-us.apache.org/repos/asf/reef.git"/>
-        <browse rdf:resource="https://git-wip-us.apache.org/repos/asf?p=reef.git"/>
+        <location rdf:resource="https://gitbox.apache.org/repos/asf/reef.git"/>
+        <browse rdf:resource="https://gitbox.apache.org/repos/asf?p=reef.git"/>
       </GitRepository>
     </repository>
   </Project>


### PR DESCRIPTION
Since we are using `GitBox`, we had better update the project information before making new release.