### PR TITLE
[REEF-2065] optimization debian package manager tweaks

### DIFF
--- a/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/Dockerfile
@@ -24,7 +24,7 @@ RUN \
   gpg --keyserver pgp.mit.edu --recv-keys B9733A7A07513CAD && \
   gpg -a --export 07513CAD | apt-key add - && \
   apt-get update && \
-  apt-get install -y hadoop hadoop-hdfs hadoop-yarn hadoop-mapreduce hadoop-client && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests hadoop hadoop-hdfs hadoop-yarn hadoop-mapreduce hadoop-client && \
   apt-get clean
 ENV CLASSPATH $CLASSPATH:/usr/lib/hadoop/client/*
 ENV HADOOP_PREFIX /usr/lib/hadoop

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/Dockerfile
@@ -24,7 +24,7 @@ RUN \
   gpg --keyserver pgp.mit.edu --recv-keys B9733A7A07513CAD && \
   gpg -a --export 07513CAD | apt-key add - && \
   apt-get update && \
-  apt-get install -y hadoop-2-2-7-1-33* && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests hadoop-2-2-7-1-33* && \
   apt-get clean
 ENV HADOOP_PREFIX /usr/hdp/2.2.7.1-33/hadoop
 

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/Dockerfile
@@ -24,7 +24,7 @@ RUN \
   gpg --keyserver pgp.mit.edu --recv-keys B9733A7A07513CAD && \
   gpg -a --export 07513CAD | apt-key add - && \
   apt-get update && \
-  apt-get install -y hadoop-2-2-8-0-3150* && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests hadoop-2-2-8-0-3150* && \
   apt-get clean
 ENV HADOOP_PREFIX /usr/hdp/2.2.8.0-3150/hadoop
 

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/Dockerfile
@@ -24,7 +24,7 @@ RUN \
   gpg --keyserver pgp.mit.edu --recv-keys B9733A7A07513CAD && \
   gpg -a --export 07513CAD | apt-key add - && \
   apt-get update && \
-  apt-get install -y hadoop-2-3-2* && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests hadoop-2-3-2* && \
   apt-get clean
 ENV HADOOP_PREFIX /usr/hdp/2.3.2.0-2950/hadoop
 

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.4/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.4/Dockerfile
@@ -24,7 +24,7 @@ RUN \
   gpg --keyserver pgp.mit.edu --recv-keys B9733A7A07513CAD && \
   gpg -a --export 07513CAD | apt-key add - && \
   apt-get update && \
-  apt-get install -y hadoop-2-4-2* && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests hadoop-2-4-2* && \
   apt-get clean
 ENV HADOOP_PREFIX /usr/hdp/2.4.2.0-258/hadoop
 

--- a/dev/docker/ubuntu12.04-jdk7-mesos0.24/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-mesos0.24/Dockerfile
@@ -25,7 +25,7 @@ RUN \
   apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
   echo "deb http://repos.mesosphere.io/ubuntu precise main" > /etc/apt/sources.list.d/mesosphere.list && \
   apt-get -y update && \
-  apt-get install -y mesos=0.24.1-0.2.35.ubuntu1204 && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests mesos=0.24.1-0.2.35.ubuntu1204 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 ENV HADOOP_HOME=$HADOOP_PREFIX

--- a/dev/docker/ubuntu12.04-jdk7-mesos0.25/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-mesos0.25/Dockerfile
@@ -25,7 +25,7 @@ RUN \
   apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
   echo "deb http://repos.mesosphere.io/ubuntu precise main" > /etc/apt/sources.list.d/mesosphere.list && \
   apt-get -y update && \
-  apt-get install -y mesos=0.25.0-0.2.70.ubuntu1204 && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests mesos=0.25.0-0.2.70.ubuntu1204 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 ENV HADOOP_HOME=$HADOOP_PREFIX

--- a/dev/docker/ubuntu12.04-jdk7-mesos0.26/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-mesos0.26/Dockerfile
@@ -25,7 +25,7 @@ RUN \
   apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
   echo "deb http://repos.mesosphere.io/ubuntu precise main" > /etc/apt/sources.list.d/mesosphere.list && \
   apt-get -y update && \
-  apt-get install -y mesos=0.26.0-0.2.145.ubuntu1204 && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests mesos=0.26.0-0.2.145.ubuntu1204 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 ENV HADOOP_HOME=$HADOOP_PREFIX

--- a/dev/docker/ubuntu12.04-jdk7-mesos0.27/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-mesos0.27/Dockerfile
@@ -25,7 +25,7 @@ RUN \
   apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
   echo "deb http://repos.mesosphere.io/ubuntu precise main" > /etc/apt/sources.list.d/mesosphere.list && \
   apt-get -y update && \
-  apt-get install -y mesos=0.27.2-2.0.15.ubuntu1204 && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests mesos=0.27.2-2.0.15.ubuntu1204 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 ENV HADOOP_HOME=$HADOOP_PREFIX

--- a/dev/docker/ubuntu12.04-jdk7-mesos0.28/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-mesos0.28/Dockerfile
@@ -25,7 +25,7 @@ RUN \
   apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
   echo "deb http://repos.mesosphere.io/ubuntu precise main" > /etc/apt/sources.list.d/mesosphere.list && \
   apt-get -y update && \
-  apt-get install -y mesos=0.28.0-2.0.16.ubuntu1204 && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests mesos=0.28.0-2.0.16.ubuntu1204 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 ENV HADOOP_HOME=$HADOOP_PREFIX

--- a/dev/docker/ubuntu12.04-jdk7/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7/Dockerfile
@@ -20,7 +20,7 @@ MAINTAINER Apache REEF <dev@reef.apache.org>
 
 RUN \
   apt-get update && \
-  apt-get install -y openssh-server python-software-properties && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests openssh-server python-software-properties && \
   apt-get clean
 
 RUN \
@@ -36,7 +36,7 @@ RUN \
   echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
   add-apt-repository -y ppa:webupd8team/java && \
   apt-get update && \
-  apt-get install -y oracle-java7-installer && \
+  apt-get install --yes --no-upgrade --no-install-recommends --no-install-suggests oracle-java7-installer && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/cache/oracle-jdk7-installer


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

JIRA:
  [REEF-2065](https://issues.apache.org/jira/browse/REEF-2065)
  
Pull Request:
  Closes #1504 

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>