### PR TITLE
[REEF-2057] Update REEF dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ language: java
 
 jdk:
   - oraclejdk8
-  - openjdk7
+  - openjdk8
 
 env: PATH=$PATH:$HOME/tools/bin
 

--- a/lang/java/reef-bridge-proto-java/pom.xml
+++ b/lang/java/reef-bridge-proto-java/pom.xml
@@ -39,7 +39,6 @@ under the License.
         <protobuf.output.directory>${project.build.directory}/generated-sources</protobuf.output.directory>
         <!-- override parent versions -->
         <protobuf.version>3.5.1</protobuf.version>
-        <netty.version>4.1.25.Final</netty.version>
     </properties>
 
     <dependencies>
@@ -92,9 +91,13 @@ under the License.
             <version>${protobuf.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -253,12 +256,6 @@ under the License.
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <relocations>
-                                <relocation>
-                                    <pattern>io.netty</pattern>
-                                    <shadedPattern>${project.groupId}.${project.artifactId}.shaded.netty</shadedPattern>
-                                </relocation>
-                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/lang/java/reef-runtime-azbatch/pom.xml
+++ b/lang/java/reef-runtime-azbatch/pom.xml
@@ -66,17 +66,17 @@ under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.7.2</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.2</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.7.2</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/lang/java/reef-runtime-hdinsight/pom.xml
+++ b/lang/java/reef-runtime-hdinsight/pom.xml
@@ -68,13 +68,13 @@ under the License.
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/lang/java/reef-runtime-multi/pom.xml
+++ b/lang/java/reef-runtime-multi/pom.xml
@@ -89,13 +89,13 @@ under the License.
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
@@ -303,7 +303,7 @@ public final class NettyMessagingTransport implements Transport {
         }
         break;
       } catch (final Exception e) {
-        if (e.getClass().getSimpleName().compareTo("ConnectException") == 0) {
+        if (e instanceof ConnectException) {
           LOG.log(Level.WARNING, "Connection refused. Retry {0} of {1}",
               new Object[]{i + 1, this.numberOfTries});
           synchronized (flag) {

--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,8 @@ under the License.
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                         <showDeprecation>true</showDeprecation>
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>
@@ -421,7 +421,7 @@ under the License.
                     <artifactId>maven-pmd-plugin</artifactId>
                     <version>3.5</version>
                     <configuration>
-                        <targetJdk>1.7</targetJdk>
+                        <targetJdk>1.8</targetJdk>
                         <excludes>
                             <exclude>*/target/generated-sources/*</exclude>
                         </excludes>
@@ -453,8 +453,8 @@ under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showDeprecation>true</showDeprecation>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,14 @@ under the License.
         <reef.log.dir>${project.build.directory}/log</reef.log.dir>
         <bundle.snappy>false</bundle.snappy>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hadoop.version>2.9.1</hadoop.version>
-        <spark.version>2.1.0</spark.version>
-        <avro.version>1.8.1</avro.version>
+        <hadoop.version>3.2.1</hadoop.version>
+        <spark.version>2.4.4</spark.version>
+        <avro.version>1.8.2</avro.version>
         <parquet.version>1.9.0</parquet.version>
         <jetty.version>6.1.26</jetty.version>
-        <jackson.version>1.9.13</jackson.version>
+        <netty.version>4.1.42.Final</netty.version>
+        <httpclient.version>4.5.6</httpclient.version>
+        <jackson.version>2.10.2</jackson.version>
         <protobuf.version>2.5.0</protobuf.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
         <sevntu.checkstyle.plugin.version>1.20.0</sevntu.checkstyle.plugin.version>
@@ -67,12 +69,12 @@ under the License.
         <kryo-serializers.version>0.37</kryo-serializers.version>
         <fast-classpath-scanner.version>2.4.5</fast-classpath-scanner.version>
         <maven.assembly>3.1.0</maven.assembly>
-        <grpc.version>1.12.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
+        <grpc.version>1.26.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
         <guava.version>20.0</guava.version>
         <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
         <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
-        <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
-        <maven-shade-plugin.version>2.4.2</maven-shade-plugin.version>
+        <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+        <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
         <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
         <!-- do not move beyond this version since it adds an incompatible guava dependency -->
         <xolstice.version>0.5.0</xolstice.version>
@@ -733,7 +735,7 @@ under the License.
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>4.0.23.Final</version>
+                <version>${netty.version}</version>
             </dependency>
 
             <dependency>
@@ -766,20 +768,20 @@ under the License.
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.3.4</version>
+                <version>${httpclient.version}</version>
             </dependency>
             <!-- End of Apache HTTP components -->
 
 
             <!-- Jackson -->
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-core-asl</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <!-- End of Jackson -->


### PR DESCRIPTION
Summary of changes:

* upgrade avro, httpclient, and netty
* update gRPC and sync up netty versions for reef-bridge-proto-java and other modules
* fix the error in Wake to work with Netty 4.1 ([REEF-2059](https://issues.apache.org/jira/browse/REEF-2059))

Migration to newer Checkstyle and Findbugs will be separate PRs

JIRA:
  [REEF-2057](https://issues.apache.org/jira/browse/REEF-2057)