### PR TITLE
[REEF-2058] Update FindBugs to version 3.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ under the License.
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
         <sevntu.checkstyle.plugin.version>1.20.0</sevntu.checkstyle.plugin.version>
         <checkstyle.version>6.17</checkstyle.version>
-        <findbugs.version>3.0.2</findbugs.version>
+        <findbugs.version>3.0.4</findbugs.version>
         <reflections.version>0.9.9-RC1</reflections.version>
         <jsr305.version>3.0.1</jsr305.version>
         <kryo.version>3.0.3</kryo.version>


### PR DESCRIPTION
FindBugs plugin v 3.0.2 that we use does not work with newer versions of maven (3.6+).
We need to upgrade FindBugs to version 3.0.4.

JIRA: [REEF-2058](https://issues.apache.org/jira/projects/REEF/issues/REEF-2058)