### PR TITLE
[REEF-2066] Bugfix: unit tests that depend on client-side timeout hung indefinitely

### DIFF
--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
@@ -30,7 +30,6 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -90,15 +89,8 @@ public class PreparedDriverFolderLauncher {
         new LoggingRunnableProcessObserver(),
         stdoutFilePath,
         stderrFilePath);
-
-    try {
-      this.executor.submit(process).get();
-    } catch (InterruptedException | ExecutionException e) {
-      LOG.log(Level.SEVERE, "Driver process failed");
-      throw new RuntimeException("Driver process failed", e);
-    } finally {
-      this.executor.shutdown();
-    }
+    this.executor.submit(process);
+    this.executor.shutdown();
   }
 
   private List<String> makeLaunchCommand() {

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcess.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcess.java
@@ -200,7 +200,6 @@ public final class RunnableProcess implements Runnable {
 
       } catch (final IOException ex) {
         LOG.log(Level.SEVERE, "Unable to spawn process " + this.id + " with command " + this.command, ex);
-        throw new RuntimeException("Unable to spawn process " + this.id + " with command " + this.command, ex);
       }
 
     } finally {


### PR DESCRIPTION
Some unit tests depend on client-side `DriverLauncher` killing the Driver process by timeout. That behavior was broken in PR #1499, and we have to revert that change.

This commit is a roll back of PR #1499

JIRA: [REEF-2066](https://issues.apache.org/jira/projects/REEF/issues/REEF-2066)