### PR TITLE
[REEF-2056] Fix dependency conflict issue

### DIFF
--- a/lang/java/reef-applications/reef-vortex/pom.xml
+++ b/lang/java/reef-applications/reef-vortex/pom.xml
@@ -63,7 +63,6 @@ under the License.
         <dependency>
         	  <artifactId>asm</artifactId>
             <groupId>org.ow2.asm</groupId>
-            <version>5.0.3</version>
         </dependency>
     </dependencies>
 

--- a/lang/java/reef-applications/reef-vortex/pom.xml
+++ b/lang/java/reef-applications/reef-vortex/pom.xml
@@ -61,8 +61,8 @@ under the License.
             <version>${kryo-serializers.version}</version>
         </dependency>
         <dependency>
-        	  <artifactId>asm</artifactId>
             <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
         </dependency>
     </dependencies>
 

--- a/lang/java/reef-applications/reef-vortex/pom.xml
+++ b/lang/java/reef-applications/reef-vortex/pom.xml
@@ -60,6 +60,11 @@ under the License.
             <artifactId>kryo-serializers</artifactId>
             <version>${kryo-serializers.version}</version>
         </dependency>
+        <dependency>
+        	  <artifactId>asm</artifactId>
+            <groupId>org.ow2.asm</groupId>
+            <version>5.0.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@ under the License.
         <!-- do not move beyond this version since it adds an incompatible guava dependency -->
         <xolstice.version>0.5.0</xolstice.version>
         <commons-codec.version>1.9</commons-codec.version>
+        <asm.version>5.0.3</asm.version>
         <rootPath>${user.dir}</rootPath>
     </properties>
 
@@ -795,7 +796,14 @@ under the License.
                 <artifactId>azure-batch</artifactId>
                 <version>3.0.0</version>
             </dependency>
-        </dependencies>
+                 
+            <!-- asm -->
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${asm.version}</version>
+                </dependency>       
+            </dependencies>
     </dependencyManagement>
 
     <modules>


### PR DESCRIPTION
Hi, in **apache-reef-0.16.0 (reef-reef-project-0.16.0\lang\java\reef-applications\reef-vortex module)**, there are mulptiple versions of **org.ow2.asm:asm.jar**. However, according to Maven's dependency management strategy, only **org.ow2.asm:asm:jar:4.2** can be loaded, and **org.ow2.asm:asm:jar:5.0.3** will be shadowed.

As shown in the following dependency tree, **com.esotericsoftware:kryo:jar:3.0.3:compile** expects to reference **org.ow2.asm:asm:jar:5.0.3:compile**. But due to dependency conflicts, Maven actually loads **org.ow2.asm:asm:jar:4.2**. As a result, **com.esotericsoftware:kryo:jar:3.0.3:compile** has to invoke the methods included in the unexpected version **org.ow2.asm:asm:jar:4.2**, which may cause inconsistent semantic behaviors.

For instance, method **org.apache.reef.vortex.common.KryoUtils.deserialize(byte[])** actually references method **org.objectweb.asm.ClassReader.accept(org.objectweb.asm.ClassVisitor,org.objectweb.asm.Attribute[],int)** in the unexpected version **org.ow2.asm:asm:jar:4.2** via the following invocation path:

```
<org.apache.reef.vortex.common.KryoUtils: java.lang.Object deserialize(byte[])> D:\testcase\NewProject3\reef-reef-project-0.16.0\lang\java\reef-applications\reef-vortex\target\classes
<com.esotericsoftware.kryo.Kryo: java.lang.Object readClassAndObject(com.esotericsoftware.kryo.io.Input)> D:\cEnvironment\repository\com\esotericsoftware\kryo\3.0.3\kryo-3.0.3.jar
<com.esotericsoftware.kryo.serializers.FieldSerializer: void setGenerics(com.esotericsoftware.kryo.Kryo,java.lang.Class[])> D:\cEnvironment\repository\com\esotericsoftware\kryo\3.0.3\kryo-3.0.3.jar
<com.esotericsoftware.kryo.serializers.FieldSerializer: void rebuildCachedFields(boolean)> D:\cEnvironment\repository\com\esotericsoftware\kryo\3.0.3\kryo-3.0.3.jar
<com.esotericsoftware.reflectasm.FieldAccess: com.esotericsoftware.reflectasm.FieldAccess get(java.lang.Class)> D:\cEnvironment\repository\com\esotericsoftware\reflectasm\1.10.1\reflectasm-1.10.1.jar
<org.objectweb.asm.ClassWriter: byte[] toByteArray()> D:\cEnvironment\repository\org\ow2\asm\asm\4.2\asm-4.2.jar
<org.objectweb.asm.ClassReader: void accept(org.objectweb.asm.ClassVisitor,int)> D:\cEnvironment\repository\org\ow2\asm\asm\4.2\asm-4.2.jar
<org.objectweb.asm.ClassReader: void accept(org.objectweb.asm.ClassVisitor,org.objectweb.asm.Attribute[],int)>
```

