### PR TITLE
[REEF-2063] Propagate exceptions of driver process fail in local runtime

### DIFF
--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
@@ -94,6 +94,7 @@ public class PreparedDriverFolderLauncher {
     try {
       this.executor.submit(process).get();
     } catch (InterruptedException | ExecutionException e) {
+      LOG.log(Level.SEVERE, "Driver process failed");
       throw new RuntimeException("Driver process failed", e);
     } finally {
       this.executor.shutdown();

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
@@ -30,6 +30,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -89,8 +90,14 @@ public class PreparedDriverFolderLauncher {
         new LoggingRunnableProcessObserver(),
         stdoutFilePath,
         stderrFilePath);
-    this.executor.submit(process);
-    this.executor.shutdown();
+
+    try {
+      this.executor.submit(process).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeException("Driver process failed", e);
+    } finally {
+      this.executor.shutdown();
+    }
   }
 
   private List<String> makeLaunchCommand() {

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcess.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcess.java
@@ -200,6 +200,7 @@ public final class RunnableProcess implements Runnable {
 
       } catch (final IOException ex) {
         LOG.log(Level.SEVERE, "Unable to spawn process " + this.id + " with command " + this.command, ex);
+        throw new RuntimeException("Unable to spawn process " + this.id + " with command " + this.command, ex);
       }
 
     } finally {


### PR DESCRIPTION
This PR includes changes:
- Catch and rethrow exceptions from spawning a driver process for a local job (local runtime).
- As a result, the client process can notice that the job has been failed to be submitted.

JIRA:
[REEF-2063](https://issues.apache.org/jira/projects/REEF/issues/REEF-2063)