By further analyzing, the expected callee org.objectweb.asm.ClassReader.accept(org.objectweb.asm.ClassVisitor,org.objectweb.asm.Attribute[],int) in shadowed version org.ow2.asm:asm:jar:5.0.3, have different implementations from the actual callees with the same signatures (same method names, same paremeters) included in the unexpected (but actual loaded) version org.ow2.asm:asm:jar:4.2, which leads to different behaviors.

Solution:
Use the newer version org.ow2.asm:asm:jar:5.0.3  to keep the version consistency.

 

Thank you for attention,

Best,

Coco

 

**Dependency Tree-----**
[INFO] org.apache.reef:vortex:jar:0.16.0
[INFO] +- org.apache.reef:reef-common:jar:0.16.0:compile
[INFO] |  +- org.apache.reef:reef-annotations:jar:0.16.0:compile
[INFO] |  +- org.apache.reef:reef-utils:jar:0.16.0:compile
[INFO] |  |  +- javax.inject:javax.inject:jar:1:compile
[INFO] |  |  - (net.jcip:jcip-annotations:jar:1.0:compile - omitted for duplicate)
[INFO] |  +- com.google.protobuf:protobuf-java:jar:2.5.0:compile
[INFO] |  +- org.apache.reef:wake:jar:0.16.0:compile
[INFO] |  |  +- cglib:cglib:jar:3.1:compile
[INFO] |  |  |  - **org.ow2.asm:asm:jar:4.2:compile**
[INFO] |  |  +- io.netty:netty-all:jar:4.0.21.Final:compile
[INFO] |  |  +- (com.google.protobuf:protobuf-java:jar:2.5.0:compile - omitted for duplicate)
[INFO] |  |  +- (org.apache.reef:tang:jar:0.16.0:compile - omitted for duplicate)
[INFO] |  |  - (net.jcip:jcip-annotations:jar:1.0:compile - omitted for duplicate)
[INFO] |  +- org.apache.reef:tang:jar:0.16.0:compile
[INFO] |  |  +- (com.google.protobuf:protobuf-java:jar:2.5.0:compile - omitted for duplicate)
[INFO] |  |  +- commons-configuration:commons-configuration:jar:1.10:compile
[INFO] |  |  |  +- commons-lang:commons-lang:jar:2.6:compile
[INFO] |  |  |  - commons-logging:commons-logging:jar:1.1.1:compile
[INFO] |  |  +- commons-cli:commons-cli:jar:1.2:compile
[INFO] |  |  +- (javax.inject:javax.inject:jar:1:compile - omitted for duplicate)
[INFO] |  |  - org.apache.avro:avro:jar:1.8.1:compile
[INFO] |  |     +- org.codehaus.jackson:jackson-core-asl:jar:1.9.13:compile
[INFO] |  |     +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13:compile
[INFO] |  |     |  - (org.codehaus.jackson:jackson-core-asl:jar:1.9.13:compile - omitted for duplicate)
[INFO] |  |     +- com.thoughtworks.paranamer:paranamer:jar:2.7:compile
[INFO] |  |     +- org.xerial.snappy:snappy-java:jar:1.1.1.3:compile
[INFO] |  |     +- org.apache.commons:commons-compress:jar:1.8.1:compile
[INFO] |  |     +- org.tukaani:xz:jar:1.5:compile
[INFO] |  |     - org.slf4j:slf4j-api:jar:1.7.7:compile
[INFO] |  +- net.jcip:jcip-annotations:jar:1.0:compile
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.3.2:compile
[INFO] |  - com.google.code.findbugs:jsr305:jar:3.0.1:compile
[INFO] +- junit:junit:jar:4.11:test
[INFO] |  - org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.mockito:mockito-core:jar:1.9.5:test
[INFO] |  +- (org.hamcrest:hamcrest-core:jar:1.1:test - omitted for conflict with 1.3)
[INFO] |  - (org.objenesis:objenesis:jar:1.0:compile - scope updated from test; omitted for duplicate)
[INFO] +- org.apache.reef:reef-runtime-local:jar:0.16.0:compile
[INFO] |  - (org.apache.reef:reef-common:jar:0.16.0:compile - omitted for duplicate)
[INFO] +- com.esotericsoftware:kryo-shaded:jar:3.0.3:compile
[INFO] |  +- com.esotericsoftware:minlog:jar:1.3.0:compile
[INFO] |  - org.objenesis:objenesis:jar:1.0:compile
[INFO] - de.javakaffee:kryo-serializers:jar:0.37:compile
[INFO]    +- com.esotericsoftware:kryo:jar:3.0.3:compile
[INFO]    |  +- com.esotericsoftware:reflectasm:jar:1.10.1:compile
[INFO]    |  |  - **(org.ow2.asm:asm:jar:5.0.3:compile - omitted for conflict with 4.2)**
[INFO]    |  +- (com.esotericsoftware:minlog:jar:1.3.0:compile - omitted for duplicate)
[INFO]    |  - (org.objenesis:objenesis:jar:2.1:compile - omitted for conflict with 1.0)
[INFO]    - (com.google.protobuf:protobuf-java:jar:2.5.0:compile - version managed from 2.6.1; omitted for duplicate)